### PR TITLE
Make Route::Node prev/next attributes private, anticipating removal

### DIFF
--- a/pyvrp/cpp/search/LocalSearch.cpp
+++ b/pyvrp/cpp/search/LocalSearch.cpp
@@ -290,8 +290,8 @@ void LocalSearch::maybeRemove(Route::Node *U,
 
     if (deltaCost < 0)
     {
-        auto *route = U->route;  // after U->remove(), U->route is a nullptr
-        U->remove();
+        auto *route = U->route;  // after remove(), U->route is a nullptr
+        route->remove(U->position);
         update(route, route);
     }
 }

--- a/pyvrp/cpp/search/LocalSearch.cpp
+++ b/pyvrp/cpp/search/LocalSearch.cpp
@@ -322,26 +322,9 @@ void LocalSearch::loadSolution(Solution const &solution)
         clients[client].route = nullptr;  // nullptr implies "not in solution"
     }
 
-    // First empty all routes
+    // First empty all routes.
     for (auto &route : routes)
-    {
-        auto const &vehicleType = data.vehicleType(route.vehicleType());
-
-        auto *startDepot = &route.startDepot;
-        auto *endDepot = &route.endDepot;
-
-        startDepot->prev = endDepot;
-        startDepot->next = endDepot;
-
-        endDepot->prev = startDepot;
-        endDepot->next = startDepot;
-
-        startDepot->tw = clients[vehicleType.depot].tw;
-        startDepot->twBefore = clients[vehicleType.depot].tw;
-
-        endDepot->tw = clients[vehicleType.depot].tw;
-        endDepot->twAfter = clients[vehicleType.depot].tw;
-    }
+        route.clear();
 
     // Determine offsets for vehicle types.
     std::vector<size_t> vehicleOffset(data.numVehicleTypes(), 0);
@@ -358,27 +341,12 @@ void LocalSearch::loadSolution(Solution const &solution)
         // on solution to be valid to not exceed the number of vehicles per
         // vehicle type.
         auto const r = vehicleOffset[solRoute.vehicleType()]++;
-        Route *route = &routes[r];
+        Route &route = routes[r];
 
-        auto *client = &clients[solRoute[0]];
-        client->route = route;
+        assert(route.empty());  // should have been emptied above.
 
-        client->prev = &route->startDepot;
-        route->startDepot.next = client;
-
-        for (size_t idx = 1; idx < solRoute.size(); idx++)
-        {
-            auto *prev = client;
-
-            client = &clients[solRoute[idx]];
-            client->route = route;
-
-            client->prev = prev;
-            prev->next = client;
-        }
-
-        client->next = &route->endDepot;
-        route->endDepot.prev = client;
+        for (auto const client : solRoute)
+            route.push_back(&clients[client]);
     }
 
     for (auto &route : routes)

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -68,7 +68,10 @@ Route::Route(ProblemData const &data, size_t const idx, size_t const vehType)
       endDepot(data.vehicleType(vehType).depot)
 {
     startDepot.route = this;
+    startDepot.tw = TWS(startDepot.client, data.client(startDepot.client));
+
     endDepot.route = this;
+    endDepot.tw = TWS(endDepot.client, data.client(endDepot.client));
 }
 
 size_t Route::vehicleType() const { return vehicleType_; }
@@ -90,9 +93,28 @@ bool Route::overlapsWith(Route const &other, double tolerance) const
     return absDiff <= tolerance * tau || absDiff >= (1 - tolerance) * tau;
 }
 
-void Route::update()
+void Route::clear()
 {
     nodes.clear();
+
+    startDepot.prev = &endDepot;
+    startDepot.next = &endDepot;
+    startDepot.twBefore = startDepot.tw;
+
+    endDepot.prev = &startDepot;
+    endDepot.next = &startDepot;
+    endDepot.twAfter = endDepot.tw;
+}
+
+void Route::push_back(Node *node)
+{
+    node->insertAfter(empty() ? &startDepot : nodes.back());
+    nodes.push_back(node);
+}
+
+void Route::update()
+{
+    clear();
     auto *node = n(&startDepot);
 
     Load load = 0;

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -50,16 +50,6 @@ void Route::Node::swapWith(Route::Node *other)
     other->route = routeU;
 }
 
