### PR TITLE
Base route angle on centroid of client locations

### DIFF
--- a/pyvrp/_ProblemData.pyi
+++ b/pyvrp/_ProblemData.pyi
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 class Client:
     """
@@ -101,6 +101,15 @@ class ProblemData:
         -------
         Client
             A simple data object containing the depot's information.
+        """
+    def centroid(self) -> Tuple[float, float]:
+        """
+        Center point of all client locations (excluding the depot).
+
+        Returns
+        -------
+        tuple
+            Centroid of all client locations.
         """
     def dist(self, first: int, second: int) -> int:
         """

--- a/pyvrp/cpp/ProblemData.cpp
+++ b/pyvrp/cpp/ProblemData.cpp
@@ -38,6 +38,11 @@ ProblemData::Client::Client(Coordinate x,
 
 ProblemData::Client const &ProblemData::depot() const { return client(0); }
 
+std::pair<double, double> const &ProblemData::centroid() const
+{
+    return centroid_;
+}
+
 Matrix<Distance> const &ProblemData::distanceMatrix() const { return dist_; }
 
 Matrix<Duration> const &ProblemData::durationMatrix() const { return dur_; }
@@ -53,11 +58,17 @@ ProblemData::ProblemData(std::vector<Client> const &clients,
                          Load vehicleCap,
                          Matrix<Distance> const distMat,
                          Matrix<Duration> const durMat)
-    : dist_(std::move(distMat)),
+    : centroid_({0, 0}),
+      dist_(std::move(distMat)),
       dur_(std::move(durMat)),
       clients_(clients),
       numClients_(std::max<size_t>(clients.size(), 1) - 1),
       numVehicles_(numVehicles),
       vehicleCapacity_(vehicleCap)
 {
+    for (size_t idx = 1; idx <= numClients(); ++idx)
+    {
+        centroid_.first += static_cast<double>(clients[idx].x) / numClients();
+        centroid_.second += static_cast<double>(clients[idx].y) / numClients();
+    }
 }

--- a/pyvrp/cpp/ProblemData.h
+++ b/pyvrp/cpp/ProblemData.h
@@ -33,9 +33,10 @@ public:
     };
 
 private:
-    Matrix<Distance> const dist_;  // Distance matrix (+depot)
-    Matrix<Duration> const dur_;   // Duration matrix (+depot)
-    std::vector<Client> clients_;  // Client (+depot) information
+    std::pair<double, double> centroid_;  // Centroid of client locations
+    Matrix<Distance> const dist_;         // Distance matrix (+depot)
+    Matrix<Duration> const dur_;          // Duration matrix (+depot)
+    std::vector<Client> clients_;         // Client (+depot) information
 
     size_t const numClients_;
     size_t const numVehicles_;
@@ -52,6 +53,11 @@ public:
      * @return A struct containing the depot's information.
      */
     [[nodiscard]] Client const &depot() const;
+
+    /**
+     * @return Centroid of client locations.
+     */
+    [[nodiscard]] std::pair<double, double> const &centroid() const;
 
     /**
      * Returns the distance between the indicated two clients.

--- a/pyvrp/cpp/ProblemData_bindings.cpp
+++ b/pyvrp/cpp/ProblemData_bindings.cpp
@@ -79,7 +79,12 @@ PYBIND11_MODULE(_ProblemData, m)
              &ProblemData::client,
              py::arg("client"),
              py::return_value_policy::reference_internal)
-        .def("depot", &ProblemData::depot, py::return_value_policy::reference)
+        .def("depot",
+             &ProblemData::depot,
+             py::return_value_policy::reference_internal)
+        .def("centroid",
+             &ProblemData::centroid,
+             py::return_value_policy::reference_internal)
         .def(
             "dist",
             [](ProblemData const &data, size_t first, size_t second) {

--- a/pyvrp/cpp/crossover/selective_route_exchange.cpp
+++ b/pyvrp/cpp/crossover/selective_route_exchange.cpp
@@ -106,10 +106,10 @@ Individual selectiveRouteExchange(
         // Difference for moving 'left' in parent A
         int differenceALeft = 0;
 
-        for (Client c : routesA[(nRoutesA + startA - 1) % nRoutesA])
+        for (Client c : routesA[(startA - 1 + nRoutesA) % nRoutesA])
             differenceALeft += !selectedB.contains(c);
 
-        for (Client c : routesA[(numMovedRoutes + startA - 1) % nRoutesA])
+        for (Client c : routesA[(startA + numMovedRoutes - 1) % nRoutesA])
             differenceALeft -= !selectedB.contains(c);
 
         // Difference for moving 'right' in parent A
@@ -124,10 +124,10 @@ Individual selectiveRouteExchange(
         // Difference for moving 'left' in parent B
         int differenceBLeft = 0;
 
-        for (Client c : routesB[(numMovedRoutes + startB - 1) % nRoutesB])
+        for (Client c : routesB[(startB - 1 + numMovedRoutes) % nRoutesB])
             differenceBLeft += selectedA.contains(c);
 
-        for (Client c : routesB[(nRoutesB + startB - 1) % nRoutesB])
+        for (Client c : routesB[(startB - 1 + nRoutesB) % nRoutesB])
             differenceBLeft -= selectedA.contains(c);
 
         // Difference for moving 'right' in parent B
@@ -152,7 +152,7 @@ Individual selectiveRouteExchange(
             for (Client c : routesA[(startA + numMovedRoutes - 1) % nRoutesA])
                 selectedA.erase(c);
 
-            startA = (nRoutesA + startA - 1) % nRoutesA;
+            startA = (startA - 1 + nRoutesA) % nRoutesA;
             selectedA.insert(routesA[startA].begin(), routesA[startA].end());
         }
         else if (bestDifference == differenceARight)
@@ -170,7 +170,7 @@ Individual selectiveRouteExchange(
             for (Client c : routesB[(startB + numMovedRoutes - 1) % nRoutesB])
                 selectedB.erase(c);
 
-            startB = (nRoutesB + startB - 1) % nRoutesB;
+            startB = (startB - 1 + nRoutesB) % nRoutesB;
             selectedB.insert(routesB[startB].begin(), routesB[startB].end());
         }
         else if (bestDifference == differenceBRight)

--- a/pyvrp/crossover/tests/test_selective_route_exchange.py
+++ b/pyvrp/crossover/tests/test_selective_route_exchange.py
@@ -64,7 +64,7 @@ def test_srex_move_all_routes():
     indiv2 = Individual(data, [[1, 2], [3], [4]])
     offspring = cpp_srex((indiv1, indiv2), data, cost_evaluator, (0, 0), 3)
 
-    # Note: result will be permuted but equality is invariant to that
+    # Note: result will be permuted but equality is invariant to that.
     assert_equal(offspring, indiv2)
 
 
@@ -103,8 +103,6 @@ def test_srex_greedy_repair():
     data = read("data/OkSmallGreedyRepair.txt")
     cost_evaluator = CostEvaluator(20, 6)
 
-    # We create the routes sorted by angle such that SREX sorting doesn't
-    # affect them
     indiv1 = Individual(data, [[3, 4], [1, 2]])
     indiv2 = Individual(data, [[2, 3], [4, 1]])
 
@@ -126,8 +124,6 @@ def test_srex_changed_start_indices():
     data = read("data/OkSmall.txt")
     cost_evaluator = CostEvaluator(20, 6)
 
-    # We create the routes sorted by angle such that SREX sorting doesn't
-    # affect them
     indiv1 = Individual(data, [[4], [1, 2, 3]])
     indiv2 = Individual(data, [[3], [1, 2, 4]])
 
@@ -153,8 +149,6 @@ def test_srex_a_right_move():
     data = read("data/OkSmall.txt")
     cost_evaluator = CostEvaluator(20, 6)
 
-    # We create the routes sorted by angle such that SREX sorting doesn't
-    # affect them
     indiv1 = Individual(data, [[4], [2], [1, 3]])
     indiv2 = Individual(data, [[3], [2], [4, 1]])
 
@@ -201,9 +195,10 @@ def test_srex_a_left_move():
     cost_evaluator = CostEvaluator(20, 6)
 
     # We create the routes sorted by angle such that SREX sorting doesn't
-    # affect them
-    indiv1 = Individual(data, [[4], [2], [1, 3]])
-    indiv2 = Individual(data, [[3], [4], [2, 1]])
+    # affect them.
+    indiv1 = Individual(data, [[2], [1, 3], [4]])
+    indiv2 = Individual(data, [[3], [2, 1], [4]])
+
     offspring = cpp_srex((indiv1, indiv2), data, cost_evaluator, (2, 2), 1)
     expected = Individual(data, [[4], [2, 1], [3]])
     assert_equal(offspring, expected)
@@ -218,10 +213,10 @@ def test_srex_b_left_move():
     cost_evaluator = CostEvaluator(20, 6)
 
     # We create the routes sorted by angle such that SREX sorting doesn't
-    # affect them
-    indiv1 = Individual(data, [[4], [2], [1, 3]])
-    indiv2 = Individual(data, [[3], [2], [4, 1]])
-    offspring = cpp_srex((indiv1, indiv2), data, cost_evaluator, (0, 0), 1)
+    # affect them.
+    indiv1 = Individual(data, [[2], [1, 3], [4]])
+    indiv2 = Individual(data, [[3], [4, 1], [2]])
+    offspring = cpp_srex((indiv1, indiv2), data, cost_evaluator, (1, 2), 1)
     expected = Individual(data, [[4, 1], [2], [3]])
     assert_equal(offspring, expected)
 
@@ -235,9 +230,10 @@ def test_srex_b_right_move():
     cost_evaluator = CostEvaluator(20, 6)
 
     # We create the routes sorted by angle such that SREX sorting doesn't
-    # affect them
-    indiv1 = Individual(data, [[4], [2], [1, 3]])
-    indiv2 = Individual(data, [[3], [4], [2, 1]])
-    offspring = cpp_srex((indiv1, indiv2), data, cost_evaluator, (0, 0), 1)
+    # affect them.
+    indiv1 = Individual(data, [[2], [1, 3], [4]])
+    indiv2 = Individual(data, [[3], [2, 1], [4]])
+
+    offspring = cpp_srex((indiv1, indiv2), data, cost_evaluator, (2, 1), 1)
     expected = Individual(data, [[4], [2], [1, 3]])
     assert_equal(offspring, expected)

--- a/pyvrp/tests/test_ProblemData.py
+++ b/pyvrp/tests/test_ProblemData.py
@@ -1,8 +1,10 @@
+import numpy as np
 from numpy.random import default_rng
 from numpy.testing import assert_, assert_allclose, assert_raises
 from pytest import mark
 
 from pyvrp import Client, ProblemData
+from pyvrp.tests.helpers import read
 
 
 @mark.parametrize(
@@ -73,6 +75,17 @@ def test_depot_is_first_client():
     )
 
     assert_(data.depot() is data.client(0))
+
+
+def test_centroid():
+    data = read("data/OkSmall.txt")
+
+    centroid = data.centroid()
+    x = [data.client(idx).x for idx in range(1, data.num_clients + 1)]
+    y = [data.client(idx).y for idx in range(1, data.num_clients + 1)]
+
+    assert_allclose(centroid[0], np.mean(x))
+    assert_allclose(centroid[1], np.mean(y))
 
 
 def test_matrix_access():


### PR DESCRIPTION
This PR modifies the angle computation to be relative to the center point of all client locations, rather than the depot location. That should result in a more effective route sorting and crossover when the depot is not centrally located.

- [x] Adds and passes relevant tests.
- [x] Has well-formatted code and documentation.

### Benchmarks

All on the X instances, where the depot's location varies quite a bit between instances.

Current main (3e90a1008fc6380f66af546cc9ed0b1d510ef66d; job ID 2505221; 10x seeds, $2.4n$ runtime with `configs/cvrp.toml`):
```
 Avg. objective: 63317.1 (min: 63301.6, max: 63342.8)
Avg. iterations: 100779.6 (min: 83520, max: 105537)
```

This PR (99c977915118e77d1a1a3408d5c95f3c3f661c08; job ID 2503917 and 2504107; 10x seeds, $2.4n$ runtime with `configs/cvrp.toml`):
```
 Avg. objective: 63302.5 (min: 63293.1, max: 63311)
Avg. iterations: 89561.6 (min: 82269, max: 104784)
```

<details>

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
