### PR TITLE
BugFix: loadIndividual sets depot TWdata to zero

### DIFF
--- a/pyvrp/cpp/educate/LocalSearch.cpp
+++ b/pyvrp/cpp/educate/LocalSearch.cpp
@@ -212,10 +212,8 @@ void LocalSearch::loadIndividual(Individual const &individual)
 
         startDepot->tw = clients[0].tw;
         startDepot->twBefore = clients[0].tw;
-        startDepot->twAfter = clients[0].tw;
 
         endDepot->tw = clients[0].tw;
-        endDepot->twBefore = clients[0].tw;
         endDepot->twAfter = clients[0].tw;
 
         Route *route = &routes[r];

--- a/pyvrp/educate/tests/test_Exchange.py
+++ b/pyvrp/educate/tests/test_Exchange.py
@@ -2,12 +2,7 @@ from numpy.testing import assert_, assert_equal
 from pytest import mark
 
 from pyvrp import CostEvaluator, Individual, XorShift128
-from pyvrp.educate import (
-    LocalSearch,
-    NeighbourhoodParams,
-    Neighbours,
-    compute_neighbours,
-)
+from pyvrp.educate import LocalSearch, NeighbourhoodParams, compute_neighbours
 from pyvrp.educate._Exchange import (
     Exchange10,
     Exchange11,
@@ -211,41 +206,3 @@ def test_relocate_after_depot_should_work():
     individual = Individual(data, [[1, 2, 3], [4]])
     expected = Individual(data, [[1, 2], [3], [4]])
     assert_equal(ls.search(individual, cost_evaluator), expected)
-
-
-def test_reoptimize_changed_objective_timewarp_OkSmall():
-    """
-    This test reproduces a bug where loadIndividual in LocalSearch.cpp would
-    reset the timewarp for a route to 0 if the route was not changed. This
-    would cause improving moves with a smaller timewarp not to be considered
-    because the current cost doesn't count the current time warp.
-    """
-    data = read("data/OkSmall.txt")
-    rng = XorShift128(seed=42)
-
-    individual = Individual(data, [[1, 2, 3, 4]])
-
-    # We make neighbours only contain 1 -> 2, so the only feasible move
-    # is changing [1, 2, 3, 4] into [2, 1, 3, 4] or moving one of the nodes
-    # into its own route. Since those solutions have larger distance but
-    # smaller time warp, they are considered improving moves with a
-    # sufficiently large time warp penalty.
-    neighbours: Neighbours = [[], [2], [], [], []]  # 1 -> 2 only
-    ls = LocalSearch(data, rng, neighbours)
-    ls.add_node_operator(Exchange10(data))
-
-    # With 0 timewarp penalty, the individual should not change since
-    # the solution [2, 1, 3, 4] has larger distance
-    improved_indiv = ls.search(individual, CostEvaluator(0, 0))
-    assert_equal(individual, improved_indiv)
-
-    # Now doing it again with a large TW penalty, we must find the alternative
-    # solution
-    # (previously this was not the case since due to caching the current TW was
-    # computed as being zero, causing the move to be evaluated as worse)
-    cost_evaluator_tw = CostEvaluator(0, 1000)
-    improved_indiv = ls.search(individual, cost_evaluator_tw)
-    # expected_indiv = Individual(data, [[2, 1, 3, 4]])
-    # assert_equal(improved_indiv, expected_indiv)
-    improved_cost = cost_evaluator_tw.penalised_cost(improved_indiv)
-    assert improved_cost < cost_evaluator_tw.penalised_cost(individual)

--- a/pyvrp/educate/tests/test_LocalSearch.py
+++ b/pyvrp/educate/tests/test_LocalSearch.py
@@ -2,7 +2,13 @@ from numpy.testing import assert_, assert_equal, assert_raises
 from pytest import mark
 
 from pyvrp import CostEvaluator, Individual, XorShift128
-from pyvrp.educate import LocalSearch, NeighbourhoodParams, compute_neighbours
+from pyvrp.educate import (
+    LocalSearch,
+    NeighbourhoodParams,
+    Neighbours,
+    compute_neighbours,
+)
+from pyvrp.educate._Exchange import Exchange10
 from pyvrp.tests.helpers import read
 
 
@@ -119,3 +125,39 @@ def test_local_search_set_get_neighbours(
     assert_equal(ls.get_neighbours(), neighbours)
     neighbours[1] = []
     assert_(ls.get_neighbours() != neighbours)
+
+
+def test_reoptimize_changed_objective_timewarp_OkSmall():
+    """
+    This test reproduces a bug where loadIndividual in LocalSearch.cpp would
+    reset the timewarp for a route to 0 if the route was not changed. This
+    would cause improving moves with a smaller timewarp not to be considered
+    because the current cost doesn't count the current time warp.
+    """
+    data = read("data/OkSmall.txt")
+    rng = XorShift128(seed=42)
+
+    individual = Individual(data, [[1, 2, 3, 4]])
+
+    # We make neighbours only contain 1 -> 2, so the only feasible move
+    # is changing [1, 2, 3, 4] into [2, 1, 3, 4] or moving one of the nodes
+    # into its own route. Since those solutions have larger distance but
+    # smaller time warp, they are considered improving moves with a
+    # sufficiently large time warp penalty.
+    neighbours: Neighbours = [[], [2], [], [], []]  # 1 -> 2 only
+    ls = LocalSearch(data, rng, neighbours)
+    ls.add_node_operator(Exchange10(data))
+
+    # With 0 timewarp penalty, the individual should not change since
+    # the solution [2, 1, 3, 4] has larger distance
+    improved_indiv = ls.search(individual, CostEvaluator(0, 0))
+    assert_equal(individual, improved_indiv)
+
+    # Now doing it again with a large TW penalty, we must find the alternative
+    # solution
+    # (previously this was not the case since due to caching the current TW was
+    # computed as being zero, causing the move to be evaluated as worse)
+    cost_evaluator_tw = CostEvaluator(0, 1000)
+    improved_indiv = ls.search(individual, cost_evaluator_tw)
+    improved_cost = cost_evaluator_tw.penalised_cost(improved_indiv)
+    assert_(improved_cost < cost_evaluator_tw.penalised_cost(individual))


### PR DESCRIPTION
`LocalSearch::loadIndividual` previously resetted `startDepot->twAfter` and `endDepot->twBefore`. The idea is that these would be overwritten anyway in `route->update()`. However it is not if the route was unchanged (i.e. if we load the same route as in the previous result).

This causes the time warp of the current solution to be evaluated as 0, which is (sometimes) incorrect. This causes some improving moves with non-zero time warp to be incorrectly evaluated as non-improving.

It is fixed by not setting these attributes in loadIndividual, this keeps them at their previous values which is in sync with the cache used by route->update(). This PR also includes a test that reproduces the bug in main.

This PR:

- [x] Adds and passes relevant tests.
- [x] Has well-formatted code and documentation.
