### PR TITLE
Bugfix: compute offsets for vehicle types correctly in LocalSeach

### DIFF
--- a/pyvrp/cpp/search/LocalSearch.cpp
+++ b/pyvrp/cpp/search/LocalSearch.cpp
@@ -319,8 +319,8 @@ void LocalSearch::loadSolution(Solution const &solution)
     std::vector<size_t> vehicleOffset(data.numVehicleTypes(), 0);
     for (size_t vehType = 1; vehType < data.numVehicleTypes(); vehType++)
     {
-        auto const available = data.vehicleType(vehType).numAvailable;
-        vehicleOffset[vehType] = vehicleOffset[vehType - 1] + available;
+        auto const prevAvail = data.vehicleType(vehType - 1).numAvailable;
+        vehicleOffset[vehType] = vehicleOffset[vehType - 1] + prevAvail;
     }
 
     // Load routes from solution.

--- a/pyvrp/search/tests/test_LocalSearch.py
+++ b/pyvrp/search/tests/test_LocalSearch.py
@@ -247,21 +247,25 @@ def test_route_vehicle_types_are_preserved_for_locally_optimal_solutions():
     assert_equal(further_improved, improved)
 
 
-def test_loading_vehicle_types():
-    # This tests a previous bug that would crash local search due to an
-    # an incorrect internal mapping of vehicle types to route indices if the
-    # last vehicle type had more vehicles than the previous
-
+def test_bugfix_vehicle_type_offsets():
+    """
+    See https://github.com/PyVRP/PyVRP/pull/292 for details. This exercises a
+    fix to a bug that would crash local search due to an incorrect internal 
+    mapping of vehicle types to route indices if the next vehicle type had
+    more vehicles than the previous.
+    """
     data = read("data/OkSmall.txt")
-    cost_evaluator = CostEvaluator(1, 1)
     data = make_heterogeneous(data, [VehicleType(10, 1), VehicleType(10, 2)])
 
-    neighbours = compute_neighbours(data)
-    ls = cpp_LocalSearch(data, neighbours)
+    ls = cpp_LocalSearch(data, compute_neighbours(data))
     ls.add_node_operator(Exchange10(data))
-    sol = Solution(data, [Route(data, [1, 3], 1), Route(data, [2, 4], 1)])
-    current_cost = cost_evaluator.penalised_cost(sol)
 
-    # The local search should not crash and the result should not be worse
-    improved_sol = ls.search(sol, cost_evaluator)
-    assert_(cost_evaluator.penalised_cost(improved_sol) <= current_cost)
+    cost_evaluator = CostEvaluator(1, 1)
+
+    current = Solution(data, [Route(data, [1, 3], 1), Route(data, [2, 4], 1)])
+    current_cost = cost_evaluator.penalised_cost(current)
+
+    improved = ls.search(current, cost_evaluator)
+    improved_cost = cost_evaluator.penalised_cost(improved)
+
+    assert_(improved_cost <= current_cost)

--- a/pyvrp/search/tests/test_LocalSearch.py
+++ b/pyvrp/search/tests/test_LocalSearch.py
@@ -250,7 +250,7 @@ def test_route_vehicle_types_are_preserved_for_locally_optimal_solutions():
 def test_bugfix_vehicle_type_offsets():
     """
     See https://github.com/PyVRP/PyVRP/pull/292 for details. This exercises a
-    fix to a bug that would crash local search due to an incorrect internal 
+    fix to a bug that would crash local search due to an incorrect internal
     mapping of vehicle types to route indices if the next vehicle type had
     more vehicles than the previous.
     """


### PR DESCRIPTION
This PR:

Fixes a bug whiched computed offsets for vehicle types incorrectly in the local search. This is only a problem for heteregeneous problem instances.

- [x] Adds and passes relevant tests.
- [x] Has well-formatted code and documentation.