### PR TITLE
Add support for double precision

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,23 +15,20 @@ jobs:
     name: >
       Build and test pyvrp using ${{ matrix.compiler }} 
       ${{ matrix.compiler-version }} and Python ${{ matrix.python-version }}
+      in ${{ matrix.precision }} precision mode
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
-        include:
-          - compiler: gcc
+        compiler: [gcc, clang]
+        compiler-version: ['10', '12', 'latest']
+        python-version: ['3.8', '3.11']
+        precision: [integer, double]
+        exclude:
+          - compiler: clang
             compiler-version: '10'  # minimum gcc version
-            python-version: '3.8'   # minimum Python version
           - compiler: gcc
-            compiler-version: latest
-            python-version: '3.11'
-          - compiler: clang
             compiler-version: '12'  # minimum clang version
-            python-version: '3.8'   # minimum Python version
-          - compiler: clang
-            compiler-version: latest
-            python-version: '3.11'
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -79,7 +76,7 @@ jobs:
         # for testing. So we also compile a debug build directly afterwards.
         run: |
           poetry install --only-root
-          poetry run python build_extensions.py --build_type debug --clean
+          poetry run python build_extensions.py --build_type debug --clean --precision ${{ matrix.precision }}
       - name: Run tests
         run: poetry run python -m pytest
       - if: matrix.compiler == 'gcc'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,11 @@ jobs:
           - compiler: clang
             compiler-version: '12'
             python-version: '3.11'
+
+          # No need to test 'new' compilers with 'old' Python versions. This
+          # saves a bit in the CI process.
+          - compiler-version: latest
+            python-version: '3.8'
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,6 +29,15 @@ jobs:
             compiler-version: '10'  # minimum gcc version
           - compiler: gcc
             compiler-version: '12'  # minimum clang version
