### PR TITLE
Remove using namespace directives

### DIFF
--- a/pyvrp/cpp/CostEvaluator.cpp
+++ b/pyvrp/cpp/CostEvaluator.cpp
@@ -2,7 +2,9 @@
 
 #include <limits>
 
-using namespace pyvrp;
+using pyvrp::Cost;
+using pyvrp::CostEvaluator;
+using pyvrp::Solution;
 
 CostEvaluator::CostEvaluator(Cost capacityPenalty, Cost timeWarpPenalty)
     : capacityPenalty(capacityPenalty), timeWarpPenalty(timeWarpPenalty)

--- a/pyvrp/cpp/ProblemData.cpp
+++ b/pyvrp/cpp/ProblemData.cpp
@@ -1,13 +1,11 @@
 #include "ProblemData.h"
 
-#include <cmath>
-#include <fstream>
 #include <numeric>
-#include <sstream>
-#include <string>
-#include <vector>
 
-using namespace pyvrp;
+using pyvrp::Distance;
+using pyvrp::Duration;
+using pyvrp::Matrix;
+using pyvrp::ProblemData;
 
 ProblemData::Client::Client(Coordinate x,
                             Coordinate y,

--- a/pyvrp/cpp/Solution.cpp
+++ b/pyvrp/cpp/Solution.cpp
@@ -5,7 +5,12 @@
 #include <numeric>
 #include <unordered_map>
 
-using namespace pyvrp;
+using pyvrp::Cost;
+using pyvrp::Distance;
+using pyvrp::Duration;
+using pyvrp::Load;
+using pyvrp::Solution;
+
 using Client = int;
 using Visits = std::vector<Client>;
 using Routes = std::vector<Solution::Route>;

--- a/pyvrp/cpp/SubPopulation.cpp
+++ b/pyvrp/cpp/SubPopulation.cpp
@@ -2,7 +2,7 @@
 
 #include <numeric>
 
-using namespace pyvrp;
+using pyvrp::SubPopulation;
 using const_iter = std::vector<SubPopulation::Item>::const_iterator;
 using iter = std::vector<SubPopulation::Item>::iterator;
 

--- a/pyvrp/cpp/bindings.cpp
+++ b/pyvrp/cpp/bindings.cpp
@@ -19,11 +19,11 @@ namespace py = pybind11;
 using namespace pyvrp;
 using TWS = TimeWindowSegment;
 
-template <typename... Args> TWS merge(Matrix<int> const &mat, Args... args)
+template <typename... Args> TWS merge(Matrix<Value> const &mat, Args... args)
 {
     Matrix<Duration> durMat(mat.numRows(), mat.numCols());
 
-    // Copy the Matrix<int> over to Matrix<Duration>. That's not very efficient,
+    // Copy the Matrix<Value> over to Matrix<Duration>. That's not efficient,
     // but since this class is internal to PyVRP that does not matter much. We
     // only expose it to Python for testing.
     for (size_t row = 0; row != durMat.numRows(); ++row)
@@ -88,27 +88,27 @@ PYBIND11_MODULE(_pyvrp, m)
         .def("__xor__", &DynamicBitset::operator^, py::arg("other"))
         .def("__invert__", &DynamicBitset::operator~);
 
-    py::class_<Matrix<int>>(m, "Matrix")
+    py::class_<Matrix<Value>>(m, "Matrix")
         .def(py::init<size_t>(), py::arg("dimension"))
         .def(py::init<size_t, size_t>(), py::arg("n_rows"), py::arg("n_cols"))
-        .def(py::init<std::vector<std::vector<int>>>(), py::arg("data"))
-        .def_property_readonly("num_cols", &Matrix<int>::numCols)
-        .def_property_readonly("num_rows", &Matrix<int>::numRows)
+        .def(py::init<std::vector<std::vector<Value>>>(), py::arg("data"))
+        .def_property_readonly("num_cols", &Matrix<Value>::numCols)
+        .def_property_readonly("num_rows", &Matrix<Value>::numRows)
         .def(
             "__getitem__",
-            [](Matrix<int> &m, std::pair<size_t, size_t> idx) -> int {
+            [](Matrix<Value> &m, std::pair<size_t, size_t> idx) -> Value {
                 return m(idx.first, idx.second);
             },
             py::arg("idx"))
         .def(
             "__setitem__",
-            [](Matrix<int> &m, std::pair<size_t, size_t> idx, int value) {
+            [](Matrix<Value> &m, std::pair<size_t, size_t> idx, Value value) {
                 m(idx.first, idx.second) = value;
             },
             py::arg("idx"),
             py::arg("value"))
-        .def("max", &Matrix<int>::max)
-        .def("size", &Matrix<int>::size);
+        .def("max", &Matrix<Value>::max)
+        .def("size", &Matrix<Value>::size);
 
     py::class_<ProblemData::Client>(m, "Client")
         .def(py::init<Value,

--- a/pyvrp/cpp/bindings.cpp
+++ b/pyvrp/cpp/bindings.cpp
@@ -16,16 +16,24 @@
 
 namespace py = pybind11;
 
-using namespace pyvrp;
-using TWS = TimeWindowSegment;
+using pyvrp::CostEvaluator;
+using pyvrp::DynamicBitset;
+using pyvrp::Matrix;
+using pyvrp::PopulationParams;
+using pyvrp::ProblemData;
+using pyvrp::Solution;
+using pyvrp::SubPopulation;
+using pyvrp::XorShift128;
+using TWS = pyvrp::TimeWindowSegment;
 
-template <typename... Args> TWS merge(Matrix<Value> const &mat, Args... args)
+template <typename... Args>
+TWS merge(Matrix<pyvrp::Value> const &mat, Args... args)
 {
-    Matrix<Duration> durMat(mat.numRows(), mat.numCols());
+    Matrix<pyvrp::Duration> durMat(mat.numRows(), mat.numCols());
 
-    // Copy the Matrix<Value> over to Matrix<Duration>. That's not efficient,
-    // but since this class is internal to PyVRP that does not matter much. We
-    // only expose it to Python for testing.
+    // Copy the Matrix<pyvrp::Value> over to Matrix<Duration>. That's not
+    // efficient, but since this class is internal to PyVRP that does not matter
+    // much. We only expose it to Python for testing.
     for (size_t row = 0; row != durMat.numRows(); ++row)
         for (size_t col = 0; col != durMat.numCols(); ++col)
             durMat(row, col) = mat(row, col);
@@ -43,14 +51,16 @@ PYBIND11_MODULE(_pyvrp, m)
              py::arg("tw_penalty") = 0)
         .def(
             "load_penalty",
-            [](CostEvaluator const &evaluator, Value load, Value capacity) {
+            [](CostEvaluator const &evaluator,
+               pyvrp::Value load,
+               pyvrp::Value capacity) {
                 return evaluator.loadPenalty(load, capacity).get();
             },
             py::arg("load"),
             py::arg("capacity"))
         .def(
             "tw_penalty",
-            [](CostEvaluator const &evaluator, Value const timeWarp) {
+            [](CostEvaluator const &evaluator, pyvrp::Value const timeWarp) {
                 return evaluator.twPenalty(timeWarp).get();
             },
             py::arg("time_warp"))
@@ -88,37 +98,37 @@ PYBIND11_MODULE(_pyvrp, m)
         .def("__xor__", &DynamicBitset::operator^, py::arg("other"))
         .def("__invert__", &DynamicBitset::operator~);
 
-    py::class_<Matrix<Value>>(m, "Matrix")
+    py::class_<Matrix<pyvrp::Value>>(m, "Matrix")
         .def(py::init<size_t>(), py::arg("dimension"))
         .def(py::init<size_t, size_t>(), py::arg("n_rows"), py::arg("n_cols"))
-        .def(py::init<std::vector<std::vector<Value>>>(), py::arg("data"))
-        .def_property_readonly("num_cols", &Matrix<Value>::numCols)
-        .def_property_readonly("num_rows", &Matrix<Value>::numRows)
+        .def(py::init<std::vector<std::vector<pyvrp::Value>>>(),
+             py::arg("data"))
+        .def_property_readonly("num_cols", &Matrix<pyvrp::Value>::numCols)
+        .def_property_readonly("num_rows", &Matrix<pyvrp::Value>::numRows)
         .def(
             "__getitem__",
-            [](Matrix<Value> &m, std::pair<size_t, size_t> idx) -> Value {
-                return m(idx.first, idx.second);
-            },
+            [](Matrix<pyvrp::Value> &m, std::pair<size_t, size_t> idx)
+                -> pyvrp::Value { return m(idx.first, idx.second); },
             py::arg("idx"))
         .def(
             "__setitem__",
-            [](Matrix<Value> &m, std::pair<size_t, size_t> idx, Value value) {
-                m(idx.first, idx.second) = value;
-            },
+            [](Matrix<pyvrp::Value> &m,
+               std::pair<size_t, size_t> idx,
+               pyvrp::Value value) { m(idx.first, idx.second) = value; },
             py::arg("idx"),
             py::arg("value"))
-        .def("max", &Matrix<Value>::max)
-        .def("size", &Matrix<Value>::size);
+        .def("max", &Matrix<pyvrp::Value>::max)
+        .def("size", &Matrix<pyvrp::Value>::size);
 
     py::class_<ProblemData::Client>(m, "Client")
-        .def(py::init<Value,
-                      Value,
-                      Value,
-                      Value,
-                      Value,
-                      Value,
-                      Value,
-                      Value,
+        .def(py::init<pyvrp::Value,
+                      pyvrp::Value,
+                      pyvrp::Value,
+                      pyvrp::Value,
+                      pyvrp::Value,
+                      pyvrp::Value,
+                      pyvrp::Value,
+                      pyvrp::Value,
                       bool>(),
              py::arg("x"),
              py::arg("y"),
@@ -162,7 +172,7 @@ PYBIND11_MODULE(_pyvrp, m)
         .def_readonly("required", &ProblemData::Client::required);
 
     py::class_<ProblemData::VehicleType>(m, "VehicleType")
-        .def(py::init<Value, size_t>(),
+        .def(py::init<pyvrp::Value, size_t>(),
              py::arg("capacity"),
              py::arg("num_available"))
         .def_property_readonly("capacity",
@@ -175,10 +185,10 @@ PYBIND11_MODULE(_pyvrp, m)
         .def(py::init(
                  [](std::vector<ProblemData::Client> const &clients,
                     std::vector<ProblemData::VehicleType> const &vehicleTypes,
-                    std::vector<std::vector<Value>> const &dist,
-                    std::vector<std::vector<Value>> const &dur) {
-                     Matrix<Distance> distMat(clients.size());
-                     Matrix<Duration> durMat(clients.size());
+                    std::vector<std::vector<pyvrp::Value>> const &dist,
+                    std::vector<std::vector<pyvrp::Value>> const &dur) {
+                     Matrix<pyvrp::Distance> distMat(clients.size());
+                     Matrix<pyvrp::Duration> durMat(clients.size());
 
                      for (size_t row = 0; row != clients.size(); ++row)
                          for (size_t col = 0; col != clients.size(); ++col)
@@ -375,7 +385,8 @@ PYBIND11_MODULE(_pyvrp, m)
         .def("avg_distance_closest", &SubPopulation::Item::avgDistanceClosest);
 
     py::class_<SubPopulation>(m, "SubPopulation")
-        .def(py::init<diversity::DiversityMeasure, PopulationParams const &>(),
+        .def(py::init<pyvrp::diversity::DiversityMeasure,
+                      PopulationParams const &>(),
              py::arg("diversity_op"),
              py::arg("params"),
              py::keep_alive<1, 3>())  // keep params alive
@@ -407,7 +418,13 @@ PYBIND11_MODULE(_pyvrp, m)
              py::arg("cost_evaluator"));
 
     py::class_<TWS>(m, "TimeWindowSegment")
-        .def(py::init<int, int, Value, Value, Value, Value, Value>(),
+        .def(py::init<int,
+                      int,
+                      pyvrp::Value,
+                      pyvrp::Value,
+                      pyvrp::Value,
+                      pyvrp::Value,
+                      pyvrp::Value>(),
              py::arg("idx_first"),
              py::arg("idx_last"),
              py::arg("duration"),

--- a/pyvrp/cpp/crossover/crossover.cpp
+++ b/pyvrp/cpp/crossover/crossover.cpp
@@ -4,7 +4,9 @@
 #include <cmath>
 #include <limits>
 
-using namespace pyvrp;
+using pyvrp::Cost;
+using pyvrp::Duration;
+
 using Client = int;
 using Route = std::vector<Client>;
 using Routes = std::vector<Route>;
@@ -15,8 +17,8 @@ namespace
 Cost deltaCost(Client client,
                Client prev,
                Client next,
-               ProblemData const &data,
-               [[maybe_unused]] CostEvaluator const &costEvaluator)
+               pyvrp::ProblemData const &data,
+               [[maybe_unused]] pyvrp::CostEvaluator const &costEvaluator)
 {
     auto const currDist = data.dist(prev, next);
     auto const propDist = data.dist(prev, client) + data.dist(client, next);
@@ -59,10 +61,10 @@ Cost deltaCost(Client client,
 }
 }  // namespace
 
-void crossover::greedyRepair(Routes &routes,
-                             DynamicBitset const &unplanned,
-                             ProblemData const &data,
-                             CostEvaluator const &costEvaluator)
+void pyvrp::crossover::greedyRepair(Routes &routes,
+                                    pyvrp::DynamicBitset const &unplanned,
+                                    pyvrp::ProblemData const &data,
+                                    pyvrp::CostEvaluator const &costEvaluator)
 {
     auto const numRoutes = routes.size();
 

--- a/pyvrp/cpp/crossover/selective_route_exchange.cpp
+++ b/pyvrp/cpp/crossover/selective_route_exchange.cpp
@@ -4,16 +4,15 @@
 
 #include <cmath>
 
-using namespace pyvrp;
 using Client = int;
 using Clients = std::vector<Client>;
-using Route = Solution::Route;
+using Route = pyvrp::Solution::Route;
 using Routes = std::vector<Route>;
 
 namespace
 {
 // Angle of the given route w.r.t. the centroid of all client locations.
-double routeAngle(ProblemData const &data, Route const &route)
+double routeAngle(pyvrp::ProblemData const &data, Route const &route)
 {
     // This computes a pseudo-angle that sorts roughly equivalently to the atan2
     // angle, but is much faster to compute. See the following post for details:
@@ -25,7 +24,7 @@ double routeAngle(ProblemData const &data, Route const &route)
     return std::copysign(1. - dx / (std::fabs(dx) + std::fabs(dy)), dy);
 }
 
-Routes sortByAscAngle(ProblemData const &data, Routes routes)
+Routes sortByAscAngle(pyvrp::ProblemData const &data, Routes routes)
 {
     auto cmp = [&data](Route a, Route b) {
         return routeAngle(data, a) < routeAngle(data, b);
@@ -36,7 +35,7 @@ Routes sortByAscAngle(ProblemData const &data, Routes routes)
 }
 }  // namespace
 
-Solution crossover::selectiveRouteExchange(
+pyvrp::Solution pyvrp::crossover::selectiveRouteExchange(
     std::pair<Solution const *, Solution const *> const &parents,
     ProblemData const &data,
     CostEvaluator const &costEvaluator,

--- a/pyvrp/cpp/diversity/broken_pairs_distance.cpp
+++ b/pyvrp/cpp/diversity/broken_pairs_distance.cpp
@@ -1,9 +1,7 @@
 #include "diversity.h"
 
-using namespace pyvrp;
-
-double diversity::brokenPairsDistance(Solution const &first,
-                                      Solution const &second)
+double pyvrp::diversity::brokenPairsDistance(pyvrp::Solution const &first,
+                                             pyvrp::Solution const &second)
 {
     auto const &fNeighbours = first.getNeighbours();
     auto const &sNeighbours = second.getNeighbours();

--- a/pyvrp/cpp/search/LocalSearch.cpp
+++ b/pyvrp/cpp/search/LocalSearch.cpp
@@ -9,9 +9,9 @@
 #include <stdexcept>
 #include <vector>
 
-using namespace pyvrp;
-using namespace pyvrp::search;
-using TWS = TimeWindowSegment;
+using pyvrp::Solution;
+using pyvrp::search::LocalSearch;
+using TWS = pyvrp::TimeWindowSegment;
 
 Solution LocalSearch::search(Solution &solution,
                              CostEvaluator const &costEvaluator)

--- a/pyvrp/cpp/search/MoveTwoClientsReversed.cpp
+++ b/pyvrp/cpp/search/MoveTwoClientsReversed.cpp
@@ -4,7 +4,7 @@
 
 #include <cassert>
 
-using namespace pyvrp::search;
+using pyvrp::search::MoveTwoClientsReversed;
 using TWS = pyvrp::TimeWindowSegment;
 
 pyvrp::Cost MoveTwoClientsReversed::evaluate(

--- a/pyvrp/cpp/search/Node.cpp
+++ b/pyvrp/cpp/search/Node.cpp
@@ -1,6 +1,6 @@
 #include "Node.h"
 
-using namespace pyvrp::search;
+using pyvrp::search::Node;
 
 void Node::insertAfter(Node *other)
 {

--- a/pyvrp/cpp/search/RelocateStar.cpp
+++ b/pyvrp/cpp/search/RelocateStar.cpp
@@ -1,6 +1,7 @@
 #include "RelocateStar.h"
 
-using namespace pyvrp::search;
+using pyvrp::search::RelocateStar;
+using pyvrp::search::Route;
 
 pyvrp::Cost RelocateStar::evaluate(Route *U,
                                    Route *V,

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -6,9 +6,8 @@
 #include <cmath>
 #include <ostream>
 
-using namespace pyvrp;
-using namespace pyvrp::search;
-using TWS = TimeWindowSegment;
+using pyvrp::search::Route;
+using TWS = pyvrp::TimeWindowSegment;
 
 Route::Route(ProblemData const &data, size_t const idx, size_t const vehType)
     : data(data), vehicleType_(vehType), idx(idx)

--- a/pyvrp/cpp/search/SwapStar.cpp
+++ b/pyvrp/cpp/search/SwapStar.cpp
@@ -1,8 +1,9 @@
 #include "SwapStar.h"
 
-using namespace pyvrp;
-using namespace pyvrp::search;
-using TWS = TimeWindowSegment;
+using pyvrp::Cost;
+using pyvrp::search::Node;
+using pyvrp::search::SwapStar;
+using TWS = pyvrp::TimeWindowSegment;
 
 void SwapStar::updateRemovalCosts(Route *R1, CostEvaluator const &costEvaluator)
 {

--- a/pyvrp/cpp/search/TwoOpt.cpp
+++ b/pyvrp/cpp/search/TwoOpt.cpp
@@ -3,9 +3,9 @@
 #include "Route.h"
 #include "TimeWindowSegment.h"
 
-using namespace pyvrp;
-using namespace pyvrp::search;
-using TWS = TimeWindowSegment;
+using pyvrp::Cost;
+using pyvrp::search::TwoOpt;
+using TWS = pyvrp::TimeWindowSegment;
 
 Cost TwoOpt::evalWithinRoute(Node *U,
                              Node *V,

--- a/pyvrp/cpp/search/bindings.cpp
+++ b/pyvrp/cpp/search/bindings.cpp
@@ -10,58 +10,71 @@
 
 namespace py = pybind11;
 
-using namespace pyvrp::search;
+using pyvrp::search::Exchange;
+using pyvrp::search::LocalSearch;
+using pyvrp::search::LocalSearchOperator;
+using pyvrp::search::MoveTwoClientsReversed;
+using pyvrp::search::RelocateStar;
+using pyvrp::search::SwapStar;
+using pyvrp::search::TwoOpt;
 
 PYBIND11_MODULE(_search, m)
 {
-    py::class_<LocalSearchOperator<Node>>(m, "NodeOperator");
-    py::class_<LocalSearchOperator<Route>>(m, "RouteOperator");
+    using NodeOp = LocalSearchOperator<pyvrp::search::Node>;
+    using RouteOp = LocalSearchOperator<pyvrp::search::Route>;
 
-    py::class_<Exchange<1, 0>, LocalSearchOperator<Node>>(m, "Exchange10")
-        .def(py::init<pyvrp::ProblemData const &>(),
-             py::arg("data"),
-             py::keep_alive<1, 2>()  // keep data alive
-        );
-    py::class_<Exchange<2, 0>, LocalSearchOperator<Node>>(m, "Exchange20")
-        .def(py::init<pyvrp::ProblemData const &>(),
-             py::arg("data"),
-             py::keep_alive<1, 2>()  // keep data alive
-        );
-    py::class_<Exchange<3, 0>, LocalSearchOperator<Node>>(m, "Exchange30")
-        .def(py::init<pyvrp::ProblemData const &>(),
-             py::arg("data"),
-             py::keep_alive<1, 2>()  // keep data alive
-        );
-    py::class_<Exchange<1, 1>, LocalSearchOperator<Node>>(m, "Exchange11")
-        .def(py::init<pyvrp::ProblemData const &>(),
-             py::arg("data"),
-             py::keep_alive<1, 2>()  // keep data alive
-        );
-    py::class_<Exchange<2, 1>, LocalSearchOperator<Node>>(m, "Exchange21")
+    py::class_<NodeOp>(m, "NodeOperator");
+    py::class_<RouteOp>(m, "RouteOperator");
+
+    py::class_<Exchange<1, 0>, NodeOp>(m, "Exchange10")
         .def(py::init<pyvrp::ProblemData const &>(),
              py::arg("data"),
              py::keep_alive<1, 2>()  // keep data alive
         );
 
-    py::class_<Exchange<3, 1>, LocalSearchOperator<Node>>(m, "Exchange31")
+    py::class_<Exchange<2, 0>, NodeOp>(m, "Exchange20")
         .def(py::init<pyvrp::ProblemData const &>(),
              py::arg("data"),
              py::keep_alive<1, 2>()  // keep data alive
         );
 
-    py::class_<Exchange<2, 2>, LocalSearchOperator<Node>>(m, "Exchange22")
+    py::class_<Exchange<3, 0>, NodeOp>(m, "Exchange30")
         .def(py::init<pyvrp::ProblemData const &>(),
              py::arg("data"),
              py::keep_alive<1, 2>()  // keep data alive
         );
 
-    py::class_<Exchange<3, 2>, LocalSearchOperator<Node>>(m, "Exchange32")
+    py::class_<Exchange<1, 1>, NodeOp>(m, "Exchange11")
         .def(py::init<pyvrp::ProblemData const &>(),
              py::arg("data"),
              py::keep_alive<1, 2>()  // keep data alive
         );
 
-    py::class_<Exchange<3, 3>, LocalSearchOperator<Node>>(m, "Exchange33")
+    py::class_<Exchange<2, 1>, NodeOp>(m, "Exchange21")
+        .def(py::init<pyvrp::ProblemData const &>(),
+             py::arg("data"),
+             py::keep_alive<1, 2>()  // keep data alive
+        );
+
+    py::class_<Exchange<3, 1>, NodeOp>(m, "Exchange31")
+        .def(py::init<pyvrp::ProblemData const &>(),
+             py::arg("data"),
+             py::keep_alive<1, 2>()  // keep data alive
+        );
+
+    py::class_<Exchange<2, 2>, NodeOp>(m, "Exchange22")
+        .def(py::init<pyvrp::ProblemData const &>(),
+             py::arg("data"),
+             py::keep_alive<1, 2>()  // keep data alive
+        );
+
+    py::class_<Exchange<3, 2>, NodeOp>(m, "Exchange32")
+        .def(py::init<pyvrp::ProblemData const &>(),
+             py::arg("data"),
+             py::keep_alive<1, 2>()  // keep data alive
+        );
+
+    py::class_<Exchange<3, 3>, NodeOp>(m, "Exchange33")
         .def(py::init<pyvrp::ProblemData const &>(),
              py::arg("data"),
              py::keep_alive<1, 2>()  // keep data alive
@@ -98,26 +111,25 @@ PYBIND11_MODULE(_search, m)
              py::arg("overlap_tolerance_degrees") = 0)
         .def("shuffle", &LocalSearch::shuffle, py::arg("rng"));
 
-    py::class_<MoveTwoClientsReversed, LocalSearchOperator<Node>>(
-        m, "MoveTwoClientsReversed")
+    py::class_<MoveTwoClientsReversed, NodeOp>(m, "MoveTwoClientsReversed")
         .def(py::init<pyvrp::ProblemData const &>(),
              py::arg("data"),
              py::keep_alive<1, 2>()  // keep data alive
         );
 
-    py::class_<RelocateStar, LocalSearchOperator<Route>>(m, "RelocateStar")
+    py::class_<RelocateStar, RouteOp>(m, "RelocateStar")
         .def(py::init<pyvrp::ProblemData const &>(),
              py::arg("data"),
              py::keep_alive<1, 2>()  // keep data alive
         );
 
-    py::class_<SwapStar, LocalSearchOperator<Route>>(m, "SwapStar")
+    py::class_<SwapStar, RouteOp>(m, "SwapStar")
         .def(py::init<pyvrp::ProblemData const &>(),
              py::arg("data"),
              py::keep_alive<1, 2>()  // keep data alive
         );
 
-    py::class_<TwoOpt, LocalSearchOperator<Node>>(m, "TwoOpt")
+    py::class_<TwoOpt, NodeOp>(m, "TwoOpt")
         .def(py::init<pyvrp::ProblemData const &>(),
              py::arg("data"),
              py::keep_alive<1, 2>()  // keep data alive


### PR DESCRIPTION
Follow-up to #264: this PR removes all `using namespace` directives.