### PR TITLE
Re-enable unused parameter build warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -24,22 +24,10 @@ if get_option('buildtype') == 'debug'
     add_project_link_arguments('--coverage', language: 'cpp')
 endif
 
-if compiler.has_argument('-Wno-unused-parameter')
-    # Ignore unused parameters, because not all operator implementations use 
-    # every argument they are given (and that's OK).
-    add_project_arguments('-Wno-unused-parameter', language: 'cpp')
-endif
-
 if get_option('problem') == 'cvrp'
     # CVRP does not have time windows, so we set a flag that compiles time 
     # window stuff out of the extension modules.
     add_project_arguments('-DVRP_NO_TIME_WINDOWS', language: 'cpp')
-
-    if compiler.has_argument('-Wno-unused-private-field')
-        # Ignore unused fields, since a number of time window related fields
-        # are unused by the CVRP.
-        add_project_arguments('-Wno-unused-private-field', language: 'cpp')
-    endif
 endif
 
 # We first compile a common library that contains all regular, C++ code. This

--- a/pyvrp/cpp/CostEvaluator.h
+++ b/pyvrp/cpp/CostEvaluator.h
@@ -59,7 +59,7 @@ Cost CostEvaluator::loadPenalty(Load load, Load vehicleCapacity) const
     return Cost(load > vehicleCapacity) * penalty;
 }
 
-Cost CostEvaluator::twPenalty(Duration timeWarp) const
+Cost CostEvaluator::twPenalty([[maybe_unused]] Duration timeWarp) const
 {
 #ifdef VRP_NO_TIME_WINDOWS
     return 0;

--- a/pyvrp/cpp/SubPopulation.cpp
+++ b/pyvrp/cpp/SubPopulation.cpp
@@ -2,6 +2,9 @@
 
 #include <numeric>
 
+using const_iter = std::vector<SubPopulation::Item>::const_iterator;
+using iter = std::vector<SubPopulation::Item>::iterator;
+
 SubPopulation::SubPopulation(DiversityMeasure divOp,
                              PopulationParams const &params)
     : divOp(divOp), params(params)
@@ -49,19 +52,11 @@ SubPopulation::Item const &SubPopulation::operator[](size_t idx) const
     return items[idx];
 }
 
-std::vector<SubPopulation::Item>::const_iterator SubPopulation::cbegin() const
-{
-    return items.cbegin();
-}
+const_iter SubPopulation::cbegin() const { return items.cbegin(); }
 
-std::vector<SubPopulation::Item>::const_iterator SubPopulation::cend() const
-{
-    return items.cend();
-}
+const_iter SubPopulation::cend() const { return items.cend(); }
 
-void SubPopulation::remove(
-    std::vector<SubPopulation::Item>::iterator const &iterator,
-    CostEvaluator const &costEvaluator)
+void SubPopulation::remove(iter const &iterator)
 {
     for (auto &[params, individual, fitness, proximity] : items)
         // Remove individual from other proximities.
@@ -92,7 +87,7 @@ void SubPopulation::purge(CostEvaluator const &costEvaluator)
         if (duplicate == items.end())  // there are no more duplicates
             break;
 
-        remove(duplicate, costEvaluator);
+        remove(duplicate);
     }
 
     while (size() > params.minPopSize)
@@ -104,7 +99,7 @@ void SubPopulation::purge(CostEvaluator const &costEvaluator)
                 return a.fitness < b.fitness;
             });
 
-        remove(worstFitness, costEvaluator);
+        remove(worstFitness);
     }
 }
 

--- a/pyvrp/cpp/SubPopulation.h
+++ b/pyvrp/cpp/SubPopulation.h
@@ -77,8 +77,7 @@ private:
     std::vector<Item> items;
 
     // Removes the element at the given iterator location from the items.
-    void remove(std::vector<Item>::iterator const &iterator,
-                CostEvaluator const &costEvaluator);
+    void remove(std::vector<Item>::iterator const &iterator);
 
 public:
     SubPopulation(DiversityMeasure divOp, PopulationParams const &params);

--- a/pyvrp/cpp/TimeWindowSegment.h
+++ b/pyvrp/cpp/TimeWindowSegment.h
@@ -64,18 +64,22 @@ TimeWindowSegment TimeWindowSegment::merge(
 }
 
 template <typename... Args>
-TimeWindowSegment
-TimeWindowSegment::merge(Matrix<Duration> const &durationMatrix,
-                         TimeWindowSegment const &first,
-                         TimeWindowSegment const &second,
-                         Args... args)
+TimeWindowSegment TimeWindowSegment::merge(
+    [[maybe_unused]] Matrix<Duration> const &durationMatrix,
+    [[maybe_unused]] TimeWindowSegment const &first,
+    [[maybe_unused]] TimeWindowSegment const &second,
+    [[maybe_unused]] Args... args)
 {
+#ifdef VRP_NO_TIME_WINDOWS
+    return {};
+#else
     auto const res = first.merge(durationMatrix, second);
 
     if constexpr (sizeof...(args) == 0)
         return res;
     else
         return merge(durationMatrix, res, args...);
+#endif;
 }
 
 Duration TimeWindowSegment::totalTimeWarp() const { return timeWarp; }