+  
+          # No need to test 'old' compilers with 'new' Python versions. This
+          # saves a bit in the CI process.
+          - compiler: gcc
+            compiler-version: '10'
+            python-version: '3.11'
+          - compiler: clang
+            compiler-version: '12'
+            python-version: '3.11'
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It currently supports the capacitated VRP (CVRP), the VRP with time windows (VRP
 
 The implementation is inspired by Thibaut Vidal's [HGS-CVRP][7], but has been completely redesigned to be easy to use as a highly customisable Python package, while maintaining speed and state-of-the-art performance.
 Users can customise various aspects of the algorithm using Python, including population management, crossover strategies, granular neighbourhoods and operator selection in the local search.
-Additionally, for advanced use cases such as supporting additional VRP variants, users can build and install PyVRP directly from the source code.
+Additionally, for advanced use cases such as supporting additional VRP variants, users can build and install `pyvrp` directly from the source code.
 
 `pyvrp` may be installed in the usual way as
 ```

--- a/build_extensions.py
+++ b/build_extensions.py
@@ -26,6 +26,12 @@ def parse_args():
         help="Which type of solver to compile. Defaults to 'vrptw'.",
     )
     parser.add_argument(
+        "--precision",
+        default="integer",
+        choices=["integer", "double"],
+        help="Double is more precise, integer faster. Defaults to 'integer'.",
+    )
+    parser.add_argument(
         "--clean",
         action="store_true",
         help="Clean build and installation directories before building.",
@@ -79,6 +85,7 @@ def build(
     build_dir: pathlib.Path,
     build_type: str,
     problem: str,
+    precision: str,
     additional: List[str],
 ):
     cwd = pathlib.Path.cwd()
@@ -88,6 +95,7 @@ def build(
         f"-Dpython.platlibdir={cwd.absolute()}",
         f"-Dproblem={problem}",
         f"-Dstrip={'true' if build_type == 'release' else 'false'}",
+        f"-Dprecision={precision}",
         *additional,
         # fmt: on
     ]
@@ -109,7 +117,13 @@ def main():
         # the CI. Else only do so when expressly asked.
         clean(build_dir, install_dir)
 
-    build(build_dir, args.build_type, args.problem, args.additional)
+    build(
+        build_dir,
+        args.build_type,
+        args.problem,
+        args.precision,
+        args.additional,
+    )
 
     if args.regenerate_type_stubs:
         regenerate_stubs(install_dir)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,7 +2,7 @@
    :alt: PyVRP logo
 
 PyVRP is a Python package that offers a high-performance implementation of the hybrid genetic search algorithm for vehicle routing problems (VRPs).
-PyVRP currently supports the Capacitated VRP (CVRP), the Vehicle Routing Problem with Time Windows (VRPTW), and prize-collecting. 
+PyVRP currently supports the capacitated VRP (CVRP), the VRP with time windows (VRPTW), and prize-collecting. 
 
 The implementation is inspired by `HGS-CVRP <https://github.com/vidalt/HGS-CVRP/>`_, but has been completely redesigned to be easy to use as a highly customisable Python package, while maintaining speed and state-of-the-art performance.
 This allows users to directly solve VRP instances, or implement variants of the HGS algorithm using Python, inspired by the examples in this documentation. 

--- a/meson.build
+++ b/meson.build
@@ -27,11 +27,11 @@ endif
 if get_option('problem') == 'cvrp'
     # CVRP does not have time windows, so we set a flag that compiles time 
     # window stuff out of the extension modules.
-    add_project_arguments('-DVRP_NO_TIME_WINDOWS', language: 'cpp')
+    add_project_arguments('-DPYVRP_NO_TIME_WINDOWS', language: 'cpp')
 endif
 
 if get_option('precision') == 'double'  # default is integer
-    add_project_arguments('-DVRP_DOUBLE_PRECISION', language: 'cpp')
+    add_project_arguments('-DPYVRP_DOUBLE_PRECISION', language: 'cpp')
 endif
 
 # We first compile a common library that contains all regular, C++ code. This

--- a/meson.build
+++ b/meson.build
@@ -31,7 +31,7 @@ if get_option('problem') == 'cvrp'
 endif
 
 if get_option('precision') == 'double'  # default is integer
-    add_project_arguments('-DDOUBLE_PRECISION', language: 'cpp')
+    add_project_arguments('-DVRP_DOUBLE_PRECISION', language: 'cpp')
 endif
 
 # We first compile a common library that contains all regular, C++ code. This

--- a/meson.build
+++ b/meson.build
@@ -24,22 +24,14 @@ if get_option('buildtype') == 'debug'
     add_project_link_arguments('--coverage', language: 'cpp')
 endif
 
-if compiler.has_argument('-Wno-unused-parameter')
-    # Ignore unused parameters, because not all operator implementations use 
-    # every argument they are given (and that's OK).
-    add_project_arguments('-Wno-unused-parameter', language: 'cpp')
-endif
-
 if get_option('problem') == 'cvrp'
     # CVRP does not have time windows, so we set a flag that compiles time 
     # window stuff out of the extension modules.
     add_project_arguments('-DVRP_NO_TIME_WINDOWS', language: 'cpp')
+endif
 
-    if compiler.has_argument('-Wno-unused-private-field')
-        # Ignore unused fields, since a number of time window related fields
-        # are unused by the CVRP.
-        add_project_arguments('-Wno-unused-private-field', language: 'cpp')
-    endif
+if get_option('precision') == 'double'  # default is integer
+    add_project_arguments('-DDOUBLE_PRECISION', language: 'cpp')
 endif
 
 # We first compile a common library that contains all regular, C++ code. This

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,3 +5,11 @@ option(
     choices: ['cvrp', 'vrptw'], 
     description: 'Problem configuration to compile.'
 )
+
+option(
+    'precision',
+    type: 'combo',
+    value: 'integer',
+    choices: ['integer', 'double'], 
+    description: 'Precision type to compile.'
+)

--- a/pyvrp/cpp/CostEvaluator.h
+++ b/pyvrp/cpp/CostEvaluator.h
@@ -61,7 +61,7 @@ Cost CostEvaluator::loadPenalty(Load load, Load vehicleCapacity) const
 
 Cost CostEvaluator::twPenalty([[maybe_unused]] Duration timeWarp) const
 {
-#ifdef VRP_NO_TIME_WINDOWS
+#ifdef PYVRP_NO_TIME_WINDOWS
     return 0;
 #else
     return static_cast<Cost>(timeWarp) * timeWarpPenalty;

--- a/pyvrp/cpp/CostEvaluator.h
+++ b/pyvrp/cpp/CostEvaluator.h
@@ -1,5 +1,5 @@
-#ifndef HGS_COSTEVALUATOR_H
-#define HGS_COSTEVALUATOR_H
+#ifndef PYVRP_COSTEVALUATOR_H
+#define PYVRP_COSTEVALUATOR_H
 
 #include "Individual.h"
 #include "Measure.h"
@@ -68,4 +68,4 @@ Cost CostEvaluator::twPenalty([[maybe_unused]] Duration timeWarp) const
 #endif
 }
 
-#endif  // HGS_COSTEVALUATOR_H
+#endif  // PYVRP_COSTEVALUATOR_H

--- a/pyvrp/cpp/Individual.h
+++ b/pyvrp/cpp/Individual.h
@@ -1,5 +1,5 @@
-#ifndef INDIVIDUAL_H
-#define INDIVIDUAL_H
+#ifndef PYVRP_INDIVIDUAL_H
+#define PYVRP_INDIVIDUAL_H
 
 #include "Measure.h"
 #include "ProblemData.h"
@@ -198,4 +198,4 @@ template <> struct hash<Individual>
 };
 }  // namespace std
 
-#endif
+#endif  // PYVRP_INDIVIDUAL_H

--- a/pyvrp/cpp/Matrix.h
+++ b/pyvrp/cpp/Matrix.h
@@ -1,5 +1,5 @@
-#ifndef MATRIX_H
-#define MATRIX_H
+#ifndef PYVRP_MATRIX_H
+#define PYVRP_MATRIX_H
 
 #include <algorithm>
 #include <sstream>
@@ -110,4 +110,4 @@ template <typename T> T Matrix<T>::max() const
 
 template <typename T> size_t Matrix<T>::size() const { return data_.size(); }
 
-#endif
+#endif  // PYVRP_MATRIX_H

