### PR TITLE
Use Solution string representation in Result string representation

### DIFF
--- a/pyvrp/Result.py
+++ b/pyvrp/Result.py
@@ -94,7 +94,7 @@ class Result:
             "",
             "Routes",
             "------",
+            str(self.best),
         ]
-        summary.extend(str(self.best).splitlines())
 
         return "\n".join(summary)

--- a/pyvrp/Result.py
+++ b/pyvrp/Result.py
@@ -95,9 +95,6 @@ class Result:
             "Routes",
             "------",
         ]
-
-        for idx, route in enumerate(self.best.get_routes(), 1):
-            if route:
-                summary.append(f"Route {idx:>2}: {route}")
+        summary.extend(str(self.best).splitlines())
 
         return "\n".join(summary)


### PR DESCRIPTION
This PR uses `Solution`s string representation to print the routes in the summary/string representation of `Result`.