### PR TITLE
Move route modification to Route

### DIFF
--- a/pyvrp/cpp/search/Exchange.h
+++ b/pyvrp/cpp/search/Exchange.h
@@ -315,14 +315,15 @@ Cost Exchange<N, M>::evaluate(Route::Node *U,
 template <size_t N, size_t M>
 void Exchange<N, M>::apply(Route::Node *U, Route::Node *V) const
 {
+    auto &vRoute = *V->route;
     auto *uToInsert = N == 1 ? U : (*U->route)[U->position + N - 1];
-    auto *insertUAfter = M == 0 ? V : (*V->route)[V->position + M - 1];
+    auto *insertUAfter = M == 0 ? V : vRoute[V->position + M - 1];
 
     // Insert these 'extra' nodes of U after the end of V...
     for (size_t count = 0; count != N - M; ++count)
     {
         auto *prev = p(uToInsert);
-        uToInsert->insertAfter(insertUAfter);
+        vRoute.insert(insertUAfter->position + 1, uToInsert);
         uToInsert = prev;
     }
 

--- a/pyvrp/cpp/search/Exchange.h
+++ b/pyvrp/cpp/search/Exchange.h
@@ -315,14 +315,16 @@ Cost Exchange<N, M>::evaluate(Route::Node *U,
 template <size_t N, size_t M>
 void Exchange<N, M>::apply(Route::Node *U, Route::Node *V) const
 {
+    auto &uRoute = *U->route;
     auto &vRoute = *V->route;
-    auto *uToInsert = N == 1 ? U : (*U->route)[U->position + N - 1];
+    auto *uToInsert = N == 1 ? U : uRoute[U->position + N - 1];
     auto *insertUAfter = M == 0 ? V : vRoute[V->position + M - 1];
 
     // Insert these 'extra' nodes of U after the end of V...
     for (size_t count = 0; count != N - M; ++count)
     {
         auto *prev = p(uToInsert);
+        uRoute.remove(uToInsert->position);
         vRoute.insert(insertUAfter->position + 1, uToInsert);
         uToInsert = prev;
     }

--- a/pyvrp/cpp/search/Exchange.h
+++ b/pyvrp/cpp/search/Exchange.h
@@ -329,7 +329,7 @@ void Exchange<N, M>::apply(Route::Node *U, Route::Node *V) const
     // ...and swap the overlapping nodes!
     for (size_t count = 0; count != M; ++count)
     {
-        U->swapWith(V);
+        Route::swap(U, V);
         U = n(U);
         V = n(V);
     }

--- a/pyvrp/cpp/search/LocalSearch.cpp
+++ b/pyvrp/cpp/search/LocalSearch.cpp
@@ -260,8 +260,8 @@ void LocalSearch::maybeInsert(Route::Node *U,
 
     if (deltaCost < 0)
     {
-        U->insertAfter(V);           // U has no route, so there's nothing to
-        update(V->route, V->route);  // update there.
+        V->route->insert(V->position + 1, U);
+        update(V->route, V->route);
     }
 }
 

--- a/pyvrp/cpp/search/LocalSearch.cpp
+++ b/pyvrp/cpp/search/LocalSearch.cpp
@@ -318,6 +318,7 @@ void LocalSearch::loadSolution(Solution const &solution)
 
     for (size_t client = 0; client <= data.numClients(); client++)
     {
+        clients[client].client = client;
         clients[client].tw = {client, data.client(client)};
         clients[client].route = nullptr;  // nullptr implies "not in solution"
     }

--- a/pyvrp/cpp/search/MoveTwoClientsReversed.cpp
+++ b/pyvrp/cpp/search/MoveTwoClientsReversed.cpp
@@ -98,7 +98,6 @@ pyvrp::Cost MoveTwoClientsReversed::evaluate(
 void MoveTwoClientsReversed::apply(Route::Node *U, Route::Node *V) const
 {
     auto *X = n(U);  // copy since the insert below changes n(U)
-
-    U->insertAfter(V);
-    X->insertAfter(V);
+    V->route->insert(V->position + 1, U);
+    V->route->insert(V->position + 1, X);
 }

--- a/pyvrp/cpp/search/MoveTwoClientsReversed.cpp
+++ b/pyvrp/cpp/search/MoveTwoClientsReversed.cpp
@@ -98,6 +98,10 @@ pyvrp::Cost MoveTwoClientsReversed::evaluate(
 void MoveTwoClientsReversed::apply(Route::Node *U, Route::Node *V) const
 {
     auto *X = n(U);  // copy since the insert below changes n(U)
+
+    U->route->remove(X->position);
+    U->route->remove(U->position);
+
     V->route->insert(V->position + 1, U);
     V->route->insert(V->position + 1, X);
 }

--- a/pyvrp/cpp/search/RelocateStar.cpp
+++ b/pyvrp/cpp/search/RelocateStar.cpp
@@ -40,6 +40,9 @@ pyvrp::Cost RelocateStar::evaluate(Route *U,
 void RelocateStar::apply([[maybe_unused]] Route *U,
                          [[maybe_unused]] Route *V) const
 {
+    auto *fromRoute = move.from->route;
     auto *toRoute = move.to->route;
+
+    fromRoute->remove(move.from->position);
     toRoute->insert(move.to->position + 1, move.from);
 }

--- a/pyvrp/cpp/search/RelocateStar.cpp
+++ b/pyvrp/cpp/search/RelocateStar.cpp
@@ -40,5 +40,6 @@ pyvrp::Cost RelocateStar::evaluate(Route *U,
 void RelocateStar::apply([[maybe_unused]] Route *U,
                          [[maybe_unused]] Route *V) const
 {
-    move.from->insertAfter(move.to);
+    auto *toRoute = move.to->route;
+    toRoute->insert(move.to->position + 1, move.from);
 }

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -58,7 +58,7 @@ void Route::clear()
 
 void Route::insert(size_t position, Node *node)
 {
-    assert(position > 0);
+    assert(0 < position && position <= nodes.size() + 1);
     auto *prev = position == 1 ? &startDepot : nodes[position - 2];
 
     if (node->route)

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -1,5 +1,6 @@
 #include "Route.h"
 
+#include <cassert>
 #include <cmath>
 #include <numbers>
 #include <ostream>
@@ -11,19 +12,7 @@ Route::Node::Node(size_t client) : client(client) {}
 
 void Route::Node::insertAfter(Route::Node *other)
 {
-    if (route)  // If we're in a route, we first stitch up the current route.
-    {           // If we're not in a route, this step should be skipped.
-        prev->next = next;
-        next->prev = prev;
-    }
-
-    prev = other;
-    next = other->next;
-
-    other->next->prev = this;
-    other->next = this;
-
-    route = other->route;
+    other->route->insert(other->position + 1, this);
 }
 
 Route::Route(ProblemData const &data, size_t const idx, size_t const vehType)
@@ -70,6 +59,29 @@ void Route::clear()
     endDepot.prev = &startDepot;
     endDepot.next = &startDepot;
     endDepot.twAfter = endDepot.tw;
+}
+
+void Route::insert(size_t position, Node *node)
+{
+    assert(position > 0);
+    auto *prev = position == 1 ? &startDepot : nodes[position - 2];
+
+    if (node->route)
+    {
+        // TODO use Route::remove()
+        node->prev->next = node->next;
+        node->next->prev = node->prev;
+    }
+
+    node->prev = prev;
+    node->next = prev->next;
+    node->route = prev->route;
+
+    prev->next->prev = node;
+    prev->next = node;
+
+    node->position = position;
+    nodes.insert(nodes.begin() + position - 1, node);
 }
 
 void Route::push_back(Node *node)

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -153,7 +153,6 @@ void Route::update()
     distance_ += data.dist(p(&endDepot)->client, endDepot.client);
 
 #ifdef PYVRP_NO_TIME_WINDOWS
-    timeWarp_ = 0;
     return;
 #else
     // Backward time window segments (depot -> client)
@@ -163,8 +162,6 @@ void Route::update()
 
     endDepot.twBefore = TWS::merge(
         data.durationMatrix(), p(&endDepot)->twBefore, endDepot.tw);
-
-    timeWarp_ = endDepot.twBefore.totalTimeWarp();
 
     // Forward time window segments (client -> depot)
     // TODO std::ranges::view::reverse once clang supports it

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -4,10 +4,12 @@
 #include <cmath>
 #include <numbers>
 #include <ostream>
+#include <ranges>
 #include <utility>
 
 using pyvrp::search::Route;
 using TWS = pyvrp::TimeWindowSegment;
+using std::ranges::views::reverse;
 
 Route::Node::Node(size_t client) : client(client) {}
 
@@ -157,7 +159,7 @@ void Route::update()
     return;
 #else
     // Backward time window segments (depot -> client)
-    for (auto *node = n(&startDepot); !node->isDepot(); node = n(node))
+    for (auto *node : nodes)
         node->twBefore
             = TWS::merge(data.durationMatrix(), p(node)->twBefore, node->tw);
 
@@ -167,7 +169,7 @@ void Route::update()
     timeWarp_ = endDepot.twBefore.totalTimeWarp();
 
     // Forward time window segments (client -> depot)
-    for (auto *node = p(&endDepot); !node->isDepot(); node = p(node))
+    for (auto *node : reverse(nodes))
         node->twAfter
             = TWS::merge(data.durationMatrix(), node->tw, n(node)->twAfter);
 

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -9,7 +9,6 @@
 
 using pyvrp::search::Route;
 using TWS = pyvrp::TimeWindowSegment;
-using std::ranges::views::reverse;
 
 Route::Node::Node(size_t client) : client(client) {}
 
@@ -169,7 +168,7 @@ void Route::update()
     timeWarp_ = endDepot.twBefore.totalTimeWarp();
 
     // Forward time window segments (client -> depot)
-    for (auto *node : reverse(nodes))
+    for (auto *node : nodes | std::ranges::views::reverse)
         node->twAfter
             = TWS::merge(data.durationMatrix(), node->tw, n(node)->twAfter);
 

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -26,30 +26,6 @@ void Route::Node::insertAfter(Route::Node *other)
     route = other->route;
 }
 
-void Route::Node::swapWith(Route::Node *other)
-{
-    auto *VPred = other->prev;
-    auto *VSucc = other->next;
-    auto *UPred = prev;
-    auto *USucc = next;
-
-    auto *routeU = route;
-    auto *routeV = other->route;
-
-    UPred->next = other;
-    USucc->prev = other;
-    VPred->next = this;
-    VSucc->prev = this;
-
-    prev = VPred;
-    next = VSucc;
-    other->prev = UPred;
-    other->next = USucc;
-
-    route = routeV;
-    other->route = routeU;
-}
-
 Route::Route(ProblemData const &data, size_t const idx, size_t const vehType)
     : data(data),
       vehicleType_(vehType),
@@ -115,6 +91,30 @@ void Route::remove(size_t position)
     node->route = nullptr;
 
     nodes.erase(nodes.begin() + position - 1);
+}
+
+void Route::swap(Node *first, Node *second)
+{
+    auto *fPred = first->prev;
+    auto *fSucc = first->next;
+    auto *sPred = second->prev;
+    auto *sSucc = second->next;
+
+    auto *fRoute = first->route;
+    auto *sRoute = second->route;
+
+    fPred->next = second;
+    fSucc->prev = second;
+    sPred->next = first;
+    sSucc->prev = first;
+
+    first->prev = sPred;
+    first->next = sSucc;
+    second->prev = fPred;
+    second->next = fSucc;
+
+    first->route = sRoute;
+    second->route = fRoute;
 }
 
 void Route::update()

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -98,6 +98,7 @@ void Route::remove(size_t position)
 
 void Route::swap(Node *first, Node *second)
 {
+    // TODO just swap clients?
     auto *fPred = first->prev;
     auto *fSucc = first->next;
     auto *sPred = second->prev;

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -60,14 +60,9 @@ void Route::clear()
 void Route::insert(size_t position, Node *node)
 {
     assert(0 < position && position <= nodes.size() + 1);
-    auto *prev = position == 1 ? &startDepot : nodes[position - 2];
+    assert(!node->route);  // must previously have been unassigned
 
-    if (node->route)
-    {
-        // TODO use Route::remove()
-        node->prev->next = node->next;
-        node->next->prev = node->prev;
-    }
+    auto *prev = position == 1 ? &startDepot : nodes[position - 2];
 
     node->prev = prev;
     node->next = prev->next;
@@ -78,6 +73,9 @@ void Route::insert(size_t position, Node *node)
 
     node->position = position;
     nodes.insert(nodes.begin() + position - 1, node);
+
+    for (auto idx = position - 1; idx != nodes.size(); ++idx)
+        nodes[idx]->position = idx + 1;
 }
 
 void Route::push_back(Node *node) { insert(size() + 1, node); }
@@ -95,6 +93,9 @@ void Route::remove(size_t position)
     node->route = nullptr;
 
     nodes.erase(nodes.begin() + position - 1);
+
+    for (auto idx = position - 1; idx != nodes.size(); ++idx)
+        nodes[idx]->position = idx + 1;
 }
 
 void Route::swap(Node *first, Node *second)

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -1,6 +1,5 @@
 #include "Route.h"
 
-#include <cassert>
 #include <cmath>
 #include <numbers>
 #include <ostream>

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -123,7 +123,6 @@ void Route::swap(Node *first, Node *second)
 
 void Route::update()
 {
-    nodes.clear();
     cumLoad.clear();
     cumDist.clear();
 
@@ -131,11 +130,8 @@ void Route::update()
     load_ = 0;
     distance_ = 0;
 
-    for (auto *node = n(&startDepot); !node->isDepot(); node = n(node))
+    for (auto *node : nodes)
     {
-        node->position = size() + 1;
-        nodes.push_back(node);
-
         auto const &clientData = data.client(node->client);
 
         centroid.first += static_cast<double>(clientData.x);

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -4,7 +4,6 @@
 #include <cmath>
 #include <numbers>
 #include <ostream>
-#include <ranges>
 #include <utility>
 
 using pyvrp::search::Route;
@@ -168,9 +167,10 @@ void Route::update()
     timeWarp_ = endDepot.twBefore.totalTimeWarp();
 
     // Forward time window segments (client -> depot)
-    for (auto *node : nodes | std::ranges::views::reverse)
-        node->twAfter
-            = TWS::merge(data.durationMatrix(), node->tw, n(node)->twAfter);
+    // TODO std::ranges::view::reverse once clang supports it
+    for (auto node = nodes.rbegin(); node != nodes.rend(); ++node)
+        (*node)->twAfter
+            = TWS::merge(data.durationMatrix(), (*node)->tw, n(*node)->twAfter);
 
     startDepot.twAfter = TWS::merge(
         data.durationMatrix(), startDepot.tw, n(&startDepot)->twAfter);

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -10,11 +10,6 @@ using TWS = pyvrp::TimeWindowSegment;
 
 Route::Node::Node(size_t client) : client(client) {}
 
-void Route::Node::insertAfter(Route::Node *other)
-{
-    other->route->insert(other->position + 1, this);
-}
-
 Route::Route(ProblemData const &data, size_t const idx, size_t const vehType)
     : data(data),
       vehicleType_(vehType),
@@ -84,11 +79,7 @@ void Route::insert(size_t position, Node *node)
     nodes.insert(nodes.begin() + position - 1, node);
 }
 
-void Route::push_back(Node *node)
-{
-    node->insertAfter(empty() ? &startDepot : nodes.back());
-    nodes.push_back(node);
-}
+void Route::push_back(Node *node) { insert(size() + 1, node); }
 
 void Route::remove(size_t position)
 {

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <numbers>
 #include <ostream>
+#include <utility>
 
 using pyvrp::search::Route;
 using TWS = pyvrp::TimeWindowSegment;
@@ -99,26 +100,24 @@ void Route::remove(size_t position)
 void Route::swap(Node *first, Node *second)
 {
     // TODO just swap clients?
+    // TODO specialise std::swap for Node
     auto *fPred = first->prev;
     auto *fSucc = first->next;
     auto *sPred = second->prev;
     auto *sSucc = second->next;
 
-    auto *fRoute = first->route;
-    auto *sRoute = second->route;
+    std::swap(first->prev, second->prev);
+    std::swap(first->next, second->next);
+    std::swap(first->route->nodes[first->position - 1],
+              second->route->nodes[second->position - 1]);
+
+    std::swap(first->route, second->route);
+    std::swap(first->position, second->position);
 
     fPred->next = second;
     fSucc->prev = second;
     sPred->next = first;
     sSucc->prev = first;
-
-    first->prev = sPred;
-    first->next = sSucc;
-    second->prev = fPred;
-    second->next = fSucc;
-
-    first->route = sRoute;
-    second->route = fRoute;
 }
 
 void Route::update()

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -48,12 +48,7 @@ void Route::clear()
 {
     nodes.clear();
 
-    startDepot.prev = &endDepot;
-    startDepot.next = &endDepot;
     startDepot.twBefore = startDepot.tw;
-
-    endDepot.prev = &startDepot;
-    endDepot.next = &startDepot;
     endDepot.twAfter = endDepot.tw;
 }
 
@@ -64,14 +59,8 @@ void Route::insert(size_t position, Node *node)
 
     auto *prev = position == 1 ? &startDepot : nodes[position - 2];
 
-    node->prev = prev;
-    node->next = prev->next;
-    node->route = prev->route;
-
-    prev->next->prev = node;
-    prev->next = node;
-
     node->position = position;
+    node->route = prev->route;
     nodes.insert(nodes.begin() + position - 1, node);
 
     for (auto idx = position - 1; idx != nodes.size(); ++idx)
@@ -85,13 +74,7 @@ void Route::remove(size_t position)
     assert(position > 0);
     auto *node = nodes[position - 1];
 
-    node->prev->next = node->next;
-    node->next->prev = node->prev;
-
-    node->prev = nullptr;
-    node->next = nullptr;
     node->route = nullptr;
-
     nodes.erase(nodes.begin() + position - 1);
 
     for (auto idx = position - 1; idx != nodes.size(); ++idx)
@@ -102,23 +85,11 @@ void Route::swap(Node *first, Node *second)
 {
     // TODO just swap clients?
     // TODO specialise std::swap for Node
-    auto *fPred = first->prev;
-    auto *fSucc = first->next;
-    auto *sPred = second->prev;
-    auto *sSucc = second->next;
-
-    std::swap(first->prev, second->prev);
-    std::swap(first->next, second->next);
     std::swap(first->route->nodes[first->position - 1],
               second->route->nodes[second->position - 1]);
 
     std::swap(first->route, second->route);
     std::swap(first->position, second->position);
-
-    fPred->next = second;
-    fSucc->prev = second;
-    sPred->next = first;
-    sSucc->prev = first;
 }
 
 void Route::update()

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -37,11 +37,6 @@ public:
         Node(size_t client);
 
         [[nodiscard]] inline bool isDepot() const;
-
-        /**
-         * Inserts this node after the other and updates the relevant links.
-         */
-        void insertAfter(Node *other);
     };
 
 private:

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -50,7 +50,7 @@ public:                // TODO make fields private
     /**
      * @return The client or depot node at the given position.
      */
-    [[nodiscard]] inline Node *operator[](size_t position) const;
+    [[nodiscard]] inline Node *operator[](size_t position);
 
     [[nodiscard]] inline std::vector<Node *>::const_iterator begin() const;
     [[nodiscard]] inline std::vector<Node *>::const_iterator end() const;
@@ -172,15 +172,9 @@ public:                // TODO make fields private
  */
 inline Route::Node *p(Route::Node *node)
 {
-    // TODO streamline this
     auto &route = *node->route;
 
-    if (node->position == 0)
-        return &route.endDepot;
-
-    if (node->position == 1)
-        return &route.startDepot;
-
+    assert(node->position > 0);
     return route[node->position - 1];
 }
 
@@ -189,15 +183,9 @@ inline Route::Node *p(Route::Node *node)
  */
 inline Route::Node *n(Route::Node *node)
 {
-    // TODO streamline this
     auto &route = *node->route;
 
-    if (node->position == route.size() + 1)
-        return &route.startDepot;
-
-    if (node->position == route.size())
-        return &route.endDepot;
-
+    assert(node->position <= route.size() + 1);
     return route[node->position + 1];
 }
 
@@ -221,9 +209,16 @@ bool Route::hasTimeWarp() const
 #endif
 }
 
-Route::Node *Route::operator[](size_t position) const
+Route::Node *Route::operator[](size_t position)
 {
-    assert(position > 0);
+    assert(position <= nodes.size() + 1);
+
+    if (position == 0)
+        return &startDepot;
+
+    if (position == nodes.size() + 1)
+        return &endDepot;
+
     return nodes[position - 1];
 }
 

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -14,15 +14,6 @@ class Route
 public:
     class Node
     {
-        // TODO obsolete this
-        friend Node *p(Node *node);
-        friend Node *n(Node *node);
-        friend class Route;
-
-        // TODO remove these fields
-        Node *prev = nullptr;  // Predecessor in route
-        Node *next = nullptr;  // Successor in route
-
     public:  // TODO make fields private
         // TODO rename client to location/loc
         size_t client;           // Location represented by this node
@@ -179,12 +170,36 @@ public:                // TODO make fields private
 /**
  * Convenience method accessing the node directly before the argument.
  */
-inline Route::Node *p(Route::Node *node) { return node->prev; }
+inline Route::Node *p(Route::Node *node)
+{
+    // TODO streamline this
+    auto &route = *node->route;
+
+    if (node->position == 0)
+        return &route.endDepot;
+
+    if (node->position == 1)
+        return &route.startDepot;
+
+    return route[node->position - 1];
+}
 
 /**
  * Convenience method accessing the node directly after the argument.
  */
-inline Route::Node *n(Route::Node *node) { return node->next; }
+inline Route::Node *n(Route::Node *node)
+{
+    // TODO streamline this
+    auto &route = *node->route;
+
+    if (node->position == route.size() + 1)
+        return &route.startDepot;
+
+    if (node->position == route.size())
+        return &route.endDepot;
+
+    return route[node->position + 1];
+}
 
 bool Route::Node::isDepot() const
 {

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -50,7 +50,6 @@ private:
     std::pair<double, double> centroid;  // Center point of route's clients
     Load load_;                          // Current route load
     Distance distance_;                  // Current route distance
-    Duration timeWarp_;                  // Current route time warp
 
 public:                // TODO make fields private
     size_t const idx;  // Route index
@@ -196,14 +195,14 @@ bool Route::Node::isDepot() const
 
 bool Route::isFeasible() const { return !hasExcessLoad() && !hasTimeWarp(); }
 
-bool Route::hasExcessLoad() const { return load_ > capacity(); }
+bool Route::hasExcessLoad() const { return load() > capacity(); }
 
 bool Route::hasTimeWarp() const
 {
 #ifdef PYVRP_NO_TIME_WINDOWS
     return false;
 #else
-    return timeWarp_ > 0;
+    return timeWarp() > 0;
 #endif
 }
 
@@ -227,7 +226,7 @@ std::vector<Route::Node *>::iterator Route::end() { return nodes.end(); }
 
 Load Route::load() const { return load_; }
 
-Duration Route::timeWarp() const { return timeWarp_; }
+Duration Route::timeWarp() const { return endDepot.twBefore.totalTimeWarp(); }
 
 Load Route::capacity() const { return data.vehicleType(vehicleType_).capacity; }
 

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -153,6 +153,12 @@ public:                // TODO make fields private
     void clear();
 
     /**
+     * Inserts the given node in position ``position``. Assumes the position is
+     * valid.
+     */
+    void insert(size_t position, Node *node);
+
+    /**
      * Inserts the given node at the back of the route.
      */
     void push_back(Node *node);

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -42,11 +42,6 @@ public:
          * Inserts this node after the other and updates the relevant links.
          */
         void insertAfter(Node *other);
-
-        /**
-         * Swaps this node with the other and updates the relevant links.
-         */
-        void swapWith(Node *other);
     };
 
 private:
@@ -166,6 +161,11 @@ public:                // TODO make fields private
      * Removes the node at ``position`` from the route.
      */
     void remove(size_t position);
+
+    /**
+     * Swaps the given nodes.
+     */
+    static void swap(Node *first, Node *second);
 
     /**
      * Updates this route. To be called after swapping nodes/changing the

--- a/pyvrp/cpp/search/SwapStar.cpp
+++ b/pyvrp/cpp/search/SwapStar.cpp
@@ -295,12 +295,12 @@ Cost SwapStar::evaluate(Route *routeU,
     return deltaCost;
 }
 
-void SwapStar::apply([[maybe_unused]] Route *U, [[maybe_unused]] Route *V) const
+void SwapStar::apply(Route *U, Route *V) const
 {
     if (best.U && best.UAfter && best.V && best.VAfter)
     {
-        best.U->insertAfter(best.UAfter);
-        best.V->insertAfter(best.VAfter);
+        V->insert(best.UAfter->position + 1, best.U);
+        U->insert(best.VAfter->position + 1, best.V);
     }
 }
 

--- a/pyvrp/cpp/search/SwapStar.cpp
+++ b/pyvrp/cpp/search/SwapStar.cpp
@@ -299,6 +299,9 @@ void SwapStar::apply(Route *U, Route *V) const
 {
     if (best.U && best.UAfter && best.V && best.VAfter)
     {
+        U->remove(best.U->position);
+        V->remove(best.V->position);
+
         V->insert(best.UAfter->position + 1, best.U);
         U->insert(best.VAfter->position + 1, best.V);
     }

--- a/pyvrp/cpp/search/TwoOpt.cpp
+++ b/pyvrp/cpp/search/TwoOpt.cpp
@@ -107,6 +107,7 @@ void TwoOpt::applyWithinRoute(Route::Node *U, Route::Node *V) const
     {
         auto *node = V;
         V = p(V);
+        U->route->remove(node->position);
         U->route->insert(insertPos++, node);
     }
 }
@@ -121,6 +122,7 @@ void TwoOpt::applyBetweenRoutes(Route::Node *U, Route::Node *V) const
     {
         auto *node = nV;
         nV = n(nV);
+        V->route->remove(node->position);
         U->route->insert(insertPos++, node);
     }
 
@@ -129,6 +131,7 @@ void TwoOpt::applyBetweenRoutes(Route::Node *U, Route::Node *V) const
     {
         auto *node = nU;
         nU = n(nU);
+        U->route->remove(node->position);
         V->route->insert(insertPos++, node);
     }
 }

--- a/pyvrp/cpp/search/TwoOpt.cpp
+++ b/pyvrp/cpp/search/TwoOpt.cpp
@@ -108,7 +108,7 @@ void TwoOpt::applyWithinRoute(Route::Node *U, Route::Node *V) const
     {
         auto *current = itRoute;
         itRoute = p(itRoute);
-        current->insertAfter(insertionPoint);
+        insertionPoint->route->insert(insertionPoint->position + 1, current);
         insertionPoint = current;
     }
 }
@@ -123,7 +123,7 @@ void TwoOpt::applyBetweenRoutes(Route::Node *U, Route::Node *V) const
     {
         auto *node = itRouteV;
         itRouteV = n(itRouteV);
-        node->insertAfter(insertLocation);
+        insertLocation->route->insert(insertLocation->position + 1, node);
         insertLocation = node;
     }
 
@@ -132,7 +132,7 @@ void TwoOpt::applyBetweenRoutes(Route::Node *U, Route::Node *V) const
     {
         auto *node = itRouteU;
         itRouteU = n(itRouteU);
-        node->insertAfter(insertLocation);
+        insertLocation->route->insert(insertLocation->position + 1, node);
         insertLocation = node;
     }
 }

--- a/pyvrp/cpp/search/TwoOpt.cpp
+++ b/pyvrp/cpp/search/TwoOpt.cpp
@@ -100,40 +100,36 @@ Cost TwoOpt::evalBetweenRoutes(Route::Node *U,
 
 void TwoOpt::applyWithinRoute(Route::Node *U, Route::Node *V) const
 {
-    auto *itRoute = V;
-    auto *insertionPoint = U;
-    auto *currNext = n(U);
+    auto *nU = n(U);
 
-    while (itRoute != currNext)  // No need to move n(U), we pivot around it
+    auto insertPos = U->position + 1;
+    while (V != nU)
     {
-        auto *current = itRoute;
-        itRoute = p(itRoute);
-        insertionPoint->route->insert(insertionPoint->position + 1, current);
-        insertionPoint = current;
+        auto *node = V;
+        V = p(V);
+        U->route->insert(insertPos++, node);
     }
 }
 
 void TwoOpt::applyBetweenRoutes(Route::Node *U, Route::Node *V) const
 {
-    auto *itRouteU = n(U);
-    auto *itRouteV = n(V);
+    auto *nU = n(U);
+    auto *nV = n(V);
 
-    auto *insertLocation = U;
-    while (!itRouteV->isDepot())
+    auto insertPos = U->position + 1;
+    while (!nV->isDepot())
     {
-        auto *node = itRouteV;
-        itRouteV = n(itRouteV);
-        insertLocation->route->insert(insertLocation->position + 1, node);
-        insertLocation = node;
+        auto *node = nV;
+        nV = n(nV);
+        U->route->insert(insertPos++, node);
     }
 
-    insertLocation = V;
-    while (!itRouteU->isDepot())
+    insertPos = V->position + 1;
+    while (!nU->isDepot())
     {
-        auto *node = itRouteU;
-        itRouteU = n(itRouteU);
-        insertLocation->route->insert(insertLocation->position + 1, node);
-        insertLocation = node;
+        auto *node = nU;
+        nU = n(nU);
+        V->route->insert(insertPos++, node);
     }
 }
 


### PR DESCRIPTION
This PR moves `Route::Node::swapWith` and `Route::Node::insertAfter` to `Route`. This allows us to incrementally update the `nodes` list, ensuring it is always up-to-date. That lets us remove the linked list representation of `Node::prev` and `Node::next` altogether.

This PR:

- [x] Is part of #96.
- [ ] Adds and passes relevant tests.
- [x] Has well-formatted code and documentation.

### Benchmark on VRPTW

Benchmark because the linked list implementation was constant time and the vector-based stuff of this PR is technically linear (but cache friendly).

This PR (593d4181361130e95e457c3f067a0bc8ad56d596; job ID 3346130; 10x seeds):
```
               mean      min       max
      inst
obj   C1    41366.2  41336.6   41388.1
      C2    16192.6  16186.5   16195.6
      R1    47357.7  47310.9   47419.8
      R2    27721.3  27701.3   27752.6
      RC1   44251.9  44217.8   44294.9
      RC2   23227.2  23207.1   23252.8
iters C1    55046.2  39111.4   62840.9
      C2    90224.6  65856.4  103908.3
      R1    29471.6  21054.5   33433.9
      R2    40072.1  29772.8   47833.2
      RC1   32833.7  23804.7   40093.5
      RC2   45170.2  32032.1   52846.2
```

Fairly recent main (few days; see #298):
```
                mean      min       max
      inst
obj   C1     41359.8  41334.3   41385.0
      C2     16191.6  16186.3   16195.0
      R1     47309.9  47246.8   47351.0
      R2     27709.4  27695.4   27726.6
      RC1    44229.4  44200.8   44251.0
      RC2    23220.1  23205.1   23228.5
iters C1     67607.0  59160.1   72707.3
      C2    114033.6  97355.1  130571.2
      R1     35821.4  30369.2   38830.0
      R2     51190.2  44466.3   54158.0
      RC1    41248.0  35409.3   46337.5
      RC2    57659.0  51814.0   63145.3
```

<details>

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
