### PR TITLE
Update docblock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ codecov = "*"
 meson = "^1.0.0"
 ninja = "^1.11.1"
 mypy = "^0.991"
-docblock = "^0.0.5"
+docblock = "^0.1.0"
 
 
 [tool.poetry.scripts]


### PR DESCRIPTION
I was toying with `alignas`, and realised `docblock` did not yet support that. This caused documentation extraction to fail. I just fixed the problem upstream, and this PR updates our dependency on `docblock` to the latest version.

<details>

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