--- a/pyvrp/cpp/Measure.h
+++ b/pyvrp/cpp/Measure.h
@@ -187,7 +187,7 @@ template <MeasureType Type> struct hash<Measure<Type>>
     size_t operator()(Measure<Type> const measure) const
     {
 #ifdef PYVRP_DOUBLE_PRECISION
-        auto const value = std::pow(10, 9) * other.get();
+        auto const value = std::pow(10, 9) * measure.get();
         return std::hash<Value>()(std::trunc(value));
 #else
         return std::hash<Value>()(measure.get());

--- a/pyvrp/cpp/Measure.h
+++ b/pyvrp/cpp/Measure.h
@@ -41,6 +41,9 @@ using Load = Measure<MeasureType::LOAD>;
  * The measure class is a thin wrapper around an underlying ``Value``. The
  * measure forms a strong type that is only explicitly convertible into other
  * arithmetic or measure types.
+ *
+ * Note that comparisons involving a Measure are not exact when compiling with
+ * double precision. A small tolerance is used instead.
  */
 template <MeasureType _> class Measure
 {

--- a/pyvrp/cpp/Measure.h
+++ b/pyvrp/cpp/Measure.h
@@ -47,7 +47,7 @@ template <MeasureType _> class Measure
     friend struct std::hash<Measure>;  // friend struct to enable hashing
 
 #ifdef PYVRP_DOUBLE_PRECISION
-    static constexpr Value const TOLERANCE = 1e-6;
+    static constexpr Value const TOLERANCE = 0.00001;  // same as in HGS-CVRP
 #else
     static constexpr Value const TOLERANCE = 1;
 #endif

--- a/pyvrp/cpp/Measure.h
+++ b/pyvrp/cpp/Measure.h
@@ -123,8 +123,7 @@ template <MeasureType Type>
 bool Measure<Type>::operator==(Measure<Type> const &other) const
 {
 #ifdef PYVRP_DOUBLE_PRECISION
-    // This uses the same tolerance as HGS-CVRP (1e-5).
-    return std::abs(value - other.value) < 1e-5;
+    return std::abs(value - other.value) < 1e-5;  // HGS-CVRP tolerance value
 #else
     return value == other.value;
 #endif

--- a/pyvrp/cpp/Measure.h
+++ b/pyvrp/cpp/Measure.h
@@ -83,7 +83,7 @@ public:
 
     // Comparison operators.
     [[nodiscard]] bool operator==(Measure const &other) const;
-    [[nodiscard]] auto operator<=>(Measure const &other) const;
+    [[nodiscard]] int operator<=>(Measure const &other) const;
 };
 
 // Retreives the underlying value.
@@ -130,7 +130,7 @@ bool Measure<Type>::operator==(Measure<Type> const &other) const
 }
 
 template <MeasureType Type>
-auto Measure<Type>::operator<=>(Measure<Type> const &other) const
+int Measure<Type>::operator<=>(Measure<Type> const &other) const
 {
     if (*this == other)  // equality must be checked first, to ensure we use a
         return 0;        // loose comparison in double precision mode.

--- a/pyvrp/cpp/Measure.h
+++ b/pyvrp/cpp/Measure.h
@@ -1,13 +1,14 @@
 #ifndef MEASURE_H
 #define MEASURE_H
 
+#include <cmath>
 #include <compare>
 #include <functional>
 #include <iostream>
 #include <limits>
 #include <type_traits>
 
-#ifdef VRP_DOUBLE_PRECISION
+#ifdef PYVRP_DOUBLE_PRECISION
 using Value = double;
 #else
 using Value = int;
@@ -118,14 +119,16 @@ Measure<Type> &Measure<Type>::operator/=(Measure<Type> const &rhs)
 }
 
 // Comparison operators.
-
 template <MeasureType Type>
 auto Measure<Type>::operator==(Measure<Type> const &other) const
 {
-    // TODO if we implement inexact equality for doubles, we also need to
-    //  update hashing to avoid two objects comparing equal but having
-    //  different hash values.
+#ifdef PYVRP_DOUBLE_PRECISION
+    auto const ourValue = std::pow(10, 9) * value;
+    auto const otherValue = std::pow(10, 9) * other.value;
+    return std::trunc(ourValue) == std::trunc(otherValue);
+#else
     return value == other.value;
+#endif
 }
 
 template <MeasureType Type>
@@ -183,7 +186,12 @@ template <MeasureType Type> struct hash<Measure<Type>>
 {
     size_t operator()(Measure<Type> const measure) const
     {
+#ifdef PYVRP_DOUBLE_PRECISION
+        auto const value = std::pow(10, 9) * other.get();
+        return std::hash<Value>()(std::trunc(value));
+#else
         return std::hash<Value>()(measure.get());
+#endif
     }
 };
 

--- a/pyvrp/cpp/Measure.h
+++ b/pyvrp/cpp/Measure.h
@@ -1,5 +1,5 @@
-#ifndef MEASURE_H
-#define MEASURE_H
+#ifndef PYVRP_MEASURE_H
+#define PYVRP_MEASURE_H
 
 #include <cmath>
 #include <compare>
@@ -210,4 +210,4 @@ public:  // TODO should return type be Measure<Type>?
 
 }  // namespace std
 
-#endif  // MEASURE_H
+#endif  // PYVRP_MEASURE_H

--- a/pyvrp/cpp/Measure.h
+++ b/pyvrp/cpp/Measure.h
@@ -7,7 +7,11 @@
 #include <limits>
 #include <type_traits>
 