-void Route::Node::remove()
-{
-    prev->next = next;
-    next->prev = prev;
-
-    prev = nullptr;
-    next = nullptr;
-    route = nullptr;
-}
-
 Route::Route(ProblemData const &data, size_t const idx, size_t const vehType)
     : data(data),
       vehicleType_(vehType),
@@ -110,6 +100,21 @@ void Route::push_back(Node *node)
 {
     node->insertAfter(empty() ? &startDepot : nodes.back());
     nodes.push_back(node);
+}
+
+void Route::remove(size_t position)
+{
+    assert(position > 0);
+    auto *node = nodes[position - 1];
+
+    node->prev->next = node->next;
+    node->next->prev = node->prev;
+
+    node->prev = nullptr;
+    node->next = nullptr;
+    node->route = nullptr;
+
+    nodes.erase(nodes.begin() + position - 1);
 }
 
 void Route::update()

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -114,7 +114,7 @@ void Route::push_back(Node *node)
 
 void Route::update()
 {
-    clear();
+    nodes.clear();
     auto *node = n(&startDepot);
 
     Load load = 0;

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -149,6 +149,17 @@ public:                // TODO make fields private
     [[nodiscard]] bool overlapsWith(Route const &other, double tolerance) const;
 
     /**
+     * Clears all clients on this route. After calling this method, ``empty()``
+     * returns true and ``size()`` is zero.
+     */
+    void clear();
+
+    /**
+     * TODO
+     */
+    void push_back(Node *node);
+
+    /**
      * Updates this route. To be called after swapping nodes/changing the
      * solution.
      */

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -42,11 +42,6 @@ public:
          * Swaps this node with the other and updates the relevant links.
          */
         void swapWith(Node *other);
-
-        /**
-         * Removes this node and updates the relevant links.
-         */
-        void remove();
     };
 
 private:
@@ -158,6 +153,11 @@ public:                // TODO make fields private
      * TODO
      */
     void push_back(Node *node);
+
+    /**
+     * TODO
+     */
+    void remove(size_t position);
 
     /**
      * Updates this route. To be called after swapping nodes/changing the

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -12,14 +12,22 @@ namespace pyvrp::search
 class Route
 {
 public:
-    struct Node
+    class Node
     {
+        // TODO obsolete this
+        friend Node *p(Node *node);
+        friend Node *n(Node *node);
+        friend class Route;
+
+        // TODO remove these fields
+        Node *prev = nullptr;  // Predecessor in route
+        Node *next = nullptr;  // Successor in route
+
+    public:  // TODO make fields private
         // TODO rename client to location/loc
         size_t client;           // Location represented by this node
         size_t position = 0;     // Position in the route
         Route *route = nullptr;  // Indicates membership of a route, if any.
-        Node *prev = nullptr;    // Predecessor in route
-        Node *next = nullptr;    // Successor in route
 
         // TODO can these data fields be moved to Route?
         Load cumulatedLoad = 0;          // Load depot -> client (incl)
@@ -150,12 +158,12 @@ public:                // TODO make fields private
     void clear();
 
     /**
-     * TODO
+     * Inserts the given node at the back of the route.
      */
     void push_back(Node *node);
 
     /**
-     * TODO
+     * Removes the node at ``position`` from the route.
      */
     void remove(size_t position);
 


### PR DESCRIPTION
See also #314. I'm working towards removing the prev/next linked list representation of the nodes. In this PR I've removed public access to these fields - they're now only accessible from the `Route` class and the `p()`/`n()` convenience methods. A follow-up PR will remove the fields completely, but first I need to work on a representation that includes the start and end depots in the `Route` `nodes` vector and other data vectors explicitly.

This PR:

- [x] Is part of #96.
- [ ] Adds and passes relevant tests.
- [x] Has well-formatted code and documentation.

<details>

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
