### PR TITLE
Get Python installation from poetry

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -63,8 +63,10 @@ libcommon = static_library(
     include_directories: INCLUDES,
 )
 
-# Next we get the extension dependencies.
-py = import('python').find_installation()
+# Next we get the extension dependencies. We should be precise about the Python
+# version we depend on: that's the one in the current environment.
+py_program = run_command('poetry', 'env', 'info', '--executable', check : true)
+py = import('python').find_installation(py_program.stdout().strip())
 dependencies = [py.dependency(), dependency('pybind11')]
 
 # Extension as [extension name, subdirectory]. The 'extension name' names the


### PR DESCRIPTION
We left implicit *which* Python to depend upon in the current build file. This PR fixes that and gets the correct Python installation directly from poetry. That way we're sure to build for the Python of the current poetry environment.

