### PR TITLE
Benchmark v0.6.0

### DIFF
--- a/docs/source/setup/benchmarks.rst
+++ b/docs/source/setup/benchmarks.rst
@@ -20,6 +20,11 @@ The configuration files used for benchmarking are ``configs/cvrp.toml`` (for CVR
      - CVRP
      - VRPTW
      - PC-VRPTW
+   * - 31 August 2023
+     - `0.6.0 <https://github.com/PyVRP/PyVRP/tree/7ce7bfe66cb4930496dab412eb0f1999b18fbfa8>`_
+     - TODO
+     - TODO
+     - TODO
    * - 1 August 2023
      - `0.5.0 <https://github.com/PyVRP/PyVRP/tree/d4799a810a8cf7d16ea2c8871204bdfb3a896d06>`_
      - 0.22%

--- a/docs/source/setup/benchmarks.rst
+++ b/docs/source/setup/benchmarks.rst
@@ -22,7 +22,7 @@ The configuration files used for benchmarking are ``configs/cvrp.toml`` (for CVR
      - PC-VRPTW
    * - 31 August 2023
      - `0.6.0 <https://github.com/PyVRP/PyVRP/tree/7ce7bfe66cb4930496dab412eb0f1999b18fbfa8>`_
-     - TODO
+     - 0.24%
      - TODO
      - TODO
    * - 1 August 2023

--- a/docs/source/setup/benchmarks.rst
+++ b/docs/source/setup/benchmarks.rst
@@ -23,8 +23,8 @@ The configuration files used for benchmarking are ``configs/cvrp.toml`` (for CVR
    * - 31 August 2023
      - `0.6.0 <https://github.com/PyVRP/PyVRP/tree/7ce7bfe66cb4930496dab412eb0f1999b18fbfa8>`_
      - 0.24%
-     - TODO
-     - TODO
+     - 0.54%
+     - 0.43%
    * - 1 August 2023
      - `0.5.0 <https://github.com/PyVRP/PyVRP/tree/d4799a810a8cf7d16ea2c8871204bdfb3a896d06>`_
      - 0.22%


### PR DESCRIPTION
This PR updates the benchmark for PyVRP v0.6.0.

- CVRP is a bit worse because of using the new SREX/local search combination (#312 and #354).
- VRPTW is also a bit worse, perhaps for the same reason.
- PC-VRPTW is much worse. No idea why.