### PR TITLE
Speed up greedyRepair, improve deltaCost evaluation

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,7 +5,7 @@ IndentWidth: 4
 SpacesBeforeTrailingComments: 2
 BreakBeforeBraces: Allman
 ColumnLimit: 80
-PackConstructorInitializers: CurrentLine
+PackConstructorInitializers: NextLine
 TabWidth: 4
 UseTab: Never
 BreakBeforeBinaryOperators: All

--- a/.clang-format
+++ b/.clang-format
@@ -5,7 +5,7 @@ IndentWidth: 4
 SpacesBeforeTrailingComments: 2
 BreakBeforeBraces: Allman
 ColumnLimit: 80
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
+PackConstructorInitializers: CurrentLine
 TabWidth: 4
 UseTab: Never
 BreakBeforeBinaryOperators: All

--- a/.clang-format
+++ b/.clang-format
@@ -5,7 +5,7 @@ IndentWidth: 4
 SpacesBeforeTrailingComments: 2
 BreakBeforeBraces: Allman
 ColumnLimit: 80
-PackConstructorInitializers: NextLine
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
 TabWidth: 4
 UseTab: Never
 BreakBeforeBinaryOperators: All

--- a/pyvrp/cpp/TimeWindowSegment.h
+++ b/pyvrp/cpp/TimeWindowSegment.h
@@ -50,19 +50,16 @@ TimeWindowSegment::merge(Matrix<Duration> const &durationMatrix,
     return {};
 #else
     auto const arcDuration = durationMatrix(idxLast, other.idxFirst);
-    auto const delta = duration - timeWarp + arcDuration;
-
-    auto const wait = other.twEarly - delta - twLate;
-    auto const tw = twEarly + delta - other.twLate;
-    auto const deltaWait = std::max<Duration>(wait, 0);
-    auto const deltaTw = std::max<Duration>(tw, 0);
+    auto const diff = duration - timeWarp + arcDuration;
+    auto const diffWait = std::max<Duration>(other.twEarly - diff - twLate, 0);
+    auto const diffTw = std::max<Duration>(twEarly + diff - other.twLate, 0);
 
     return {idxFirst,
             other.idxLast,
-            duration + other.duration + arcDuration + deltaWait,
-            timeWarp + other.timeWarp + deltaTw,
-            std::max(other.twEarly - delta, twEarly) - deltaWait,
-            std::min(other.twLate - delta, twLate) + deltaTw};
+            duration + other.duration + arcDuration + diffWait,
+            timeWarp + other.timeWarp + diffTw,
+            std::max(other.twEarly - diff, twEarly) - diffWait,
+            std::min(other.twLate - diff, twLate) + diffTw};
 #endif
 }
 

--- a/pyvrp/cpp/crossover/crossover.cpp
+++ b/pyvrp/cpp/crossover/crossover.cpp
@@ -80,7 +80,7 @@ void crossover::greedyRepair(Routes &routes,
 
         // Determine non-empty route with centroid nearest to this client.
         auto bestDistance = std::numeric_limits<double>::max();
-        auto bestIdx = 0;
+        auto bestRouteIdx = 0;
         for (auto rIdx = 0; rIdx != numRoutes; ++rIdx)
         {
             if (routes[rIdx].empty())
@@ -91,33 +91,33 @@ void crossover::greedyRepair(Routes &routes,
 
             if (distance < bestDistance)
             {
-                bestIdx = rIdx;
+                bestRouteIdx = rIdx;
                 bestDistance = distance;
             }
         }
 
         // Find best insertion point in selected route.
-        auto &route = routes[bestIdx];
+        auto &bestRoute = routes[bestRouteIdx];
         Cost bestCost = std::numeric_limits<Cost>::max();
         auto offset = 0;
-        for (size_t idx = 0; idx <= route.size(); ++idx)
+        for (size_t idx = 0; idx <= bestRoute.size(); ++idx)
         {
             Client prev, next;
 
             if (idx == 0)  // try after depot
             {
                 prev = 0;
-                next = route[0];
+                next = bestRoute[0];
             }
-            else if (idx == route.size())  // try before depot
+            else if (idx == bestRoute.size())  // try before depot
             {
-                prev = route.back();
+                prev = bestRoute.back();
                 next = 0;
             }
             else  // try between [idx - 1] and [idx]
             {
-                prev = route[idx - 1];
-                next = route[idx];
+                prev = bestRoute[idx - 1];
+                next = bestRoute[idx];
             }
 
             auto cost = deltaCost(client, prev, next, data, costEvaluator);
@@ -128,12 +128,11 @@ void crossover::greedyRepair(Routes &routes,
             }
         }
 
-        // Insert client into route and update route centroid.
-        route.insert(route.begin() + offset, client);
-
-        auto const size = static_cast<double>(route.size());
-        auto const [routeX, routeY] = centroids[bestIdx];
-        centroids[bestIdx].first = (routeX * (size - 1) + x) / size;
-        centroids[bestIdx].second = (routeY * (size - 1) + y) / size;
+        // Update route centroid and insert client into route.
+        auto const size = static_cast<double>(bestRoute.size());
+        auto const [routeX, routeY] = centroids[bestRouteIdx];
+        centroids[bestRouteIdx].first = (routeX * size + x) / (size + 1);
+        centroids[bestRouteIdx].second = (routeY * size + y) / (size + 1);
+        bestRoute.insert(bestRoute.begin() + offset, client);
     }
 }

