### PR TITLE
BugFix: `Solution::operator==` for unassigned clients

### DIFF
--- a/pyvrp/cpp/Solution.cpp
+++ b/pyvrp/cpp/Solution.cpp
@@ -108,7 +108,7 @@ bool Solution::operator==(Solution const &other) const
 }
 
 Solution::Solution(ProblemData const &data, RandomNumberGenerator &rng)
-    : neighbours(data.numClients() + 1, {0, 0})
+    : neighbours(data.numClients() + 1, {-1, -1})
 {
     // Shuffle clients (to create random routes)
     auto clients = std::vector<int>(data.numClients());
@@ -153,7 +153,7 @@ Solution::Solution(ProblemData const &data,
 }
 
 Solution::Solution(ProblemData const &data, std::vector<Route> const &routes)
-    : routes_(routes), neighbours(data.numClients() + 1, {0, 0})
+    : routes_(routes), neighbours(data.numClients() + 1, {-1, -1})
 {
     if (routes.size() > data.numVehicles())
     {

--- a/pyvrp/cpp/Solution.h
+++ b/pyvrp/cpp/Solution.h
@@ -204,7 +204,7 @@ private:
     Routes routes_;
     std::vector<std::pair<Client, Client>> neighbours;  // pairs of [pred, succ]
 
-    // Determines the [pred, succ] pairs for each client.
+    // Determines the [pred, succ] pairs for each client (-1 if unassigned).
     void makeNeighbours();
 
     // Evaluates this solution's characteristics.

--- a/pyvrp/tests/test_Solution.py
+++ b/pyvrp/tests/test_Solution.py
@@ -157,15 +157,15 @@ def test_route_constructor_allows_incomplete_solutions():
 def test_get_neighbours():
     data = read("data/OkSmall.txt")
 
-    sol = Solution(data, [[3, 4], [1, 2]])
+    sol = Solution(data, [[3], [1, 2]])
     neighbours = sol.get_neighbours()
 
     expected = [
-        (0, 0),  # 0: is depot
+        (-1, -1),  # 0: is depot
         (0, 2),  # 1: between depot (0) to 2
         (1, 0),  # 2: between 1 and depot (0)
-        (0, 4),  # 3: between depot (0) and 4
-        (3, 0),  # 4: between 3 and depot (0)
+        (0, 0),  # 3: between depot (0) and depot (0)
+        (-1, -1),  # 4: unassigned
     ]
 
     assert_equal(data.num_clients, 4)
@@ -611,6 +611,28 @@ def test_eq_heterogeneous_vehicle():
 
     # But changing the vehicle types should be different
     sol3 = Solution(data, [Route(data, [1, 2], 1), Route(data, [3, 4], 0)])
+    assert_(sol1 != sol3)
+
+
+def test_eq_unassigned():
+    """
+    Tests the equality operator for solutions with unassigned clients.
+    """
+    clients = [
+        Client(x=0, y=0),
+        Client(x=0, y=1, required=False),
+        Client(x=1, y=0, required=False),
+    ]
+    vehicle_types = [VehicleType(1, 2)]
+    dist = [[0, 1, 1], [1, 0, 1], [1, 1, 0]]
+
+    data = ProblemData(clients, vehicle_types, dist, dist)
+
+    sol1 = Solution(data, [[1]])
+    sol2 = Solution(data, [[1]])
+    sol3 = Solution(data, [[2]])
+
+    assert_(sol1 == sol2)
     assert_(sol1 != sol3)
 
 


### PR DESCRIPTION
- Add test case for `Solution::operator==` for two different solutions with unassigned clients that fails in main since these solutions are considered equal in current main as it doesn't take into account whether clients are assigned or not
- Use `-1` in `Solution::neighbours` for unassigned clients, this distinguishes unassigned clients from clients adjacent to the depot (this will also affect the
- This also affects `pyvrp::diversity::brokenPairsDistance` which will now consider these as different

This PR:

- [x] Fixes #315.
- [x] Adds and passes relevant tests.
- [x] Has well-formatted code and documentation.