+#ifdef VRP_DOUBLE_PRECISION
+using Value = double;
+#else
 using Value = int;
+#endif
 
 enum class MeasureType
 {

--- a/pyvrp/cpp/ProblemData.cpp
+++ b/pyvrp/cpp/ProblemData.cpp
@@ -6,13 +6,13 @@
 #include <string>
 #include <vector>
 
-ProblemData::Client::Client(int x,
-                            int y,
-                            int demand,
-                            int serviceDuration,
-                            int twEarly,
-                            int twLate,
-                            int prize,
+ProblemData::Client::Client(Coordinate x,
+                            Coordinate y,
+                            Load demand,
+                            Duration serviceDuration,
+                            Duration twEarly,
+                            Duration twLate,
+                            Cost prize,
                             bool required)
     : x(x),
       y(y),

--- a/pyvrp/cpp/ProblemData.h
+++ b/pyvrp/cpp/ProblemData.h
@@ -1,5 +1,5 @@
-#ifndef HGS_PROBLEMDATA_H
-#define HGS_PROBLEMDATA_H
+#ifndef PYVRP_PROBLEMDATA_H
+#define PYVRP_PROBLEMDATA_H
 
 #include "Matrix.h"
 #include "Measure.h"
@@ -129,4 +129,4 @@ Duration ProblemData::duration(size_t first, size_t second) const
     return dur_(first, second);
 }
 
-#endif  // HGS_PROBLEMDATA_H
+#endif  // PYVRP_PROBLEMDATA_H

--- a/pyvrp/cpp/ProblemData.h
+++ b/pyvrp/cpp/ProblemData.h
@@ -22,13 +22,13 @@ public:
         Cost const prize = 0;        // Prize for visiting this client
         bool const required = true;  // Must client be in solution?
 
-        Client(int x,
-               int y,
-               int demand = 0,
-               int serviceDuration = 0,
-               int twEarly = 0,
-               int twLate = 0,
-               int prize = 0,
+        Client(Coordinate x,
+               Coordinate y,
+               Load demand = 0,
+               Duration serviceDuration = 0,
+               Duration twEarly = 0,
+               Duration twLate = 0,
+               Cost prize = 0,
                bool required = true);
     };
 

--- a/pyvrp/cpp/ProblemData_bindings.cpp
+++ b/pyvrp/cpp/ProblemData_bindings.cpp
@@ -8,7 +8,7 @@ namespace py = pybind11;
 PYBIND11_MODULE(_ProblemData, m)
 {
     py::class_<ProblemData::Client>(m, "Client")
-        .def(py::init<int, int, int, int, int, int, int, bool>(),
+        .def(py::init<Value, Value, Value, Value, Value, Value, Value, bool>(),
              py::arg("x"),
              py::arg("y"),
              py::arg("demand") = 0,
@@ -48,9 +48,9 @@ PYBIND11_MODULE(_ProblemData, m)
     py::class_<ProblemData>(m, "ProblemData")
         .def(py::init([](std::vector<ProblemData::Client> const &clients,
                          int numVehicles,
-                         int vehicleCap,
-                         std::vector<std::vector<int>> const &dist,
-                         std::vector<std::vector<int>> const &dur) {
+                         Value vehicleCap,
+                         std::vector<std::vector<Value>> const &dist,
+                         std::vector<std::vector<Value>> const &dur) {
                  Matrix<Distance> distMat(clients.size());
                  Matrix<Duration> durMat(clients.size());
 

--- a/pyvrp/cpp/README.md
+++ b/pyvrp/cpp/README.md
@@ -6,6 +6,10 @@ this top-level folder will be made available in the top-level `pyvrp` package,
 whereas for example everything in `cpp/educate` will be present in 
 `pyvrp.educate` after installation (and so on for the other folders).
 
+When building on our implementation, please refrain from defining symbols 
+starting with the `PYVRP_` prefix. PyVRP reserves any such global declarations
+for internal use.
+
 We use `pybind11` to generate the Python bindings for the C++ codebase. These
 bindings are generated in the `X_bindings.cpp` source files of each object `X`
 that we want to expose to Python. 

--- a/pyvrp/cpp/SubPopulation.h
+++ b/pyvrp/cpp/SubPopulation.h
@@ -1,5 +1,5 @@
-#ifndef SUBPOPULATION_H
-#define SUBPOPULATION_H
+#ifndef PYVRP_SUBPOPULATION_H
+#define PYVRP_SUBPOPULATION_H
 
 #include "CostEvaluator.h"
 #include "Individual.h"
@@ -102,4 +102,4 @@ public:
     void updateFitness(CostEvaluator const &costEvaluator);
 };
 
-#endif  // SUBPOPULATION_H
+#endif  // PYVRP_SUBPOPULATION_H

--- a/pyvrp/cpp/TimeWindowSegment.h
+++ b/pyvrp/cpp/TimeWindowSegment.h
@@ -1,5 +1,5 @@
-#ifndef TIMEWINDOWDATA_H
-#define TIMEWINDOWDATA_H
+#ifndef PYVRP_TIMEWINDOWSEGMENT_H
+#define PYVRP_TIMEWINDOWSEGMENT_H
 
 #include "Matrix.h"
 #include "Measure.h"
@@ -99,4 +99,4 @@ TimeWindowSegment::TimeWindowSegment(int idxFirst,
 {
 }
 
-#endif  // TIMEWINDOWDATA_H
+#endif  // PYVRP_TIMEWINDOWSEGMENT_H

--- a/pyvrp/cpp/TimeWindowSegment.h
+++ b/pyvrp/cpp/TimeWindowSegment.h
@@ -46,7 +46,7 @@ TimeWindowSegment TimeWindowSegment::merge(
     [[maybe_unused]] Matrix<Duration> const &durationMatrix,
     [[maybe_unused]] TimeWindowSegment const &other) const
 {
-#ifdef VRP_NO_TIME_WINDOWS
+#ifdef PYVRP_NO_TIME_WINDOWS
     return {};
 #else
     auto const arcDuration = durationMatrix(idxLast, other.idxFirst);
@@ -70,7 +70,7 @@ TimeWindowSegment TimeWindowSegment::merge(
     [[maybe_unused]] TimeWindowSegment const &second,
     [[maybe_unused]] Args... args)
 {
-#ifdef VRP_NO_TIME_WINDOWS
+#ifdef PYVRP_NO_TIME_WINDOWS
     return {};
 #else
     auto const res = first.merge(durationMatrix, second);

--- a/pyvrp/cpp/XorShift128.h
+++ b/pyvrp/cpp/XorShift128.h
@@ -1,5 +1,5 @@
-#ifndef XORSHIFT128_H
-#define XORSHIFT128_H
+#ifndef PYVRP_XORSHIFT128_H
+#define PYVRP_XORSHIFT128_H
 
 #include <cstddef>
 #include <cstdint>
@@ -82,4 +82,4 @@ template <typename T> XorShift128::result_type XorShift128::randint(T high)
     return operator()() % high;
 }
 
-#endif  // XORSHIFT128_H
+#endif  // PYVRP_XORSHIFT128_H

--- a/pyvrp/cpp/crossover/crossover.cpp
+++ b/pyvrp/cpp/crossover/crossover.cpp
@@ -20,7 +20,7 @@ Cost deltaCost(Client client,
     auto const currDist = data.dist(prev, next);
     auto const propDist = data.dist(prev, client) + data.dist(client, next);
 
-#ifdef VRP_NO_TIME_WINDOWS
+#ifdef PYVRP_NO_TIME_WINDOWS
     return static_cast<Cost>(propDist - currDist);
 #else
     auto const &clientData = data.client(client);

--- a/pyvrp/cpp/crossover/crossover.h
+++ b/pyvrp/cpp/crossover/crossover.h
@@ -1,5 +1,5 @@
-#ifndef CROSSOVER_H
-#define CROSSOVER_H
+#ifndef PYVRP_CROSSOVER_H
+#define PYVRP_CROSSOVER_H
 
 #include "CostEvaluator.h"
 #include "Individual.h"
@@ -51,4 +51,4 @@ Individual selectiveRouteExchange(
     std::pair<size_t, size_t> const startIndices,
     size_t const numMovedRoutes);
 
-#endif  // CROSSOVER_H
+#endif  // PYVRP_CROSSOVER_H

--- a/pyvrp/cpp/diversity/diversity.h
+++ b/pyvrp/cpp/diversity/diversity.h
@@ -1,5 +1,5 @@
-#ifndef HGS_DIVERSITY_H
-#define HGS_DIVERSITY_H
+#ifndef PYVRP_DIVERSITY_H
+#define PYVRP_DIVERSITY_H
 
 #include "Individual.h"
 #include "ProblemData.h"
@@ -21,4 +21,4 @@ typedef std::function<double(Individual const &, Individual const &)>
  */
 double brokenPairsDistance(Individual const &first, Individual const &second);
 
-#endif  // HGS_DIVERSITY_H
+#endif  // PYVRP_DIVERSITY_H

--- a/pyvrp/cpp/educate/CircleSector.h
+++ b/pyvrp/cpp/educate/CircleSector.h
@@ -1,5 +1,5 @@
-#ifndef CIRCLESECTOR_H
-#define CIRCLESECTOR_H
+#ifndef PYVRP_CIRCLESECTOR_H
+#define PYVRP_CIRCLESECTOR_H
 
 // Data structure to represent circle sectors
 // Angles are measured in [0,65535] instead of [0,359], in such a way that
@@ -79,4 +79,4 @@ struct CircleSector
     }
 };
 
-#endif
+#endif  // PYVRP_CIRCLESECTOR_H

--- a/pyvrp/cpp/educate/Exchange.h
+++ b/pyvrp/cpp/educate/Exchange.h
@@ -1,5 +1,5 @@
-#ifndef EXCHANGE_H
-#define EXCHANGE_H
+#ifndef PYVRP_EXCHANGE_H
+#define PYVRP_EXCHANGE_H
 
 #include "LocalSearchOperator.h"
 #include "TimeWindowSegment.h"
@@ -318,4 +318,4 @@ template <size_t N, size_t M> void Exchange<N, M>::apply(Node *U, Node *V) const
     }
 }
 
-#endif  // EXCHANGE_H
+#endif  // PYVRP_EXCHANGE_H

--- a/pyvrp/cpp/educate/LocalSearch.h
+++ b/pyvrp/cpp/educate/LocalSearch.h
@@ -1,5 +1,5 @@
-#ifndef LOCALSEARCH_H
-#define LOCALSEARCH_H
+#ifndef PYVRP_LOCALSEARCH_H
+#define PYVRP_LOCALSEARCH_H
 
 #include "CostEvaluator.h"
 #include "Individual.h"
@@ -106,4 +106,4 @@ public:
     LocalSearch(ProblemData &data, XorShift128 &rng, Neighbours neighbours);
 };
 
-#endif
+#endif  // PYVRP_LOCALSEARCH_H

--- a/pyvrp/cpp/educate/LocalSearchOperator.h
+++ b/pyvrp/cpp/educate/LocalSearchOperator.h
@@ -1,5 +1,5 @@
-#ifndef LOCALSEARCHOPERATOR_H
-#define LOCALSEARCHOPERATOR_H
+#ifndef PYVRP_LOCALSEARCHOPERATOR_H
+#define PYVRP_LOCALSEARCHOPERATOR_H
 
 #include "CostEvaluator.h"
 #include "Individual.h"
@@ -75,4 +75,4 @@ public:
     virtual void update([[maybe_unused]] Route *U){};
 };
 
-#endif  // LOCALSEARCHOPERATOR_H
+#endif  // PYVRP_LOCALSEARCHOPERATOR_H

--- a/pyvrp/cpp/educate/MoveTwoClientsReversed.h
+++ b/pyvrp/cpp/educate/MoveTwoClientsReversed.h
@@ -1,5 +1,5 @@
-#ifndef MOVETWOCLIENTSREVERSED_H
-#define MOVETWOCLIENTSREVERSED_H
+#ifndef PYVRP_MOVETWOCLIENTSREVERSED_H
+#define PYVRP_MOVETWOCLIENTSREVERSED_H
 
 #include "LocalSearchOperator.h"
 
@@ -17,4 +17,4 @@ public:
     void apply(Node *U, Node *V) const override;
 };
 
-#endif  // MOVETWOCLIENTSREVERSED_H
+#endif  // PYVRP_MOVETWOCLIENTSREVERSED_H

--- a/pyvrp/cpp/educate/Node.h
+++ b/pyvrp/cpp/educate/Node.h
@@ -1,5 +1,5 @@
-#ifndef NODE_H
-#define NODE_H
+#ifndef PYVRP_NODE_H
+#define PYVRP_NODE_H
 
 #include "Measure.h"
 #include "TimeWindowSegment.h"
@@ -53,4 +53,4 @@ inline Node *p(Node *node) { return node->prev; }
  */
 inline Node *n(Node *node) { return node->next; }
 
-#endif  // NODE_H
+#endif  // PYVRP_NODE_H

--- a/pyvrp/cpp/educate/RelocateStar.h
+++ b/pyvrp/cpp/educate/RelocateStar.h
@@ -1,5 +1,5 @@
-#ifndef RELOCATESTAR_H
-#define RELOCATESTAR_H
+#ifndef PYVRP_RELOCATESTAR_H
+#define PYVRP_RELOCATESTAR_H
 
 #include "Exchange.h"
 #include "LocalSearchOperator.h"
@@ -32,4 +32,4 @@ public:
     }
 };
 
