### PR TITLE
Evaluate fixed costs in TwoOpt

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ ubuntu-20.04, windows-2019, macos-11 ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install rtools
         if: ${{ runner.os == 'Windows' }}
         run: |
@@ -39,7 +39,7 @@ jobs:
     needs: [ build ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,7 @@ jobs:
           - compiler-version: latest
             python-version: '3.8'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/DOC.yml
+++ b/.github/workflows/DOC.yml
@@ -22,7 +22,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up pages
         uses: actions/configure-pages@v3
       - name: Set up Python

--- a/pyvrp/cpp/search/TwoOpt.cpp
+++ b/pyvrp/cpp/search/TwoOpt.cpp
@@ -64,6 +64,21 @@ Cost TwoOpt::evalBetweenRoutes(Route::Node *U,
 
     Cost deltaCost = static_cast<Cost>(proposed - current);
 
+    // We're going to incur fixed cost if a route is currently empty but
+    // becomes non-empty due to the proposed move.
+    if (uRoute->empty() && U->isDepot() && !n(V)->isDepot())
+        deltaCost += uRoute->fixedCost();
+
+    if (vRoute->empty() && V->isDepot() && !n(U)->isDepot())
+        deltaCost += vRoute->fixedCost();
+
+    // We lose fixed cost if a route becomes empty due to the proposed move.
+    if (!uRoute->empty() && U->isDepot() && n(V)->isDepot())
+        deltaCost -= uRoute->fixedCost();
+
+    if (!vRoute->empty() && V->isDepot() && n(U)->isDepot())
+        deltaCost -= vRoute->fixedCost();
+
     if (uRoute->isFeasible() && vRoute->isFeasible() && deltaCost >= 0)
         return deltaCost;
 

--- a/pyvrp/search/tests/test_TwoOpt.py
+++ b/pyvrp/search/tests/test_TwoOpt.py
@@ -163,8 +163,8 @@ def test_within_route_move(ok_small):
 
 def test_move_involving_empty_routes():
     """
-    This test checks that a 2-OPT move, which either involves an empty route
-    or turns a non-empty route into an empty route, is correctly evaluated.
+    This test checks that a 2-OPT move that turns an empty route into a
+    non-empty route (or vice-versa) is correctly evaluated.
     """
     data = ProblemData(
         clients=[Client(x=0, y=0), Client(x=1, y=1), Client(x=1, y=0)],
@@ -191,5 +191,5 @@ def test_move_involving_empty_routes():
 
     # This move creates routes (depot -> depot) and (depot -> 1 -> 2 -> depot),
     # turning route 1 into an empty route, while turning route 2 into a
-    # non-empty one. The fixed cost incurred is thus 100 - 10 = 90.
+    # non-empty route. The total fixed cost incurred is thus 100 - 10 = 90.
     assert_allclose(op.evaluate(route1[0], route2[0], cost_eval), 90)

--- a/pyvrp/search/tests/test_TwoOpt.py
+++ b/pyvrp/search/tests/test_TwoOpt.py
@@ -185,11 +185,36 @@ def test_move_involving_empty_routes():
     op = TwoOpt(data)
     cost_eval = CostEvaluator(0, 0)
 
+    # This move does not change the route structure, so the delta cost is 0.
+    assert_allclose(op.evaluate(route1[2], route2[0], cost_eval), 0)
+
     # This move creates routes (depot -> 1 -> depot) and (depot -> 2 -> depot),
-    # turning route 2 into a non-empty route and thus incurring its fixed cost.
+    # making route 2 non-empty and thus incurring its fixed cost of 100.
     assert_allclose(op.evaluate(route1[1], route2[0], cost_eval), 100)
 
     # This move creates routes (depot -> depot) and (depot -> 1 -> 2 -> depot),
-    # turning route 1 into an empty route, while turning route 2 into a
-    # non-empty route. The total fixed cost incurred is thus 100 - 10 = 90.
+    # making route 1 empty, while making route 2 non-empty. The total fixed
+    # cost incurred is thus -10 + 100 = 90.
     assert_allclose(op.evaluate(route1[0], route2[0], cost_eval), 90)
+
+    # Now we reverse the visits of route 1 and 2, so that we can hit the cases
+    # where route 1 is empty.
+    route1.clear()
+
+    for loc in [1, 2]:
+        route2.append(Node(loc=loc))
+
+    route1.update()  # depot -> depot
+    route2.update()  # depot -> 1 -> 2 -> depot
+
+    # This move does not change the route structure, so the delta cost is 0.
+    assert_allclose(op.evaluate(route1[0], route2[2], cost_eval), 0)
+
+    # This move creates routes (depot -> 1 -> depot) and (depot -> 2 -> depot),
+    # making route 1 non-empty and thus incurring its fixed cost of 10.
+    assert_allclose(op.evaluate(route1[0], route2[1], cost_eval), 10)
+
+    # This move creates routes (depot -> 1 -> 2 -> depot) and (depot -> depot),
+    # making route 1 non-empty, while making route 2 empty. The total fixed
+    # cost incurred is thus 10 - 100 = -90.
+    assert_allclose(op.evaluate(route1[0], route2[0], cost_eval), -90)

--- a/pyvrp/search/tests/test_TwoOpt.py
+++ b/pyvrp/search/tests/test_TwoOpt.py
@@ -210,7 +210,7 @@ def test_move_involving_empty_routes():
     # This move does not change the route structure, so the delta cost is 0.
     assert_allclose(op.evaluate(route1[0], route2[2], cost_eval), 0)
 
-    # This move creates routes (depot -> 1 -> depot) and (depot -> 2 -> depot),
+    # This move creates routes (depot -> 2 -> depot) and (depot -> 1 -> depot),
     # making route 1 non-empty and thus incurring its fixed cost of 10.
     assert_allclose(op.evaluate(route1[0], route2[1], cost_eval), 10)
 

--- a/pyvrp/search/tests/test_TwoOpt.py
+++ b/pyvrp/search/tests/test_TwoOpt.py
@@ -1,11 +1,13 @@
 from typing import List
 
 import numpy as np
-from numpy.testing import assert_, assert_equal
+from numpy.testing import assert_, assert_allclose, assert_equal
 from pytest import mark
 
 from pyvrp import (
+    Client,
     CostEvaluator,
+    ProblemData,
     RandomNumberGenerator,
     Solution,
     VehicleType,
@@ -149,7 +151,7 @@ def test_within_route_move(ok_small):
     # Load remains the same, but the time warp decreases substantially as well:
     # from 3633 (due to visiting client 3 far too late) to 0. This results in
     # a total delta cost of -3633 + 5176 - 6270 = -4727.
-    assert_equal(two_opt.evaluate(nodes[4], nodes[3], cost_eval), -4_727)
+    assert_allclose(two_opt.evaluate(nodes[4], nodes[3], cost_eval), -4_727)
 
     # Check that applying the proposed move indeed creates the correct route.
     two_opt.apply(nodes[4], nodes[3])
@@ -157,3 +159,37 @@ def test_within_route_move(ok_small):
     assert_equal(route[2].client, 3)
     assert_equal(route[3].client, 2)
     assert_equal(route[4].client, 1)
+
+
+def test_move_involving_empty_routes():
+    """
+    This test checks that a 2-OPT move, which either involves an empty route
+    or turns a non-empty route into an empty route, is correctly evaluated.
+    """
+    data = ProblemData(
+        clients=[Client(x=0, y=0), Client(x=1, y=1), Client(x=1, y=0)],
+        vehicle_types=[VehicleType(0, 1, 10), VehicleType(0, 1, 100)],
+        distance_matrix=np.zeros((3, 3), dtype=int),
+        duration_matrix=np.zeros((3, 3), dtype=int),
+    )
+
+    route1 = Route(data, idx=0, vehicle_type=0)
+    route2 = Route(data, idx=1, vehicle_type=1)
+
+    for loc in [1, 2]:
+        route1.append(Node(loc=loc))
+
+    route1.update()  # depot -> 1 -> 2 -> depot
+    route2.update()  # depot -> depot
+
+    op = TwoOpt(data)
+    cost_eval = CostEvaluator(0, 0)
+
+    # This move creates routes (depot -> 1 -> depot) and (depot -> 2 -> depot),
+    # turning route 2 into a non-empty route and thus incurring its fixed cost.
+    assert_allclose(op.evaluate(route1[1], route2[0], cost_eval), 100)
+
+    # This move creates routes (depot -> depot) and (depot -> 1 -> 2 -> depot),
+    # turning route 1 into an empty route, while turning route 2 into a
+    # non-empty one. The fixed cost incurred is thus 100 - 10 = 90.
+    assert_allclose(op.evaluate(route1[0], route2[0], cost_eval), 90)

--- a/pyvrp/tests/test_Model.py
+++ b/pyvrp/tests/test_Model.py
@@ -339,6 +339,31 @@ def test_model_solves_instance_with_zero_or_one_clients():
     assert_equal(solution, [[1]])
 
 
+def test_model_solves_small_instance_with_fixed_costs():
+    """
+    High-level test that creates and solves a small instance with vehicle fixed
+    costs, to see if the model (and thus the underlying solution algorithm)
+    can handle that. This test exercises the bug identified in issue #380.
+    Before fixing this bug, the solver would hang on this instance.
+    """
+    m = Model()
+
+    for idx in range(2):
+        m.add_vehicle_type(capacity=0, num_available=2, fixed_cost=10)
+
+    m.add_depot(x=0, y=0, tw_early=0, tw_late=40)
+
+    for idx in range(5):
+        m.add_client(x=idx, y=idx, service_duration=1, tw_early=0, tw_late=20)
+
+    for frm in m.locations:
+        for to in m.locations:
+            m.add_edge(frm, to, distance=0, duration=5)
+
+    res = m.solve(stop=MaxIterations(2000))
+    assert_(res.is_feasible())
+
+
 def test_model_solves_small_instance_with_shift_durations():
     """
     High-level test that creates and solves a small instance with shift

--- a/pyvrp/tests/test_Model.py
+++ b/pyvrp/tests/test_Model.py
@@ -349,7 +349,7 @@ def test_model_solves_small_instance_with_fixed_costs():
     m = Model()
 
     for idx in range(2):
-        m.add_vehicle_type(capacity=0, num_available=2, fixed_cost=10)
+        m.add_vehicle_type(capacity=0, num_available=5, fixed_cost=10)
 
     m.add_depot(x=0, y=0, tw_early=0, tw_late=40)
 
@@ -360,7 +360,7 @@ def test_model_solves_small_instance_with_fixed_costs():
         for to in m.locations:
             m.add_edge(frm, to, distance=0, duration=5)
 
-    res = m.solve(stop=MaxIterations(2000))
+    res = m.solve(stop=MaxIterations(100))
     assert_(res.is_feasible())
 
 


### PR DESCRIPTION
This PR fixes the bug identified in #380, which was caused by TwoOpt not considering fixed costs.