### PR TITLE
Add depots to Route::nodes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,7 @@ project(
     version: run_command('poetry', 'version', '--short', check: true).stdout(),
     default_options: [
         'cpp_std=c++20',
+        'b_ndebug=if-release',  # disables asserts in release builds
         'b_lto=true',  # sets -flto
         'werror=true',  # sets -Werror
         'warning_level=3',  # level 3 sets -Wextra and -Wpedantic

--- a/pyvrp/cpp/search/Exchange.h
+++ b/pyvrp/cpp/search/Exchange.h
@@ -75,7 +75,7 @@ bool Exchange<N, M>::overlap(Route::Node *U, Route::Node *V) const
 template <size_t N, size_t M>
 bool Exchange<N, M>::adjacent(Route::Node *U, Route::Node *V) const
 {
-    return (U->route == V->route)
+    return U->route == V->route
            && (U->idx + N == V->idx || V->idx + M == U->idx);
 }
 

--- a/pyvrp/cpp/search/LocalSearch.cpp
+++ b/pyvrp/cpp/search/LocalSearch.cpp
@@ -260,7 +260,7 @@ void LocalSearch::maybeInsert(Route::Node *U,
 
     if (deltaCost < 0)
     {
-        V->route->insert(V->position + 1, U);
+        V->route->insert(V->idx + 1, U);
         update(V->route, V->route);
     }
 }
@@ -291,7 +291,7 @@ void LocalSearch::maybeRemove(Route::Node *U,
     if (deltaCost < 0)
     {
         auto *route = U->route;  // after remove(), U->route is a nullptr
-        route->remove(U->position);
+        route->remove(U->idx);
         update(route, route);
     }
 }

--- a/pyvrp/cpp/search/LocalSearch.cpp
+++ b/pyvrp/cpp/search/LocalSearch.cpp
@@ -123,9 +123,9 @@ void LocalSearch::search(CostEvaluator const &costEvaluator)
                         continue;
 
                     if (U->route)  // try inserting U into the empty route.
-                        applyNodeOps(U, &empty->startDepot, costEvaluator);
+                        applyNodeOps(U, (*empty)[0], costEvaluator);
                     else  // U is not in the solution, so again try inserting.
-                        maybeInsert(U, &empty->startDepot, costEvaluator);
+                        maybeInsert(U, (*empty)[0], costEvaluator);
                 }
             }
         }

--- a/pyvrp/cpp/search/RelocateStar.cpp
+++ b/pyvrp/cpp/search/RelocateStar.cpp
@@ -43,6 +43,6 @@ void RelocateStar::apply([[maybe_unused]] Route *U,
     auto *fromRoute = move.from->route;
     auto *toRoute = move.to->route;
 
-    fromRoute->remove(move.from->position);
-    toRoute->insert(move.to->position + 1, move.from);
+    fromRoute->remove(move.from->idx);
+    toRoute->insert(move.to->idx + 1, move.from);
 }

