### PR TITLE
Bump sphinx-immaterial to v0.11.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ optional = true
 nbsphinx = ">=0.8.9"
 ipython = ">=8.6.0"
 numpydoc = ">=1.5.0"
-sphinx-immaterial = ">=0.11.5"
+sphinx-immaterial = ">=0.11.6"
 
 
 [tool.poetry.group.examples]


### PR DESCRIPTION
Fixes an indentation issue with the pseudocode; see #273 for details. Was already fixed upstream but hadn't been released to PyPI yet.
 