### PR TITLE
Allow empty local search neighbourhoods

### DIFF
--- a/pyvrp/Model.py
+++ b/pyvrp/Model.py
@@ -216,13 +216,17 @@ class Model:
         locs = self.locations
         loc2idx = {id(loc): idx for idx, loc in enumerate(locs)}
 
-        max_data_value = max(max(e.distance, e.duration) for e in self._edges)
-        if max_data_value > MAX_USER_VALUE:
-            msg = """
-            The maximum distance or duration value is very large. This might
-            impact numerical stability. Consider rescaling your input data.
-            """
-            warn(msg, ScalingWarning)
+        if self._edges:
+            max_data_value = max(
+                max(e.distance, e.duration) for e in self._edges
+            )
+            if max_data_value > MAX_USER_VALUE:
+                msg = """
+                The maximum distance or duration value is very large. This
+                might impact numerical stability. Consider rescaling your input
+                data.
+                """
+                warn(msg, ScalingWarning)
 
         # Default value is a sufficiently large value to make sure any edges
         # not set below are never traversed.

--- a/pyvrp/Model.py
+++ b/pyvrp/Model.py
@@ -217,9 +217,9 @@ class Model:
         loc2idx = {id(loc): idx for idx, loc in enumerate(locs)}
 
         if self._edges:
-            max_val = max(max(e.distance, e.duration) for e in self._edges)
+            max_value = max(max(e.distance, e.duration) for e in self._edges)
 
-            if max_val > MAX_USER_VALUE:
+            if max_value > MAX_USER_VALUE:
                 msg = """
                 The maximum distance or duration value is very large. This may
                 impact numerical stability. Consider rescaling your input data.

--- a/pyvrp/Model.py
+++ b/pyvrp/Model.py
@@ -217,14 +217,12 @@ class Model:
         loc2idx = {id(loc): idx for idx, loc in enumerate(locs)}
 
         if self._edges:
-            max_data_value = max(
-                max(e.distance, e.duration) for e in self._edges
-            )
-            if max_data_value > MAX_USER_VALUE:
+            max_val = max(max(e.distance, e.duration) for e in self._edges)
+
+            if max_val > MAX_USER_VALUE:
                 msg = """
