### PR TITLE
Allow empty search space in local search

### DIFF
--- a/pyvrp/cpp/educate/LocalSearch.cpp
+++ b/pyvrp/cpp/educate/LocalSearch.cpp
@@ -295,10 +295,6 @@ void LocalSearch::setNeighbours(Neighbours neighbours)
         }
     }
 
-    auto isEmpty = [](auto const &neighbours) { return neighbours.empty(); };
-    if (std::all_of(neighbours.begin(), neighbours.end(), isEmpty))
-        throw std::runtime_error("Neighbourhood is empty.");
-
     this->neighbours = neighbours;
 }
 

--- a/pyvrp/cpp/educate/LocalSearch.cpp
+++ b/pyvrp/cpp/educate/LocalSearch.cpp
@@ -8,14 +8,14 @@
 
 Individual LocalSearch::search(Individual &individual)
 {
+    if (nodeOps.empty())  // no-op
+        return individual;
+
     loadIndividual(individual);
 
     // Shuffling the order beforehand adds diversity to the search
     std::shuffle(orderNodes.begin(), orderNodes.end(), rng);
     std::shuffle(nodeOps.begin(), nodeOps.end(), rng);
-
-    if (nodeOps.empty())
-        throw std::runtime_error("No known node operators.");
 
     // Caches the last time nodes were tested for modification (uses nbMoves to
     // track this). The lastModified field, in contrast, track when a route was
@@ -76,6 +76,9 @@ Individual LocalSearch::search(Individual &individual)
 Individual LocalSearch::intensify(Individual &individual,
                                   int overlapToleranceDegrees)
 {
+    if (routeOps.empty())  // no-op
+        return individual;
+
     loadIndividual(individual);
 
     auto const overlapTolerance = overlapToleranceDegrees * 65536;
@@ -83,9 +86,6 @@ Individual LocalSearch::intensify(Individual &individual,
     // Shuffling the order beforehand adds diversity to the search
     std::shuffle(orderRoutes.begin(), orderRoutes.end(), rng);
     std::shuffle(routeOps.begin(), routeOps.end(), rng);
-
-    if (routeOps.empty())
-        throw std::runtime_error("No known route operators.");
 
     std::vector<int> lastTestedRoutes(data.numVehicles(), -1);
     lastModified = std::vector<int>(data.numVehicles(), 0);

--- a/pyvrp/cpp/educate/LocalSearch.h
+++ b/pyvrp/cpp/educate/LocalSearch.h
@@ -87,9 +87,8 @@ public:
     Individual search(Individual &individual);
 
     /**
-     * Performs a more intensive local search around the given individual,
-     * using route-based operators and subpath enumeration. Returns a new,
-     * hopefully improved individual.
+     * Performs an intensifying local search around the given individual, using
+     * route-based operators. Returns a new, hopefully improved individual.
      */
     Individual intensify(Individual &individual,
                          int overlapToleranceDegrees = 0);

--- a/pyvrp/educate/LocalSearch.py
+++ b/pyvrp/educate/LocalSearch.py
@@ -149,12 +149,6 @@ class LocalSearch:
             This parameter controls the amount of overlap needed before two
             routes are evaluated.
 
-        Raises
-        ------
-        RuntimeError
-            When this method is called before registering route operators.
-            Operators can be registered using :meth:`~add_route_operator`.
-
         Returns
         -------
         Individual
@@ -172,12 +166,6 @@ class LocalSearch:
         ----------
         individual
             The individual to improve.
-
-        Raises
-        ------
-        RuntimeError
-            When this method is called before registering node operators.
-            Operators can be registered using :meth:`~add_node_operator`.
 
         Returns
         -------

--- a/pyvrp/educate/tests/test_LocalSearch.py
+++ b/pyvrp/educate/tests/test_LocalSearch.py
@@ -6,24 +6,6 @@ from pyvrp.educate import LocalSearch, NeighbourhoodParams, compute_neighbours
 from pyvrp.tests.helpers import read
 
 
-def test_local_search_raises_when_neighbourhood_structure_is_empty():
-    data = read("data/OkSmall.txt")
-    pm = PenaltyManager(data.vehicle_capacity)
-    rng = XorShift128(seed=42)
-
-    # Is completely empty neighbourhood, so there's nothing to do for the
-    # local search in this case.
-    neighbours = [[] for _ in range(data.num_clients + 1)]
-
-    with assert_raises(RuntimeError):
-        LocalSearch(data, pm, rng, neighbours)
-
-    ls = LocalSearch(data, pm, rng, compute_neighbours(data))
-
-    with assert_raises(RuntimeError):
-        ls.set_neighbours(neighbours)
-
-
 @mark.parametrize("size", [1, 2, 3, 4, 6, 7])  # num_clients + 1 == 5
 def test_local_search_raises_when_neighbourhood_dimensions_do_not_match(size):
     data = read("data/OkSmall.txt")

--- a/pyvrp/educate/tests/test_LocalSearch.py
+++ b/pyvrp/educate/tests/test_LocalSearch.py
@@ -1,24 +1,9 @@
 from numpy.testing import assert_, assert_equal, assert_raises
 from pytest import mark
 
-from pyvrp import Individual, PenaltyManager, XorShift128
+from pyvrp import PenaltyManager, XorShift128
 from pyvrp.educate import LocalSearch, NeighbourhoodParams, compute_neighbours
 from pyvrp.tests.helpers import read
-
-
-def test_local_search_raises_when_there_are_no_operators():
-    data = read("data/OkSmall.txt")
-    pm = PenaltyManager(data.vehicle_capacity)
-    rng = XorShift128(seed=42)
-
-    ls = LocalSearch(data, pm, rng, compute_neighbours(data))
-    individual = Individual.make_random(data, pm, rng)
-
-    with assert_raises(RuntimeError):
-        ls.search(individual)
-
-    with assert_raises(RuntimeError):
-        ls.intensify(individual)
 
 
 def test_local_search_raises_when_neighbourhood_structure_is_empty():

--- a/pyvrp/educate/tests/test_LocalSearch.py
+++ b/pyvrp/educate/tests/test_LocalSearch.py
@@ -1,9 +1,44 @@
 from numpy.testing import assert_, assert_equal, assert_raises
 from pytest import mark
 
-from pyvrp import PenaltyManager, XorShift128
+from pyvrp import Individual, PenaltyManager, XorShift128
 from pyvrp.educate import LocalSearch, NeighbourhoodParams, compute_neighbours
 from pyvrp.tests.helpers import read
+
+
+def test_empty_neighbourhood_search_returns_same_solution():
+    data = read("data/OkSmall.txt")
+    pm = PenaltyManager(data.vehicle_capacity)
+    rng = XorShift128(seed=42)
+
+    neighbourhood = [[] for _ in range(data.num_clients + 1)]  # is empty
+    ls = LocalSearch(data, pm, rng, neighbourhood)
+
+    for _ in range(100):  # repeat a few times to make sure
+        individual = Individual.make_random(data, pm, rng)
+        assert_equal(ls.search(individual), individual)
+
+
+def test_no_node_operators_search_returns_same_solution():
+    data = read("data/OkSmall.txt")
+    pm = PenaltyManager(data.vehicle_capacity)
+    rng = XorShift128(seed=42)
+    ls = LocalSearch(data, pm, rng, compute_neighbours(data))
+
+    for _ in range(100):  # repeat a few times to make sure
+        individual = Individual.make_random(data, pm, rng)
+        assert_equal(ls.search(individual), individual)
+
+
+def test_no_route_operators_intensify_returns_same_solution():
+    data = read("data/OkSmall.txt")
+    pm = PenaltyManager(data.vehicle_capacity)
+    rng = XorShift128(seed=42)
+    ls = LocalSearch(data, pm, rng, compute_neighbours(data))
+
+    for _ in range(100):  # repeat a few times to make sure
+        individual = Individual.make_random(data, pm, rng)
+        assert_equal(ls.intensify(individual), individual)
 
 
 @mark.parametrize("size", [1, 2, 3, 4, 6, 7])  # num_clients + 1 == 5


### PR DESCRIPTION
Follows somewhat from #170. I don't think we should disallow an empty search space, either due to no operators or an empty granular neighbourhood.