--- a/pyvrp/cpp/crossover/crossover.cpp
+++ b/pyvrp/cpp/crossover/crossover.cpp
@@ -30,7 +30,7 @@ Cost deltaCost(Client client,
     auto const clientLate = clientData.twLate;
     auto const nextLate = data.client(next).twLate;
 
-    // Fastest we can be done at prev, and thus get ready to leave for client
+    // Determine the earliest time we can depart from prev.
     auto const prevStart = std::max(data.duration(0, prev), prevData.twEarly);
     auto const prevFinish = prevStart + prevData.serviceDuration;
 

--- a/pyvrp/cpp/crossover/crossover.cpp
+++ b/pyvrp/cpp/crossover/crossover.cpp
@@ -17,14 +17,11 @@ Cost deltaCost(Client client,
                ProblemData const &data,
                CostEvaluator const &costEvaluator)
 {
-    // clang-format off
-    auto const deltaDist = data.dist(prev, client) 
-                           + data.dist(client, next)
-                           - data.dist(prev, next);
-    // clang-format on
+    auto const currDist = data.dist(prev, next);
+    auto const propDist = data.dist(prev, client) + data.dist(client, next);
 
 #ifdef VRP_NO_TIME_WINDOWS
-    return static_cast<Cost>(deltaDist);
+    return static_cast<Cost>(propDist - currDist);
 #else
     auto const &clientData = data.client(client);
     auto const &prevData = data.client(prev);
@@ -46,7 +43,7 @@ Cost deltaCost(Client client,
     auto const propTimeWarp = std::max<Duration>(arriveClient - clientLate, 0)
                               + std::max<Duration>(arriveNext - nextLate, 0);
 
-    return static_cast<Cost>(deltaDist)
+    return static_cast<Cost>(propDist - currDist)
            + costEvaluator.twPenalty(propTimeWarp)
            - costEvaluator.twPenalty(currTimeWarp);
 #endif

--- a/pyvrp/cpp/crossover/crossover.cpp
+++ b/pyvrp/cpp/crossover/crossover.cpp
@@ -39,8 +39,8 @@ Cost deltaCost(Client client,
     auto const currTimeWarp = std::max<Duration>(prevNextArrive - nextLate, 0);
 
     // Determine arrival at client. This incurs some timewarp if the arrival is
-    // after client.twLate. We finish at arrival time + service. But if there
-    // is some time warp, we subtract that from the departure time at client.
+    // after client.twLate. We finish at start time + service. We subtract any
+    // time warp from the departure time at client.
     auto const clientArrive = prevFinish + data.duration(prev, client);
     auto const clientStart = std::max(clientArrive, clientData.twEarly);
     auto const clientTimeWarp = std::max<Duration>(clientStart - clientLate, 0);

--- a/pyvrp/cpp/crossover/crossover.h
+++ b/pyvrp/cpp/crossover/crossover.h
@@ -12,11 +12,13 @@
 namespace crossover
 {
 /**
- * Greedily inserts the unplanned clients into non-empty routes.
+ * Greedily inserts each unplanned client into the non-empty route that's
+ * nearest to the client.
  */
 void greedyRepair(std::vector<std::vector<int>> &routes,
                   std::vector<int> const &unplanned,
-                  ProblemData const &data);
+                  ProblemData const &data,
+                  CostEvaluator const &costEvaluator);
 }  // namespace crossover
 
 /**

--- a/pyvrp/cpp/crossover/selective_route_exchange.cpp
+++ b/pyvrp/cpp/crossover/selective_route_exchange.cpp
@@ -227,8 +227,8 @@ Individual selectiveRouteExchange(
         if (!selectedB.contains(c))
             unplanned.push_back(c);
 
-    crossover::greedyRepair(routes1, unplanned, data);
-    crossover::greedyRepair(routes2, unplanned, data);
+    crossover::greedyRepair(routes1, unplanned, data, costEvaluator);
+    crossover::greedyRepair(routes2, unplanned, data, costEvaluator);
 
     Individual indiv1{data, routes1};
     Individual indiv2{data, routes2};

--- a/pyvrp/cpp/educate/Exchange.h
+++ b/pyvrp/cpp/educate/Exchange.h
@@ -59,13 +59,11 @@ bool Exchange<N, M>::containsDepot(Node *node, size_t segLength) const
 template <size_t N, size_t M>
 bool Exchange<N, M>::overlap(Node *U, Node *V) const
 {
-    // clang-format off
     return U->route == V->route
-        // We need max(M, 1) here because when V is the depot and M == 0, this
-        // would turn negative and wrap around to a large number.
-        && U->position <= V->position + std::max<size_t>(M, 1) - 1
-        && V->position <= U->position + N - 1;
-    // clang-format on
+           // We need max(M, 1) here because when V is the depot and M == 0,
+           // this would turn negative and wrap around to a large number.
+           && U->position <= V->position + std::max<size_t>(M, 1) - 1
+           && V->position <= U->position + N - 1;
 }
 
 template <size_t N, size_t M>


### PR DESCRIPTION
This PR addresses some issues in `greedyRepair` that I had on my radar for a while. `greedyRepair` takes some 5-10% of time on a typical run, so it worth spending some time here. These are my main concerns:
- The evaluation done by `deltaCost` requires feasibility, returning +inf in case of an infeasible assignment. That's a very high hill to climb, and might result in a bad insertion point.
- `deltaCost` evaluated arrival at the new client using an arc from the depot. That should be from `prev`, not the depot.
- `greedyRepair` looks through all non-empty routes, which takes quadratic time (in the number of clients). 

The first two issues I fixed by improving `deltaCost` to also take into account the time warp changes. This results in a much smoother evaluation. The final issue I address by only evaluating the route whose centroid is nearest to a particular client. This ensures clients are inserted in routes that are geographically somewhat close to them, and avoids repairing routes in too "wild" manner.

The benchmarks below suggest that these changes together are quite a bit better than our current main.

### Benchmarks

All on VRPTW.

Current main (a356bc089f6f7c4c8e28c083f59bcd0915c6902d; job ID 2321737; 10x seeds/1h runtime with `configs/vrptw.toml`):
```
 Avg. objective: 333460.7 (min: 333349, max: 333558)
Avg. iterations: 105018.2 (min: 102172, max: 112949)
```

This PR with improved deltaCost (8027bc6e44f6bc96fe35dbc1413319225f92edcd; job ID ; 10x seeds/1h runtime with `configs/vrptw.toml`):
```
 Avg. objective: 333422.1 (min: 333230, max: 333537)
Avg. iterations: 104198.4 (min: 100101, max: 111432)
```

This PR with improved deltaCost + centroid restriction (5f67fe83b049ae33f442c0490bc750de122493cb; job ID 2327749; 10x seeds/1h runtime with `configs/vrptw.toml`):
```
 Avg. objective: 333281.2 (min: 333209, max: 333419)
Avg. iterations: 106865.8 (min: 102866, max: 111996)
```

This PR with improved deltaCost + centroid restriction (76aaa2de5b958345c996f19483376ed3e7e4c91f; job ID 2335754; 10x seeds/1h runtime with `configs/vrptw.toml`):
```
 Avg. objective: 333351.8 (min: 333243, max: 333503)
Avg. iterations:  95841.3 (min:  76534, max: 109555)
```
(this one had a lot of <100K iteration runs; possibly something weird going on with the cluster)

This PR with improved deltaCost + centroid restriction (ed2d4370240f69feac611dff390a4f72d7896e16; job ID 2354749; 10x seeds/2h runtime with `configs/vrptw.toml`):
```
 Avg. objective: 333013.4 (min: 332917, max: 333123)
Avg. iterations: 188641.2 (min: 144886, max: 217751)
```
<details>

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
