### PR TITLE
Reduce VehicleType struct size

### DIFF
--- a/pyvrp/cpp/ProblemData.cpp
+++ b/pyvrp/cpp/ProblemData.cpp
@@ -47,8 +47,8 @@ ProblemData::VehicleType::VehicleType(Load capacity,
                                       Cost fixedCost,
                                       std::optional<Duration> twEarly,
                                       std::optional<Duration> twLate)
-    : capacity(capacity),
-      numAvailable(numAvailable),
+    : numAvailable(numAvailable),
+      capacity(capacity),
       fixedCost(fixedCost),
       twEarly(twEarly),
       twLate(twLate)

--- a/pyvrp/cpp/ProblemData.h
+++ b/pyvrp/cpp/ProblemData.h
@@ -158,9 +158,9 @@ public:
      */
     struct VehicleType
     {
-        Load const capacity;        // This type's vehicle capacity
         size_t const numAvailable;  // Available vehicles of this type
         size_t const depot = 0;     // Departure and return depot location
+        Load const capacity;        // This type's vehicle capacity
         Cost const fixedCost;       // Fixed cost of using this vehicle type
         std::optional<Duration> const twEarly;  // Start of shift
         std::optional<Duration> const twLate;   // End of shift


### PR DESCRIPTION
This PR reduces the packing of the `VehicleType` struct a bit, which reduces its overall size from 48 to 40 bytes. That's a bit smaller and should fit better on a cache line. The change is purely internal to the layout of the struct, so this does not break anything.

<details>

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