--- a/pyvrp/cpp/TimeWindowSegment.h
+++ b/pyvrp/cpp/TimeWindowSegment.h
@@ -79,7 +79,7 @@ TimeWindowSegment TimeWindowSegment::merge(
         return res;
     else
         return merge(durationMatrix, res, args...);
-#endif;
+#endif
 }
 
 Duration TimeWindowSegment::totalTimeWarp() const { return timeWarp; }

--- a/pyvrp/cpp/TimeWindowSegment.h
+++ b/pyvrp/cpp/TimeWindowSegment.h
@@ -42,9 +42,9 @@ public:
                              Duration twLate);
 };
 
-TimeWindowSegment
-TimeWindowSegment::merge(Matrix<Duration> const &durationMatrix,
-                         TimeWindowSegment const &other) const
+TimeWindowSegment TimeWindowSegment::merge(
+    [[maybe_unused]] Matrix<Duration> const &durationMatrix,
+    [[maybe_unused]] TimeWindowSegment const &other) const
 {
 #ifdef VRP_NO_TIME_WINDOWS
     return {};
@@ -70,16 +70,12 @@ TimeWindowSegment::merge(Matrix<Duration> const &durationMatrix,
                          TimeWindowSegment const &second,
                          Args... args)
 {
-#ifdef VRP_NO_TIME_WINDOWS
-    return {};
-#else
     auto const res = first.merge(durationMatrix, second);
 
     if constexpr (sizeof...(args) == 0)
         return res;
     else
         return merge(durationMatrix, res, args...);
-#endif
 }
 
 Duration TimeWindowSegment::totalTimeWarp() const { return timeWarp; }

--- a/pyvrp/cpp/crossover/crossover.cpp
+++ b/pyvrp/cpp/crossover/crossover.cpp
@@ -15,7 +15,7 @@ Cost deltaCost(Client client,
                Client prev,
                Client next,
                ProblemData const &data,
-               CostEvaluator const &costEvaluator)
+               [[maybe_unused]] CostEvaluator const &costEvaluator)
 {
     auto const currDist = data.dist(prev, next);
     auto const propDist = data.dist(prev, client) + data.dist(client, next);

--- a/pyvrp/cpp/educate/LocalSearchOperator.h
+++ b/pyvrp/cpp/educate/LocalSearchOperator.h
@@ -31,15 +31,14 @@ public:
      * cost delta does not constitute a full evaluation.
      */
     virtual Cost evaluate(Arg *U, Arg *V, CostEvaluator const &costEvaluator)
-    {
-        return 0;
-    }
+        = 0;
 
     /**
      * Applies this operator to the given arguments. For improvements, should
      * only be called if <code>evaluate()</code> returns a negative delta cost.
      */
-    virtual void apply(Arg *U, Arg *V) const {};
+    // TODO remove arguments - always applies to most recently evaluated pair.
+    virtual void apply(Arg *U, Arg *V) const = 0;
 
     LocalSearchOperatorBase(ProblemData const &data) : data(data){};
     virtual ~LocalSearchOperatorBase() = default;
@@ -66,14 +65,14 @@ public:
      * Called once after loading in the individual to improve. This can be used
      * to e.g. update local operator state.
      */
-    virtual void init(Individual const &indiv){};
+    virtual void init([[maybe_unused]] Individual const &indiv){};
 
     /**
      * Called when a route has been changed. Can be used to update caches, but
      * the implementation should be fast: this is called every time something
      * changes!
      */
-    virtual void update(Route *U){};
+    virtual void update([[maybe_unused]] Route *U){};
 };
 
 #endif  // LOCALSEARCHOPERATOR_H

--- a/pyvrp/cpp/educate/RelocateStar.cpp
+++ b/pyvrp/cpp/educate/RelocateStar.cpp
@@ -33,7 +33,8 @@ Cost RelocateStar::evaluate(Route *U,
     return move.deltaCost;
 }
 
-void RelocateStar::apply(Route *U, Route *V) const
+void RelocateStar::apply([[maybe_unused]] Route *U,
+                         [[maybe_unused]] Route *V) const
 {
     move.from->insertAfter(move.to);
 }

--- a/pyvrp/cpp/educate/SwapStar.cpp
+++ b/pyvrp/cpp/educate/SwapStar.cpp
@@ -286,7 +286,7 @@ Cost SwapStar::evaluate(Route *routeU,
     return deltaCost;
 }
 
-void SwapStar::apply(Route *U, Route *V) const
+void SwapStar::apply([[maybe_unused]] Route *U, [[maybe_unused]] Route *V) const
 {
     if (best.U && best.UAfter && best.V && best.VAfter)
     {


### PR DESCRIPTION
I recently learned there's a `[[maybe_unused]]` attribute in C++ that can be used to indicate parameters might be unused. Some parameters aren't used everywhere (e.g., CVRP does not use a lot of the TW related parameters). To deal with that we had disabled the unused parameter warnings.

This PR instead uses that attribute where needed, and re-enables the compiler warnings we previously disabled.

<details>

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