-                The maximum distance or duration value is very large. This
-                might impact numerical stability. Consider rescaling your input
-                data.
+                The maximum distance or duration value is very large. This may
+                impact numerical stability. Consider rescaling your input data.
                 """
                 warn(msg, ScalingWarning)
 

--- a/pyvrp/Population.py
+++ b/pyvrp/Population.py
@@ -120,7 +120,7 @@ class Population:
         # may trigger a purge which needs to compute the biased fitness which
         # requires computing the cost.
         if solution.is_feasible():
-            # Note: the feasible subpopulation actually doet not depend
+            # Note: the feasible subpopulation actually does not depend
             # on the penalty values but we use the same implementation.
             self._feas.add(solution, cost_evaluator)
         else:

--- a/pyvrp/cpp/search/LocalSearch.cpp
+++ b/pyvrp/cpp/search/LocalSearch.cpp
@@ -404,10 +404,6 @@ void LocalSearch::setNeighbours(Neighbours neighbours)
         }
     }
 
-    auto isEmpty = [](auto const &neighbours) { return neighbours.empty(); };
-    if (std::all_of(neighbours.begin(), neighbours.end(), isEmpty))
-        throw std::runtime_error("Neighbourhood is empty.");
-
     this->neighbours = neighbours;
 }
 

--- a/pyvrp/search/tests/test_LocalSearch.py
+++ b/pyvrp/search/tests/test_LocalSearch.py
@@ -41,7 +41,7 @@ def test_local_search_return_same_solution_when_neighbourhood_is_empty():
     ls = LocalSearch(data, rng, [[] for _ in range(data.num_clients + 1)])
     sol = Solution.make_random(data, rng)
 
-    # No operators have been added, so these calls should be no-ops.
+    # The neighbourhood is empty, so these calls should be no-ops.
     assert_equal(ls.search(sol, cost_evaluator), sol)
     assert_equal(ls.intensify(sol, cost_evaluator), sol)
 

--- a/pyvrp/search/tests/test_LocalSearch.py
+++ b/pyvrp/search/tests/test_LocalSearch.py
@@ -33,17 +33,20 @@ def test_local_search_returns_same_solution_when_there_are_no_operators():
     assert_equal(ls.intensify(sol, cost_evaluator), sol)
 
 
-def test_local_search_return_same_solution_when_neighbourhood_is_empty():
+def test_local_search_returns_same_solution_with_empty_neighbourhood():
     data = read("data/OkSmall.txt")
     cost_evaluator = CostEvaluator(20, 6)
     rng = RandomNumberGenerator(seed=42)
 
     ls = LocalSearch(data, rng, [[] for _ in range(data.num_clients + 1)])
-    sol = Solution.make_random(data, rng)
+    ls.add_node_operator(Exchange10(data))
+    ls.add_node_operator(Exchange11(data))
 
-    # The neighbourhood is empty, so these calls should be no-ops.
+    # The search is completed after one iteration due to the empty
+    # neighbourhood. This also prevents moves involving empty routes,
+    # which are not explicitly forbidden by the empty neighbourhood.
+    sol = Solution.make_random(data, rng)
     assert_equal(ls.search(sol, cost_evaluator), sol)
-    assert_equal(ls.intensify(sol, cost_evaluator), sol)
 
 
 @mark.parametrize("size", [1, 2, 3, 4, 6, 7])  # num_clients + 1 == 5

--- a/pyvrp/search/tests/test_LocalSearch.py
+++ b/pyvrp/search/tests/test_LocalSearch.py
@@ -33,23 +33,6 @@ def test_local_search_returns_same_solution_when_there_are_no_operators():
     assert_equal(ls.intensify(sol, cost_evaluator), sol)
 
 
-def test_local_search_raises_when_neighbourhood_structure_is_empty():
-    data = read("data/OkSmall.txt")
-    rng = RandomNumberGenerator(seed=42)
-
-    # Is completely empty neighbourhood, so there's nothing to do for the
-    # local search in this case.
-    neighbours = [[] for _ in range(data.num_clients + 1)]
-
-    with assert_raises(RuntimeError):
-        LocalSearch(data, rng, neighbours)
-
-    ls = LocalSearch(data, rng, compute_neighbours(data))
-
-    with assert_raises(RuntimeError):
-        ls.set_neighbours(neighbours)
-
-
 @mark.parametrize("size", [1, 2, 3, 4, 6, 7])  # num_clients + 1 == 5
 def test_local_search_raises_when_neighbourhood_dimensions_do_not_match(size):
     data = read("data/OkSmall.txt")

--- a/pyvrp/search/tests/test_LocalSearch.py
+++ b/pyvrp/search/tests/test_LocalSearch.py
@@ -33,6 +33,19 @@ def test_local_search_returns_same_solution_when_there_are_no_operators():
     assert_equal(ls.intensify(sol, cost_evaluator), sol)
 
 
+def test_local_search_return_same_solution_when_neighbourhood_is_empty():
+    data = read("data/OkSmall.txt")
+    cost_evaluator = CostEvaluator(20, 6)
+    rng = RandomNumberGenerator(seed=42)
+
+    ls = LocalSearch(data, rng, [[] for _ in range(data.num_clients + 1)])
+    sol = Solution.make_random(data, rng)
+
+    # No operators have been added, so these calls should be no-ops.
+    assert_equal(ls.search(sol, cost_evaluator), sol)
+    assert_equal(ls.intensify(sol, cost_evaluator), sol)
+
+
 @mark.parametrize("size", [1, 2, 3, 4, 6, 7])  # num_clients + 1 == 5
 def test_local_search_raises_when_neighbourhood_dimensions_do_not_match(size):
     data = read("data/OkSmall.txt")

--- a/pyvrp/tests/test_Model.py
+++ b/pyvrp/tests/test_Model.py
@@ -270,7 +270,8 @@ def test_model_solves_empty_instance():
 
     # Solve an instance with no clients.
     res = m.solve(stop=MaxIterations(1))
-    assert_equal(res.best.get_routes(), [])
+    solution = [r.visits() for r in res.best.get_routes()]
+    assert_equal(solution, [])
 
     # Solve an instance with one client.
     clients = [m.add_client(x=0, y=0, demand=0)]
@@ -278,4 +279,5 @@ def test_model_solves_empty_instance():
     m.add_edge(clients[0], depot, distance=0)
 
     res = m.solve(stop=MaxIterations(1))
-    assert_equal(res.best.get_routes(), [[1]])
+    solution = [r.visits() for r in res.best.get_routes()]
+    assert_equal(solution, [[1]])

--- a/pyvrp/tests/test_Model.py
+++ b/pyvrp/tests/test_Model.py
@@ -259,6 +259,7 @@ def test_data_warns_about_scaling_issues(recwarn):
         model.data()
 
 
+@mark.filterwarnings("ignore::pyvrp.exceptions.EmptySolutionWarning")
 def test_model_solves_instance_with_zero_or_one_clients():
     """
     This test exercises the bug identified in issue #272, where the model