--- a/pyvrp/cpp/search/RelocateStar.cpp
+++ b/pyvrp/cpp/search/RelocateStar.cpp
@@ -11,12 +11,12 @@ pyvrp::Cost RelocateStar::evaluate(Route *U,
 
     for (auto *nodeU : *U)
     {
-        // Test inserting U after V's start depot
-        Cost deltaCost
-            = relocate.evaluate(nodeU, &V->startDepot, costEvaluator);
+        // Test inserting U after V's depot (idx 0).
+        auto *depot = (*V)[0];
+        Cost deltaCost = relocate.evaluate(nodeU, depot, costEvaluator);
 
         if (deltaCost < move.deltaCost)
-            move = {deltaCost, nodeU, &V->startDepot};
+            move = {deltaCost, nodeU, depot};
 
         for (auto *nodeV : *V)
         {

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -113,8 +113,6 @@ void Route::swap(Node *first, Node *second)
 
 void Route::update()
 {
-    cumDist[0] = 0;
-    cumLoad[0] = 0;
     centroid = {0, 0};
 
     for (size_t idx = 1; idx != nodes.size(); ++idx)

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -124,17 +124,14 @@ void Route::update()
 
         if (!node->isDepot())
         {
-            centroid.first += static_cast<double>(clientData.x);
-            centroid.second += static_cast<double>(clientData.y);
+            centroid.first += static_cast<double>(clientData.x) / size();
+            centroid.second += static_cast<double>(clientData.y) / size();
         }
 
         auto const dist = data.dist(p(node)->client, node->client);
         cumDist[pos] = cumDist[pos - 1] + dist;
         cumLoad[pos] = cumLoad[pos - 1] + clientData.demand;
     }
-
-    centroid.first /= size();
-    centroid.second /= size();
 
 #ifdef PYVRP_NO_TIME_WINDOWS
     return;

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -13,9 +13,9 @@ Route::Node::Node(size_t client) : client(client) {}
 Route::Route(ProblemData const &data, size_t const idx, size_t const vehType)
     : data(data),
       vehicleType_(vehType),
-      idx(idx),
       startDepot(data.vehicleType(vehType).depot),
-      endDepot(data.vehicleType(vehType).depot)
+      endDepot(data.vehicleType(vehType).depot),
+      idx(idx)
 {
     startDepot.route = this;
     startDepot.tw = TWS(startDepot.client, data.client(startDepot.client));

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -9,6 +9,17 @@
 
 namespace pyvrp::search
 {
+/**
+ * This ``Route`` class supports fast delta cost computations and in-place
+ * modification. It can be used to implement move evaluations.
+ *
+ * A ``Route`` object tracks a full route, including the depots. The clients
+ * and depots on the route can be accessed using ``Route::operator[]`` on a
+ * ``route`` object: ``route[0]`` is the starting depot, ``route[route.size()]``
+ * is the last client, and ``route[route.size() + 1]`` is the ending depot.
+ * Note that `Route::size()`` returns the number of *clients* in the route; this
+ * does *not* include the depots.
+ */
 class Route
 {
 public:

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -40,10 +40,11 @@ private:
 
     std::pair<double, double> centroid;  // Center point of route's clients
 
+    Node startDepot;  // Departure depot for this route
+    Node endDepot;    // Return depot for this route
+
 public:                // TODO make fields private
     size_t const idx;  // Route index
-    Node startDepot;   // Departure depot for this route
-    Node endDepot;     // Return depot for this route
 
     /**
      * @return The client or depot node at the given ``idx``.

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -246,7 +246,7 @@ bool Route::empty() const { return size() == 0; }
 
 size_t Route::size() const
 {
-    assert(nodes.size() >= 2);
+    assert(nodes.size() >= 2);  // excl. depots
     return nodes.size() - 2;
 }
 

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -17,7 +17,7 @@ public:
     public:  // TODO make fields private
         // TODO rename client to location/loc
         size_t client;           // Location represented by this node
-        size_t position = 0;     // Position in the route
+        size_t idx = 0;          // Position in the route
         Route *route = nullptr;  // Indicates membership of a route, if any.
 
         // TODO can these data fields be moved to Route?
@@ -46,9 +46,9 @@ public:                // TODO make fields private
     Node endDepot;     // Return depot for this route
 
     /**
-     * @return The client or depot node at the given position.
+     * @return The client or depot node at the given ``idx``.
      */
-    [[nodiscard]] inline Node *operator[](size_t position);
+    [[nodiscard]] inline Node *operator[](size_t idx);
 
     [[nodiscard]] inline std::vector<Node *>::const_iterator begin() const;
     [[nodiscard]] inline std::vector<Node *>::const_iterator end() const;
@@ -136,10 +136,10 @@ public:                // TODO make fields private
     void clear();
 
     /**
-     * Inserts the given node in position ``position``. Assumes the position is
+     * Inserts the given node at index ``idx``. Assumes the given index is
      * valid.
      */
-    void insert(size_t position, Node *node);
+    void insert(size_t idx, Node *node);
 
     /**
      * Inserts the given node at the back of the route.
@@ -147,9 +147,9 @@ public:                // TODO make fields private
     void push_back(Node *node);
 
     /**
-     * Removes the node at ``position`` from the route.
+     * Removes the node at ``idx`` from the route.
      */
-    void remove(size_t position);
+    void remove(size_t idx);
 
     /**
      * Swaps the given nodes.
@@ -171,7 +171,7 @@ public:                // TODO make fields private
 inline Route::Node *p(Route::Node *node)
 {
     auto &route = *node->route;
-    return route[node->position - 1];
+    return route[node->idx - 1];
 }
 
 /**
@@ -180,7 +180,7 @@ inline Route::Node *p(Route::Node *node)
 inline Route::Node *n(Route::Node *node)
 {
     auto &route = *node->route;
-    return route[node->position + 1];
+    return route[node->idx + 1];
 }
 
 bool Route::Node::isDepot() const
@@ -203,10 +203,10 @@ bool Route::hasTimeWarp() const
 #endif
 }
 
-Route::Node *Route::operator[](size_t position)
+Route::Node *Route::operator[](size_t idx)
 {
-    assert(position < nodes.size());
-    return nodes[position];
+    assert(idx < nodes.size());
+    return nodes[idx];
 }
 
 std::vector<Route::Node *>::const_iterator Route::begin() const

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -35,8 +35,8 @@ private:
     size_t const vehicleType_;
 
     std::vector<Node *> nodes;      // Nodes in this route, excl. depot
-    std::vector<Load> cumLoad;      // Cumulative load along route (incl.)
     std::vector<Distance> cumDist;  // Cumulative dist along route (incl.)
+    std::vector<Load> cumLoad;      // Cumulative load along route (incl.)
 
     std::pair<double, double> centroid;  // Center point of route's clients
 

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -17,8 +17,14 @@ namespace pyvrp::search
  * and depots on the route can be accessed using ``Route::operator[]`` on a
  * ``route`` object: ``route[0]`` and ``route[route.size() + 1]`` are the start
  * and end depots, respectively, and any clients in between are on the indices
- * ``{1, ..., size()}`` (empty if ``size() == 0``). Note that `Route::size()``
+ * ``{1, ..., size()}`` (empty if ``size() == 0``). Note that ``Route::size()``
  * returns the number of *clients* in the route; this excludes the depots.
+ *
+ * .. note::
+ *
+ *    Modifications to the ``Route`` object do not immediately propagate to its
+ *    statitics like time window data, or load and distance attributes. To make
+ *    that happen, ``Route::update()`` must be called!
  */
 class Route
 {
@@ -45,7 +51,7 @@ private:
     ProblemData const &data;
     size_t const vehicleType_;
 
-    std::vector<Node *> nodes;      // Nodes in this route, excl. depot
+    std::vector<Node *> nodes;      // Nodes in this route, including depots
     std::vector<Distance> cumDist;  // Cumulative dist along route (incl.)
     std::vector<Load> cumLoad;      // Cumulative load along route (incl.)
 

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -15,10 +15,10 @@ namespace pyvrp::search
  *
  * A ``Route`` object tracks a full route, including the depots. The clients
  * and depots on the route can be accessed using ``Route::operator[]`` on a
- * ``route`` object: ``route[0]`` is the starting depot, ``route[route.size()]``
- * is the last client, and ``route[route.size() + 1]`` is the ending depot.
- * Note that `Route::size()`` returns the number of *clients* in the route; this
- * does *not* include the depots.
+ * ``route`` object: ``route[0]`` and ``route[route.size() + 1]`` are the start
+ * and end depots, respectively, and any clients in between are on the indices
+ * ``{1, ..., size()}`` (empty if ``size() == 0``). Note that `Route::size()``
+ * returns the number of *clients* in the route; this excludes the depots.
  */
 class Route
 {

--- a/pyvrp/cpp/search/SwapStar.cpp
+++ b/pyvrp/cpp/search/SwapStar.cpp
@@ -35,21 +35,19 @@ void SwapStar::updateInsertionCost(Route *R,
     insertPositions.shouldUpdate = false;
 
     // Insert cost of U just after the depot (0 -> U -> ...)
-    auto twData = TWS::merge(data.durationMatrix(),
-                             R->startDepot.twBefore,
-                             U->tw,
-                             n(&R->startDepot)->twAfter);
+    auto *depot = (*R)[0];
+    auto twData = TWS::merge(
+        data.durationMatrix(), depot->twBefore, U->tw, n(depot)->twAfter);
 
-    Distance deltaDist
-        = data.dist(R->startDepot.client, U->client)
-          + data.dist(U->client, n(&R->startDepot)->client)
-          - data.dist(R->startDepot.client, n(&R->startDepot)->client);
+    Distance deltaDist = data.dist(depot->client, U->client)
+                         + data.dist(U->client, n(depot)->client)
+                         - data.dist(depot->client, n(depot)->client);
 
     Cost deltaCost = static_cast<Cost>(deltaDist)
                      + costEvaluator.twPenalty(twData.totalTimeWarp())
                      - costEvaluator.twPenalty(R->timeWarp());
 
-    insertPositions.maybeAdd(deltaCost, &R->startDepot);
+    insertPositions.maybeAdd(deltaCost, depot);
 
     for (auto *V : *R)
     {

--- a/pyvrp/cpp/search/SwapStar.cpp
+++ b/pyvrp/cpp/search/SwapStar.cpp
@@ -209,10 +209,10 @@ Cost SwapStar::evaluate(Route *routeU,
 
     // We cannot have that UAfter == V or VAfter == U, as the positions must
     // always be strictly different.
-    assert(best.VAfter->position != best.U->position);
-    assert(best.UAfter->position != best.V->position);
+    assert(best.VAfter->idx != best.U->idx);
+    assert(best.UAfter->idx != best.V->idx);
 
-    if (best.VAfter->position + 1 == best.U->position)
+    if (best.VAfter->idx + 1 == best.U->idx)
     {
         // Special case
         auto uTWS = TWS::merge(data.durationMatrix(),
@@ -222,30 +222,30 @@ Cost SwapStar::evaluate(Route *routeU,
 
         deltaCost += costEvaluator.twPenalty(uTWS.totalTimeWarp());
     }
-    else if (best.VAfter->position < best.U->position)
+    else if (best.VAfter->idx < best.U->idx)
     {
         auto uTWS = TWS::merge(
             data.durationMatrix(),
             best.VAfter->twBefore,
             best.V->tw,
-            routeU->twBetween(best.VAfter->position + 1, best.U->position - 1),
+            routeU->twBetween(best.VAfter->idx + 1, best.U->idx - 1),
             n(best.U)->twAfter);
 
         deltaCost += costEvaluator.twPenalty(uTWS.totalTimeWarp());
     }
     else
     {
-        auto uTWS = TWS::merge(
-            data.durationMatrix(),
-            p(best.U)->twBefore,
-            routeU->twBetween(best.U->position + 1, best.VAfter->position),
-            best.V->tw,
-            n(best.VAfter)->twAfter);
+        auto uTWS
+            = TWS::merge(data.durationMatrix(),
+                         p(best.U)->twBefore,
+                         routeU->twBetween(best.U->idx + 1, best.VAfter->idx),
+                         best.V->tw,
+                         n(best.VAfter)->twAfter);
 
         deltaCost += costEvaluator.twPenalty(uTWS.totalTimeWarp());
     }
 
-    if (best.UAfter->position + 1 == best.V->position)
+    if (best.UAfter->idx + 1 == best.V->idx)
     {
         // Special case
         auto vTWS = TWS::merge(data.durationMatrix(),
@@ -255,25 +255,25 @@ Cost SwapStar::evaluate(Route *routeU,
 
         deltaCost += costEvaluator.twPenalty(vTWS.totalTimeWarp());
     }
-    else if (best.UAfter->position < best.V->position)
+    else if (best.UAfter->idx < best.V->idx)
     {
         auto vTWS = TWS::merge(
             data.durationMatrix(),
             best.UAfter->twBefore,
             best.U->tw,
-            routeV->twBetween(best.UAfter->position + 1, best.V->position - 1),
+            routeV->twBetween(best.UAfter->idx + 1, best.V->idx - 1),
             n(best.V)->twAfter);
 
         deltaCost += costEvaluator.twPenalty(vTWS.totalTimeWarp());
     }
     else
     {
-        auto vTWS = TWS::merge(
-            data.durationMatrix(),
-            p(best.V)->twBefore,
-            routeV->twBetween(best.V->position + 1, best.UAfter->position),
-            best.U->tw,
-            n(best.UAfter)->twAfter);
+        auto vTWS
+            = TWS::merge(data.durationMatrix(),
+                         p(best.V)->twBefore,
+                         routeV->twBetween(best.V->idx + 1, best.UAfter->idx),
+                         best.U->tw,
+                         n(best.UAfter)->twAfter);
 
         deltaCost += costEvaluator.twPenalty(vTWS.totalTimeWarp());
     }
@@ -299,11 +299,11 @@ void SwapStar::apply(Route *U, Route *V) const
 {
     if (best.U && best.UAfter && best.V && best.VAfter)
     {
-        U->remove(best.U->position);
-        V->remove(best.V->position);
+        U->remove(best.U->idx);
+        V->remove(best.V->idx);
 
-        V->insert(best.UAfter->position + 1, best.U);
-        U->insert(best.VAfter->position + 1, best.V);
+        V->insert(best.UAfter->idx + 1, best.U);
+        U->insert(best.VAfter->idx + 1, best.V);
     }
 }
 


### PR DESCRIPTION
This PR adds the depots to `Route::nodes`, at index 0 (`startDepot`) and index `Route::size() + 1` (`endDepot`). So this is now an inclusive/complete route.

Doing this lets us simplify a lot of edge cases, mostly by realigning `position` (1-based) and the index into `nodes` (0-based). Additionally, we can make the depots private because they can be accessed via `Route::operator[]`. Iteration over routes still iterates only over clients, and routes are empty (`Route::empty() == true`) when there are no clients in them.

This PR:

- [x] Is part of #96.
- [ ] Adds and passes relevant tests.
- [x] Has well-formatted code and documentation.

### Benchmarks on VRPTW

See #319 for an earlier batch of benchmarks.

This PR (79a1cc661163d38d997330668177829496f71e49; job ID 3350569):
```
                mean       min       max
      inst
obj   C1     41359.9   41333.3   41383.4
      C2     16191.5   16186.3   16194.4
      R1     47307.9   47264.4   47350.1
      R2     27710.4   27696.9   27728.9
      RC1    44229.0   44207.2   44246.1
      RC2    23217.8   23205.0   23226.7
iters C1     67896.1   64152.1   72730.3
      C2    114640.7  110379.3  122336.3
      R1     35754.7   34111.1   37694.9
      R2     50979.6   46661.8   52468.4
      RC1    40433.6   38074.8   44908.3
      RC2    59870.8   55444.4   62651.8
```

Fairly recent main (from a few days ago; see #298):
```
                mean      min       max
      inst
obj   C1     41359.8  41334.3   41385.0
      C2     16191.6  16186.3   16195.0
      R1     47309.9  47246.8   47351.0
      R2     27709.4  27695.4   27726.6
      RC1    44229.4  44200.8   44251.0
      RC2    23220.1  23205.1   23228.5
iters C1     67607.0  59160.1   72707.3
      C2    114033.6  97355.1  130571.2
      R1     35821.4  30369.2   38830.0
      R2     51190.2  44466.3   54158.0
      RC1    41248.0  35409.3   46337.5
      RC2    57659.0  51814.0   63145.3
```

<details>

This PR (abb6f5e48e5c4e7cc157253e4517c731500d3bfd; job ID 3348287):
```
               mean      min       max
      inst
obj   C1    41366.9  41335.8   41391.6
      C2    16192.4  16186.7   16194.7
      R1    47354.2  47294.4   47415.6
      R2    27720.2  27705.1   27747.8
      RC1   44249.6  44223.2   44276.4
      RC2   23227.1  23206.1   23250.4
iters C1    55317.1  43407.0   63864.4
      C2    91960.4  72240.9  107821.7
      R1    28772.0  22465.9   32226.3
      R2    41040.2  32322.1   48440.9
      RC1   33406.8  26224.5   37612.2
      RC2   46706.5  36193.7   51721.4
```

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