-#endif  // RELOCATESTAR_H
+#endif  // PYVRP_RELOCATESTAR_H

--- a/pyvrp/cpp/educate/Route.h
+++ b/pyvrp/cpp/educate/Route.h
@@ -1,5 +1,5 @@
-#ifndef HGS_VRPTW_ROUTE_H
-#define HGS_VRPTW_ROUTE_H
+#ifndef PYVRP_ROUTE_H
+#define PYVRP_ROUTE_H
 
 #include "CircleSector.h"
 #include "Node.h"
@@ -187,4 +187,4 @@ Load Route::loadBetween(size_t start, size_t end) const
 // Outputs a route into a given ostream in CVRPLib format
 std::ostream &operator<<(std::ostream &out, Route const &route);
 
-#endif  // HGS_VRPTW_ROUTE_H
+#endif  // PYVRP_ROUTE_H

--- a/pyvrp/cpp/educate/Route.h
+++ b/pyvrp/cpp/educate/Route.h
@@ -121,7 +121,7 @@ bool Route::hasExcessLoad() const { return !isLoadFeasible_; }
 
 bool Route::hasTimeWarp() const
 {
-#ifdef VRP_NO_TIME_WINDOWS
+#ifdef PYVRP_NO_TIME_WINDOWS
     return false;
 #else
     return !isTimeWarpFeasible_;

--- a/pyvrp/cpp/educate/SwapStar.h
+++ b/pyvrp/cpp/educate/SwapStar.h
@@ -1,5 +1,5 @@
-#ifndef SWAPSTAR_H
-#define SWAPSTAR_H
+#ifndef PYVRP_SWAPSTAR_H
+#define PYVRP_SWAPSTAR_H
 
 #include "LocalSearchOperator.h"
 #include "Matrix.h"
@@ -108,4 +108,4 @@ public:
     }
 };
 