--- a/pyvrp/tests/test_Model.py
+++ b/pyvrp/tests/test_Model.py
@@ -3,7 +3,7 @@ from pytest import mark
 
 from pyvrp import Model
 from pyvrp.constants import MAX_USER_VALUE, MAX_VALUE
-from pyvrp.exceptions import ScalingWarning
+from pyvrp.exceptions import EmptySolutionWarning, ScalingWarning
 from pyvrp.stop import MaxIterations
 from pyvrp.tests.helpers import read
 
@@ -259,7 +259,6 @@ def test_data_warns_about_scaling_issues(recwarn):
         model.data()
 
 
-@mark.filterwarnings("ignore::pyvrp.exceptions.EmptySolutionWarning")
 def test_model_solves_instance_with_zero_or_one_clients():
     """
     This test exercises the bug identified in issue #272, where the model
@@ -270,7 +269,9 @@ def test_model_solves_instance_with_zero_or_one_clients():
     depot = m.add_depot(x=0, y=0)
 
     # Solve an instance with no clients.
-    res = m.solve(stop=MaxIterations(1))
+    with assert_warns(EmptySolutionWarning):
+        res = m.solve(stop=MaxIterations(1))
+
     solution = [r.visits() for r in res.best.get_routes()]
     assert_equal(solution, [])
 

--- a/pyvrp/tests/test_Model.py
+++ b/pyvrp/tests/test_Model.py
@@ -257,3 +257,25 @@ def test_data_warns_about_scaling_issues(recwarn):
     model.add_edge(depot, client, distance=MAX_USER_VALUE + 1)
     with assert_warns(ScalingWarning):
         model.data()
+
+
+def test_model_solves_empty_instance():
+    """
+    This test exercises the bug identified in issue #272, where the model
+    could not solve an instance with no clients or just one client.
+    """
+    m = Model()
+    m.add_vehicle_type(capacity=15, num_available=1)
+    depot = m.add_depot(x=0, y=0)
+
+    # Solve an instance with no clients.
+    res = m.solve(stop=MaxIterations(1))
+    assert_equal(res.best.get_routes(), [])
+
+    # Solve an instance with one client.
+    clients = [m.add_client(x=0, y=0, demand=0)]
+    m.add_edge(depot, clients[0], distance=0)
+    m.add_edge(clients[0], depot, distance=0)
+
+    res = m.solve(stop=MaxIterations(1))
+    assert_equal(res.best.get_routes(), [[1]])

--- a/pyvrp/tests/test_Model.py
+++ b/pyvrp/tests/test_Model.py
@@ -259,10 +259,10 @@ def test_data_warns_about_scaling_issues(recwarn):
         model.data()
 
 
-def test_model_solves_empty_instance():
+def test_model_solves_instance_with_zero_or_one_clients():
     """
     This test exercises the bug identified in issue #272, where the model
-    could not solve an instance with no clients or just one client.
+    could not solve an instance with zero clients or just one client.
     """
     m = Model()
     m.add_vehicle_type(capacity=15, num_available=1)


### PR DESCRIPTION
This PR:

- [x] Closes #272. By allowing empty local search neighbourhoods, the runtime error is no longer emitted and instances with zero or one client can be solved.
- [x] Adds and passes relevant tests.
- [x] Has well-formatted code and documentation.

<details>

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
