### PR TITLE
Rename doc prefix to PYVRP_doc_

### DIFF
--- a/extract_docstrings.py
+++ b/extract_docstrings.py
@@ -14,15 +14,15 @@ _PREFIX = """
 #define __VA_SIZE(...) __EXPAND(__COUNT(__VA_ARGS__, 7, 6, 5, 4, 3, 2, 1, 0))
 #define __CAT1(a, b) a ## b
 #define __CAT2(a, b) __CAT1(a, b)
-#define __DOC1(n1) __doc_##n1
-#define __DOC2(n1, n2) __doc_##n1##_##n2
-#define __DOC3(n1, n2, n3) __doc_##n1##_##n2##_##n3
-#define __DOC4(n1, n2, n3, n4) __doc_##n1##_##n2##_##n3##_##n4
-#define __DOC5(n1, n2, n3, n4, n5) __doc_##n1##_##n2##_##n3##_##n4##_##n5
+#define __DOC1(n1) PYVRP_doc_##n1
+#define __DOC2(n1, n2) PYVRP_doc_##n1##_##n2
+#define __DOC3(n1, n2, n3) PYVRP_doc_##n1##_##n2##_##n3
+#define __DOC4(n1, n2, n3, n4) PYVRP_doc_##n1##_##n2##_##n3##_##n4
+#define __DOC5(n1, n2, n3, n4, n5) PYVRP_doc_##n1##_##n2##_##n3##_##n4##_##n5
 #define __DOC6(n1, n2, n3, n4, n5, n6) \
-    __doc_##n1##_##n2##_##n3##_##n4##_##n5##_##n6
+    PYVRP_doc_##n1##_##n2##_##n3##_##n4##_##n5##_##n6
 #define __DOC7(n1, n2, n3, n4, n5, n6, n7) \
-    __doc_##n1##_##n2##_##n3##_##n4##_##n5##_##n6##_##n7
+    PYVRP_doc_##n1##_##n2##_##n3##_##n4##_##n5##_##n6##_##n7
 #define DOC(...) \
     __EXPAND(__EXPAND(__CAT2(__DOC, __VA_SIZE(__VA_ARGS__)))(__VA_ARGS__))
 
@@ -72,7 +72,7 @@ def to_cpp_stmt(name: str, docstrings: List[str]) -> str:
     # a C++ operator overload is not a valid variable name.
     parts = name.split("::")
     parts[-1] = _OP2DUNDER.get(parts[-1], parts[-1])
-    var_name = "__doc_" + "_".join(parts)
+    var_name = "PYVRP_doc_" + "_".join(parts)
 
     # Structure of the C++ statement we are going to write.
     cpp_stmt = 'static char const *{var_name} = R"doc(\n{doc}\n)doc";'


### PR DESCRIPTION
We already reserve any symbols starting with the `PYVRP_` prefix for internal use, so this is consistent with that.

Additionally, and more importantly, any identifiers in the global namespace that begin with a double underscore (like our current use of `__doc_`) is ill-formed: https://en.cppreference.com/w/cpp/language/identifiers#In_declarations.  