-#endif  // SWAPSTAR_H
+#endif  // PYVRP_SWAPSTAR_H

--- a/pyvrp/cpp/educate/TwoOpt.h
+++ b/pyvrp/cpp/educate/TwoOpt.h
@@ -1,5 +1,5 @@
-#ifndef TWOOPT_H
-#define TWOOPT_H
+#ifndef PYVRP_TWOOPT_H
+#define PYVRP_TWOOPT_H
 
 #include "LocalSearchOperator.h"
 
@@ -32,4 +32,4 @@ public:
     void apply(Node *U, Node *V) const override;
 };
 
-#endif  // TWOOPT_H
+#endif  // PYVRP_TWOOPT_H

--- a/pyvrp/plotting/plot_route_schedule.py
+++ b/pyvrp/plotting/plot_route_schedule.py
@@ -156,7 +156,7 @@ def plot_route_schedule(
     # Set labels, legends and title
     ax.set_xlabel("Distance")
     ax.set_ylabel("Time")
-    twin1.set_ylabel(f"Load (capacity = {data.vehicle_capacity})")
+    twin1.set_ylabel(f"Load (capacity = {data.vehicle_capacity:.0f})")
 
     if legend:
         twin1.legend(loc="upper right")

--- a/pyvrp/tests/test_CostEvaluator.py
+++ b/pyvrp/tests/test_CostEvaluator.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_, assert_allclose, assert_equal
+from numpy.testing import assert_, assert_allclose
 from pytest import mark
 
 from pyvrp import CostEvaluator, Individual
@@ -9,22 +9,22 @@ from pyvrp.tests.helpers import read
 def test_load_penalty():
     cost_evaluator = CostEvaluator(2, 1)
 
-    assert_equal(cost_evaluator.load_penalty(0, 1), 0)  # below capacity
-    assert_equal(cost_evaluator.load_penalty(1, 1), 0)  # at capacity
+    assert_allclose(cost_evaluator.load_penalty(0, 1), 0)  # below capacity
+    assert_allclose(cost_evaluator.load_penalty(1, 1), 0)  # at capacity
 
     # Penalty per unit excess capacity is 2
     # 1 unit above capacity
-    assert_equal(cost_evaluator.load_penalty(2, 1), 2)
+    assert_allclose(cost_evaluator.load_penalty(2, 1), 2)
     # 2 units above capacity
-    assert_equal(cost_evaluator.load_penalty(3, 1), 4)
+    assert_allclose(cost_evaluator.load_penalty(3, 1), 4)
 
     # Penalty per unit excess capacity is 4
     cost_evaluator = CostEvaluator(4, 1)
 
     # 1 unit above capacity
-    assert_equal(cost_evaluator.load_penalty(2, 1), 4)
+    assert_allclose(cost_evaluator.load_penalty(2, 1), 4)
     # 2 units above capacity
-    assert_equal(cost_evaluator.load_penalty(3, 1), 8)
+    assert_allclose(cost_evaluator.load_penalty(3, 1), 8)
 
 
 @mark.parametrize("capacity", [5, 15, 29, 51, 103])
@@ -33,15 +33,15 @@ def test_load_penalty_always_zero_when_below_capacity(capacity: int):
     cost_evaluator = CostEvaluator(load_penalty, 1)
 
     for load in range(capacity):  # all below capacity
-        assert_equal(cost_evaluator.load_penalty(load, capacity), 0)
+        assert_allclose(cost_evaluator.load_penalty(load, capacity), 0)
 
     # at capacity
-    assert_equal(cost_evaluator.load_penalty(capacity, capacity), 0)
+    assert_allclose(cost_evaluator.load_penalty(capacity, capacity), 0)
     # above capacity
-    assert_equal(
+    assert_allclose(
         cost_evaluator.load_penalty(capacity + 1, capacity), load_penalty
     )
-    assert_equal(
+    assert_allclose(
         cost_evaluator.load_penalty(capacity + 2, capacity), 2 * load_penalty
     )
 
@@ -50,16 +50,16 @@ def test_tw_penalty():
     cost_evaluator = CostEvaluator(1, 2)
 
     # Penalty per unit time warp is 2
-    assert_equal(cost_evaluator.tw_penalty(0), 0)
-    assert_equal(cost_evaluator.tw_penalty(1), 2)
-    assert_equal(cost_evaluator.tw_penalty(2), 4)
+    assert_allclose(cost_evaluator.tw_penalty(0), 0)
+    assert_allclose(cost_evaluator.tw_penalty(1), 2)
+    assert_allclose(cost_evaluator.tw_penalty(2), 4)
 
     cost_evaluator = CostEvaluator(1, 4)
 
     # Penalty per unit excess capacity is now 4
-    assert_equal(cost_evaluator.tw_penalty(0), 0)
-    assert_equal(cost_evaluator.tw_penalty(1), 4)
-    assert_equal(cost_evaluator.tw_penalty(2), 8)
+    assert_allclose(cost_evaluator.tw_penalty(0), 0)
+    assert_allclose(cost_evaluator.tw_penalty(1), 4)
+    assert_allclose(cost_evaluator.tw_penalty(2), 8)
 
 
 def test_cost():
@@ -71,16 +71,22 @@ def test_cost():
     feas_indiv = Individual(data, [[1, 2], [3], [4]])
     distance = feas_indiv.distance()
 
-    assert_equal(cost_evaluator.cost(feas_indiv), distance)
-    assert_equal(default_cost_evaluator.cost(feas_indiv), distance)
+    assert_allclose(cost_evaluator.cost(feas_indiv), distance)
+    assert_allclose(default_cost_evaluator.cost(feas_indiv), distance)
 
     # Infeasible individual
     infeas_indiv = Individual(data, [[1, 2, 3, 4]])
+    assert_(not infeas_indiv.is_feasible())
 
-    # C++ code represents infinity using a relevant maximal value.
-    INFEAS_COST = np.iinfo(np.int32).max
-    assert_equal(cost_evaluator.cost(infeas_indiv), INFEAS_COST)
-    assert_equal(default_cost_evaluator.cost(infeas_indiv), INFEAS_COST)
+    # The C++ code represents infinity using a relevant maximal value, which
+    # depends on the precision type (double or integer).
+    if isinstance(distance, int):
+        INFEAS_COST = np.iinfo(np.int32).max
+    else:
+        INFEAS_COST = np.finfo(np.float64).max
+
+    assert_allclose(cost_evaluator.cost(infeas_indiv), INFEAS_COST)
+    assert_allclose(default_cost_evaluator.cost(infeas_indiv), INFEAS_COST)
 
 
 def test_cost_with_prizes():
@@ -105,30 +111,27 @@ def test_penalised_cost():
     data = read("data/OkSmall.txt")
     penalty_capacity = 20
     penalty_tw = 6
-    default_cost_evaluator = CostEvaluator()
+    default_evaluator = CostEvaluator()
     cost_evaluator = CostEvaluator(penalty_capacity, penalty_tw)
 
-    # Feasible individual
-    feas_indiv = Individual(data, [[1, 2], [3], [4]])
-    feas_dist = feas_indiv.distance()
+    feas = Individual(data, [[1, 2], [3], [4]])
+    assert_(feas.is_feasible())
 
-    # For feasible individual, cost and penalised_cost should equal distance
-    assert_equal(cost_evaluator.penalised_cost(feas_indiv), feas_dist)
-    assert_equal(default_cost_evaluator.penalised_cost(feas_indiv), feas_dist)
+    # For a feasible individual, cost and penalised_cost equal distance.
+    assert_allclose(cost_evaluator.penalised_cost(feas), feas.distance())
+    assert_allclose(default_evaluator.penalised_cost(feas), feas.distance())
 
-    # Infeasible individual
-    infeas_indiv = Individual(data, [[1, 2, 3, 4]])
+    infeas = Individual(data, [[1, 2, 3, 4]])
+    assert_(not infeas.is_feasible())
 
-    # Compute cost associated to violated constraints
-    load_penalty_cost = penalty_capacity * infeas_indiv.excess_load()
-    tw_penalty_cost = penalty_tw * infeas_indiv.time_warp()
-    infeas_dist = infeas_indiv.distance()
+    # Compute cost associated with violated constraints.
+    load_penalty_cost = penalty_capacity * infeas.excess_load()
+    tw_penalty_cost = penalty_tw * infeas.time_warp()
+    infeas_dist = infeas.distance()
 
     # Test penalised cost
     expected_cost = infeas_dist + load_penalty_cost + tw_penalty_cost
-    assert_equal(cost_evaluator.penalised_cost(infeas_indiv), expected_cost)
+    assert_allclose(cost_evaluator.penalised_cost(infeas), expected_cost)
 
     # Default cost evaluator has 0 weights and only computes distance as cost
-    assert_equal(
-        default_cost_evaluator.penalised_cost(infeas_indiv), infeas_dist
-    )
+    assert_allclose(default_evaluator.penalised_cost(infeas), infeas_dist)

--- a/pyvrp/tests/test_Individual.py
+++ b/pyvrp/tests/test_Individual.py
@@ -328,8 +328,8 @@ def test_str_contains_essential_information():
                 assert_(str(client) in str_route)
 
         # Last lines should contain the travel distance and collected prizes.
-        assert_(str(individual.distance()) in str_representation[-2])
-        assert_(str(individual.prizes()) in str_representation[-1])
+        assert_(str(int(individual.distance())) in str_representation[-2])
+        assert_(str(int(individual.prizes())) in str_representation[-1])
 
 
 def test_hash():


### PR DESCRIPTION
This PR:

- [x] Closes #47.
- [ ] Adds and passes relevant tests.
- [x] Has well-formatted code and documentation.

### Benchmarks

All on VRPTW.

Integer precision (bd1b87e97c29cad55fd3f07b9da127d0266b1003; job ID 2370987; 10x seeds/1h with `configs/vrptw.toml`):
```
 Avg. objective: 333303.7 (min: 333107, max: 333384)
Avg. iterations: 102962.3 (min: 101098, max: 104870)
```
So this is basically unchanged.

Double precision (a2de0879a383903b884faa34fa36fcadc44369f4; job ID 2372134; 10x seeds/1h with `configs/vrptw.toml`):
```
 Avg. objective:  33418.1 (min: 33405, max: 33433)
Avg. iterations:  80966.0 (min: 77283, max: 87658)
```

<details>

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
