### PR TITLE
Don't re-open namespace std for specialisations

### DIFF
--- a/pyvrp/cpp/Measure.h
+++ b/pyvrp/cpp/Measure.h
@@ -187,9 +187,8 @@ std::ostream &operator<<(std::ostream &out, pyvrp::Measure<Type> const measure)
 }
 
 // Specialisations for hashing and numerical limits.
-namespace std
-{
-template <pyvrp::MeasureType Type> struct hash<pyvrp::Measure<Type>>
+
+template <pyvrp::MeasureType Type> struct std::hash<pyvrp::Measure<Type>>
 {
     size_t operator()(pyvrp::Measure<Type> const measure) const
     {
@@ -204,7 +203,8 @@ template <pyvrp::MeasureType Type> struct hash<pyvrp::Measure<Type>>
     }
 };
 
-template <pyvrp::MeasureType Type> class numeric_limits<pyvrp::Measure<Type>>
+template <pyvrp::MeasureType Type>
+class std::numeric_limits<pyvrp::Measure<Type>>
 {
 public:
     static pyvrp::Value max()
@@ -217,6 +217,5 @@ public:
         return std::numeric_limits<pyvrp::Value>::min();
     }
 };
-}  // namespace std
 
 #endif  // PYVRP_MEASURE_H

--- a/pyvrp/cpp/Solution.h
+++ b/pyvrp/cpp/Solution.h
@@ -456,9 +456,7 @@ std::ostream &operator<<(std::ostream &out, pyvrp::Solution const &sol);
 std::ostream &operator<<(std::ostream &out,
                          pyvrp::Solution::Route const &route);
 
-namespace std
-{
-template <> struct hash<pyvrp::Solution>
+template <> struct std::hash<pyvrp::Solution>
 {
     size_t operator()(pyvrp::Solution const &sol) const
     {
@@ -471,6 +469,5 @@ template <> struct hash<pyvrp::Solution>
         return res;
     }
 };
-}  // namespace std
 
 #endif  // PYVRP_SOLUTION_H


### PR DESCRIPTION
I read [this blog post](https://quuxplusone.github.io/blog/2021/10/27/dont-reopen-namespace-std/) on the train just yet, and they make some good points. I realised we do do this, but it's trivial to change this around so it also works without re-opening `namespace std`. This PR makes the required changes.
