### PR TITLE
Make returned matrix non-writeable

### DIFF
--- a/pyvrp/search/neighbourhood.py
+++ b/pyvrp/search/neighbourhood.py
@@ -108,8 +108,7 @@ def _compute_proximity(
     data: ProblemData, weight_wait_time: float, weight_time_warp: float
 ) -> np.ndarray[float]:
     """
-    Computes proximity for neighborhood. Proximity is based on Vidal et al.
-    (2013).
+    Computes proximity for neighborhood. Proximity is based on [1]_.
 
     Parameters
     ----------

--- a/pyvrp/search/neighbourhood.py
+++ b/pyvrp/search/neighbourhood.py
@@ -133,17 +133,17 @@ def _compute_proximity(
     """
     clients = [data.client(idx) for idx in range(data.num_clients + 1)]
 
-    early = np.array([client.tw_early for client in clients])
-    late = np.array([client.tw_late for client in clients])
-    service = np.array([client.service_duration for client in clients])
-    prize = np.array([client.prize for client in clients])
+    early = np.asarray([client.tw_early for client in clients])
+    late = np.asarray([client.tw_late for client in clients])
+    service = np.asarray([client.service_duration for client in clients])
+    prize = np.asarray([client.prize for client in clients])
     duration = np.asarray(data.duration_matrix(), dtype=float)
 
     min_wait_time = early[..., :] - duration - service[:, ...] - late[:, ...]
     min_time_warp = early[:, ...] + service[:, ...] + duration - late[..., :]
 
     return (
-        data.distance_matrix()
+        np.asarray(data.distance_matrix(), dtype=float)
         + weight_wait_time * np.maximum(min_wait_time, 0)
         + weight_time_warp * np.maximum(min_time_warp, 0)
         - prize[..., :]

--- a/pyvrp/search/neighbourhood.py
+++ b/pyvrp/search/neighbourhood.py
@@ -108,7 +108,8 @@ def _compute_proximity(
     data: ProblemData, weight_wait_time: float, weight_time_warp: float
 ) -> np.ndarray[float]:
     """
-    Computes proximity for neighborhood. Proximity is based on [1]_.
+    Computes proximity for neighborhood. Proximity is based on [1]_, with
+    modification for additional VRP variants.
 
     Parameters
     ----------

--- a/pyvrp/tests/test_ProblemData.py
+++ b/pyvrp/tests/test_ProblemData.py
@@ -202,3 +202,21 @@ def test_matrix_access():
         for to in range(size):
             assert_allclose(data.dist(frm, to), dist_mat[frm, to])
             assert_allclose(data.duration(frm, to), dur_mat[frm, to])
+
+
+def test_matrices_are_not_writeable():
+    data = ProblemData(
+        clients=[Client(x=0, y=0)],
+        vehicle_types=[VehicleType(1, 2)],
+        distance_matrix=np.array([[0]]),
+        duration_matrix=np.array([[0]]),
+    )
+
+    dist_mat = data.distance_matrix()
+    dur_mat = data.duration_matrix()
+
+    with assert_raises(ValueError):
+        dist_mat[0, 0] = 1_000
+
+    with assert_raises(ValueError):
+        dur_mat[0, 0] = 1_000


### PR DESCRIPTION
This PR closes #344, and improves the matrix type casting a bit. In particular, calling `data.distance_matrix()` and `data.duration_matrix()` from Python no longer copies the underlying matrices.

<details>

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
