### PR TITLE
Add name fields

### DIFF
--- a/pyvrp/Model.py
+++ b/pyvrp/Model.py
@@ -117,6 +117,7 @@ class Model:
         release_time: int = 0,
         prize: int = 0,
         required: bool = True,
+        name: str = "",
     ) -> Client:
         """
         Adds a client with the given attributes to the model. Returns the
@@ -132,6 +133,7 @@ class Model:
             release_time,
             prize,
             required,
+            name,
         )
 
         self._clients.append(client)
@@ -143,12 +145,13 @@ class Model:
         y: int,
         tw_early: int = 0,
         tw_late: int = 0,
+        name: str = "",
     ) -> Depot:
         """
         Adds a depot with the given attributes to the model. Returns the
         created :class:`~pyvrp._pyvrp.Client` instance.
         """
-        depot = Depot(x, y, tw_early=tw_early, tw_late=tw_late)
+        depot = Depot(x, y, tw_early=tw_early, tw_late=tw_late, name=name)
         self._depots.append(depot)
         return depot
 
@@ -193,6 +196,7 @@ class Model:
         tw_early: Optional[int] = None,
         tw_late: Optional[int] = None,
         max_duration: Optional[int] = None,
+        name: str = "",
     ) -> VehicleType:
         """
         Adds a vehicle type with the given attributes to the model. Returns the
@@ -224,6 +228,7 @@ class Model:
             tw_early,
             tw_late,
             max_duration,
+            name,
         )
 
         self._vehicle_types.append(vehicle_type)

--- a/pyvrp/_pyvrp.pyi
+++ b/pyvrp/_pyvrp.pyi
@@ -33,6 +33,7 @@ class Client:
     release_time: int
     prize: int
     required: bool
+    name: str
     def __init__(
         self,
         x: int,
@@ -44,6 +45,7 @@ class Client:
         release_time: int = 0,
         prize: int = 0,
         required: bool = True,
+        name: str = "",
     ) -> None: ...
 
 class VehicleType:
@@ -54,6 +56,7 @@ class VehicleType:
     tw_early: Optional[int]
     tw_late: Optional[int]
     max_duration: Optional[int]
+    name: str
     def __init__(
         self,
         num_available: int = 1,
@@ -63,6 +66,7 @@ class VehicleType:
         tw_early: Optional[int] = None,
         tw_late: Optional[int] = None,
         max_duration: Optional[int] = None,
+        name: str = "",
     ) -> None: ...
 
 class ProblemData:

--- a/pyvrp/cpp/ProblemData.cpp
+++ b/pyvrp/cpp/ProblemData.cpp
@@ -17,9 +17,6 @@ namespace
 static char *duplicate(const char *src)
 {
     char *dst = new char[std::strlen(src) + 1];  // space for src + null
-    if (!dst)
-        return dst;
-
     std::strcpy(dst, src);
     return dst;
 }

--- a/pyvrp/cpp/ProblemData.cpp
+++ b/pyvrp/cpp/ProblemData.cpp
@@ -15,7 +15,8 @@ ProblemData::Client::Client(Coordinate x,
                             Duration twLate,
                             Duration releaseTime,
                             Cost prize,
-                            bool required)
+                            bool required,
+                            std::string name)
     : x(x),
       y(y),
       demand(demand),
@@ -24,6 +25,7 @@ ProblemData::Client::Client(Coordinate x,
       twLate(twLate),
       releaseTime(releaseTime),
       prize(prize),
+      name(name),
       required(required)
 {
     if (demand < 0)
@@ -48,13 +50,15 @@ ProblemData::VehicleType::VehicleType(size_t numAvailable,
                                       Cost fixedCost,
                                       std::optional<Duration> twEarly,
                                       std::optional<Duration> twLate,
-                                      std::optional<Duration> maxDuration)
+                                      std::optional<Duration> maxDuration,
+                                      std::string name)
     : numAvailable(numAvailable),
       depot(depot),
       capacity(capacity),
       fixedCost(fixedCost),
       twEarly(twEarly),
       twLate(twLate),
+      name(name),
       maxDuration(maxDuration.value_or(std::numeric_limits<Duration>::max()))
 {
     if (numAvailable == 0)

--- a/pyvrp/cpp/ProblemData.cpp
+++ b/pyvrp/cpp/ProblemData.cpp
@@ -14,7 +14,7 @@ namespace
 // which my compiler does not (yet) have. See here for the actual recipe:
 // https://stackoverflow.com/a/252802/4316405 (modified to use new instead of
 // malloc).
-static char *duplicate(const char *src)
+static char *duplicate(char const *src)
 {
     char *dst = new char[std::strlen(src) + 1];  // space for src + null
     std::strcpy(dst, src);

--- a/pyvrp/cpp/ProblemData.h
+++ b/pyvrp/cpp/ProblemData.h
@@ -7,6 +7,7 @@
 #include <cassert>
 #include <iosfwd>
 #include <optional>
+#include <string>
 #include <vector>
 
 namespace pyvrp
@@ -52,6 +53,7 @@ public:
      *    release_time: int = 0,
      *    prize: int = 0,
      *    required: bool = True,
+     *    name: str = "",
      * )
      *
      * Simple data object storing all client data as (read-only) properties.
@@ -84,6 +86,8 @@ public:
      * required
      *     Whether this client must be part of a feasible solution. Default
      *     True.
+     * name
+     *     Free-form name field for this client. Default empty.
      */
     struct Client
     {
@@ -94,8 +98,9 @@ public:
         Duration const twEarly;      // Earliest possible start of service
         Duration const twLate;       // Latest possible start of service
         Duration const releaseTime;  // Earliest possible time to leave depot
-        Cost const prize = 0;        // Prize for visiting this client
-        bool const required = true;  // Must client be in solution?
+        Cost const prize;            // Prize for visiting this client
+        std::string const name;      // Location name (for reference)
+        bool const required;         // Must client be in solution?
 
         Client(Coordinate x,
                Coordinate y,
@@ -105,7 +110,8 @@ public:
                Duration twLate = 0,
                Duration releaseTime = 0,
                Cost prize = 0,
-               bool required = true);
+               bool required = true,
+               std::string name = "");
     };
 
     /**
@@ -117,6 +123,7 @@ public:
      *     tw_early: Optional[int] = None,
      *     tw_late: Optional[int] = None,
      *     max_duration: Optional[int] = None,
+     *     name: str = "",
      * )
      *
      * Simple data object storing all vehicle type data as properties.
@@ -148,6 +155,8 @@ public:
      *     time if not given.
      * max_duration
      *     Maximum route duration. Unconstrained if not explicitly set.
+     * name
+     *     Free-form name field for this vehicle type. Default empty.
      *
      * Attributes
      * ----------
@@ -166,6 +175,8 @@ public:
      * max_duration
      *     Maximum duration of the route this vehicle type is assigned to. This
      *     is a very large number when the maximum duration is unconstrained.
+     * name
+     *     Free-form name field for this vehicle type.
      */
     struct VehicleType
     {
@@ -175,7 +186,8 @@ public:
         Cost const fixedCost;       // Fixed cost of using this vehicle type
         std::optional<Duration> const twEarly;  // Start of shift
         std::optional<Duration> const twLate;   // End of shift
-        Duration const maxDuration;
+        std::string const name;                 // Type name (for reference)
+        Duration const maxDuration;             // Maximum route duration
 
         VehicleType(size_t numAvailable = 1,
                     Load capacity = 0,
@@ -183,7 +195,8 @@ public:
                     Cost fixedCost = 0,
                     std::optional<Duration> twEarly = std::nullopt,
                     std::optional<Duration> twLate = std::nullopt,
-                    std::optional<Duration> maxDuration = std::nullopt);
+                    std::optional<Duration> maxDuration = std::nullopt,
+                    std::string name = "");
     };
 
 private:

--- a/pyvrp/cpp/ProblemData.h
+++ b/pyvrp/cpp/ProblemData.h
@@ -7,7 +7,6 @@
 #include <cassert>
 #include <iosfwd>
 #include <optional>
-#include <string>
 #include <vector>
 
 namespace pyvrp
@@ -99,7 +98,7 @@ public:
         Duration const twLate;       // Latest possible start of service
         Duration const releaseTime;  // Earliest possible time to leave depot
         Cost const prize;            // Prize for visiting this client
-        std::string const name;      // Location name (for reference)
+        char const *name;            // Location name (for reference)
         bool const required;         // Must client be in solution?
 
         Client(Coordinate x,
@@ -111,7 +110,15 @@ public:
                Duration releaseTime = 0,
                Cost prize = 0,
                bool required = true,
-               std::string name = "");
+               char const *name = "");
+
+        Client(Client const &client);
+        Client(Client &&client);
+
+        Client &operator=(Client const &client) = delete;
+        Client &operator=(Client &&client) = delete;
+
+        ~Client();
     };
 
     /**
@@ -186,7 +193,7 @@ public:
         Cost const fixedCost;       // Fixed cost of using this vehicle type
         std::optional<Duration> const twEarly;  // Start of shift
         std::optional<Duration> const twLate;   // End of shift
-        std::string const name;                 // Type name (for reference)
+        char const *name;                       // Type name (for reference)
         Duration const maxDuration;             // Maximum route duration
 
         VehicleType(size_t numAvailable = 1,
@@ -196,7 +203,15 @@ public:
                     std::optional<Duration> twEarly = std::nullopt,
                     std::optional<Duration> twLate = std::nullopt,
                     std::optional<Duration> maxDuration = std::nullopt,
-                    std::string name = "");
+                    char const *name = "");
+
+        VehicleType(VehicleType const &vehicleType);
+        VehicleType(VehicleType &&vehicleType);
+
+        VehicleType &operator=(VehicleType const &vehicleType) = delete;
+        VehicleType &operator=(VehicleType &&vehicleType) = delete;
+
+        ~VehicleType();
     };
 
 private:

--- a/pyvrp/cpp/bindings.cpp
+++ b/pyvrp/cpp/bindings.cpp
@@ -88,9 +88,7 @@ PYBIND11_MODULE(_pyvrp, m)
                       py::return_value_policy::reference_internal)
         .def(
             "__str__",
-            [](ProblemData::Client const &client) -> py::str {
-                return client.name;
-            },
+            [](ProblemData::Client const &client) { return client.name; },
             py::return_value_policy::reference_internal);
 
     py::class_<ProblemData::VehicleType>(
@@ -123,7 +121,7 @@ PYBIND11_MODULE(_pyvrp, m)
                       py::return_value_policy::reference_internal)
         .def(
             "__str__",
-            [](ProblemData::VehicleType const &vehType) -> py::str {
+            [](ProblemData::VehicleType const &vehType) {
                 return vehType.name;
             },
             py::return_value_policy::reference_internal);

--- a/pyvrp/cpp/bindings.cpp
+++ b/pyvrp/cpp/bindings.cpp
@@ -16,6 +16,7 @@
 #include <pybind11/stl.h>
 
 #include <sstream>
+#include <string>
 
 namespace py = pybind11;
 
@@ -62,7 +63,8 @@ PYBIND11_MODULE(_pyvrp, m)
                       pyvrp::Duration,
                       pyvrp::Duration,
                       pyvrp::Cost,
-                      bool>(),
+                      bool,
+                      std::string>(),
              py::arg("x"),
              py::arg("y"),
              py::arg("demand") = 0,
@@ -71,7 +73,8 @@ PYBIND11_MODULE(_pyvrp, m)
              py::arg("tw_late") = 0,
              py::arg("release_time") = 0,
              py::arg("prize") = 0,
-             py::arg("required") = true)
+             py::arg("required") = true,
+             py::arg("name") = "")
         .def_readonly("x", &ProblemData::Client::x)
         .def_readonly("y", &ProblemData::Client::y)
         .def_readonly("demand", &ProblemData::Client::demand)
@@ -80,7 +83,10 @@ PYBIND11_MODULE(_pyvrp, m)
         .def_readonly("tw_late", &ProblemData::Client::twLate)
         .def_readonly("release_time", &ProblemData::Client::releaseTime)
         .def_readonly("prize", &ProblemData::Client::prize)
-        .def_readonly("required", &ProblemData::Client::required);
+        .def_readonly("required", &ProblemData::Client::required)
+        .def_readonly("name", &ProblemData::Client::name)
+        .def("__str__",
+             [](ProblemData::Client const &client) { return client.name; });
 
     py::class_<ProblemData::VehicleType>(
         m, "VehicleType", DOC(pyvrp, ProblemData, VehicleType))
@@ -90,21 +96,27 @@ PYBIND11_MODULE(_pyvrp, m)
                       pyvrp::Cost,
                       std::optional<pyvrp::Duration>,
                       std::optional<pyvrp::Duration>,
-                      std::optional<pyvrp::Duration>>(),
+                      std::optional<pyvrp::Duration>,
+                      std::string>(),
              py::arg("num_available") = 1,
              py::arg("capacity") = 0,
              py::arg("depot") = 0,
              py::arg("fixed_cost") = 0,
              py::arg("tw_early") = py::none(),
              py::arg("tw_late") = py::none(),
-             py::arg("max_duration") = py::none())
+             py::arg("max_duration") = py::none(),
+             py::arg("name") = "")
         .def_readonly("num_available", &ProblemData::VehicleType::numAvailable)
         .def_readonly("depot", &ProblemData::VehicleType::depot)
         .def_readonly("capacity", &ProblemData::VehicleType::capacity)
         .def_readonly("fixed_cost", &ProblemData::VehicleType::fixedCost)
         .def_readonly("tw_early", &ProblemData::VehicleType::twEarly)
         .def_readonly("tw_late", &ProblemData::VehicleType::twLate)
-        .def_readonly("max_duration", &ProblemData::VehicleType::maxDuration);
+        .def_readonly("max_duration", &ProblemData::VehicleType::maxDuration)
+        .def_readonly("name", &ProblemData::VehicleType::name)
+        .def("__str__", [](ProblemData::VehicleType const &vehType) {
+            return vehType.name;
+        });
 
     py::class_<ProblemData>(m, "ProblemData", DOC(pyvrp, ProblemData))
         .def(py::init<std::vector<ProblemData::Client> const &,

--- a/pyvrp/cpp/bindings.cpp
+++ b/pyvrp/cpp/bindings.cpp
@@ -16,7 +16,6 @@
 #include <pybind11/stl.h>
 
 #include <sstream>
-#include <string>
 
 namespace py = pybind11;
 
@@ -64,7 +63,7 @@ PYBIND11_MODULE(_pyvrp, m)
                       pyvrp::Duration,
                       pyvrp::Cost,
                       bool,
-                      std::string>(),
+                      char const *>(),
              py::arg("x"),
              py::arg("y"),
              py::arg("demand") = 0,
@@ -84,9 +83,15 @@ PYBIND11_MODULE(_pyvrp, m)
         .def_readonly("release_time", &ProblemData::Client::releaseTime)
         .def_readonly("prize", &ProblemData::Client::prize)
         .def_readonly("required", &ProblemData::Client::required)
-        .def_readonly("name", &ProblemData::Client::name)
-        .def("__str__",
-             [](ProblemData::Client const &client) { return client.name; });
+        .def_readonly("name",
+                      &ProblemData::Client::name,
+                      py::return_value_policy::reference_internal)
+        .def(
+            "__str__",
+            [](ProblemData::Client const &client) -> py::str {
+                return client.name;
+            },
+            py::return_value_policy::reference_internal);
 
     py::class_<ProblemData::VehicleType>(
         m, "VehicleType", DOC(pyvrp, ProblemData, VehicleType))
@@ -97,7 +102,7 @@ PYBIND11_MODULE(_pyvrp, m)
                       std::optional<pyvrp::Duration>,
                       std::optional<pyvrp::Duration>,
                       std::optional<pyvrp::Duration>,
-                      std::string>(),
+                      char const *>(),
              py::arg("num_available") = 1,
              py::arg("capacity") = 0,
              py::arg("depot") = 0,
@@ -113,10 +118,15 @@ PYBIND11_MODULE(_pyvrp, m)
         .def_readonly("tw_early", &ProblemData::VehicleType::twEarly)
         .def_readonly("tw_late", &ProblemData::VehicleType::twLate)
         .def_readonly("max_duration", &ProblemData::VehicleType::maxDuration)
-        .def_readonly("name", &ProblemData::VehicleType::name)
-        .def("__str__", [](ProblemData::VehicleType const &vehType) {
-            return vehType.name;
-        });
+        .def_readonly("name",
+                      &ProblemData::VehicleType::name,
+                      py::return_value_policy::reference_internal)
+        .def(
+            "__str__",
+            [](ProblemData::VehicleType const &vehType) -> py::str {
+                return vehType.name;
+            },
+            py::return_value_policy::reference_internal);
 
     py::class_<ProblemData>(m, "ProblemData", DOC(pyvrp, ProblemData))
         .def(py::init<std::vector<ProblemData::Client> const &,

--- a/pyvrp/tests/test_Model.py
+++ b/pyvrp/tests/test_Model.py
@@ -467,3 +467,23 @@ def test_model_solves_line_instance_with_multiple_depots():
     routes = res.best.get_routes()
     assert_equal(routes[0].visits(), [2, 3])
     assert_equal(routes[1].visits(), [5, 4])
+
+
+def test_client_depot_and_vehicle_type_name_fields():
+    """
+    Tests that name fields are properly passed to client, depot, and vehicle
+    types.
+    """
+    m = Model()
+
+    depot = m.add_depot(1, 1, name="depot1")
+    assert_equal(depot.name, "depot1")
+    assert_equal(str(depot), "depot1")
+
+    veh_type = m.add_vehicle_type(name="veh_type1")
+    assert_equal(veh_type.name, "veh_type1")
+    assert_equal(str(veh_type), "veh_type1")
+
+    client = m.add_client(1, 2, name="client1")
+    assert_equal(client.name, "client1")
+    assert_equal(str(client), "client1")

--- a/pyvrp/tests/test_ProblemData.py
+++ b/pyvrp/tests/test_ProblemData.py
@@ -18,15 +18,16 @@ from pyvrp import Client, ProblemData, VehicleType
         "tw_late",
         "release_time",
         "prize",
+        "name",
     ),
     [
-        (1, 1, 1, 1, 0, 1, 0, 0),  # normal
-        (1, 1, 1, 0, 0, 1, 0, 0),  # zero duration
-        (1, 1, 0, 1, 0, 1, 0, 0),  # zero demand
-        (1, 1, 1, 1, 0, 0, 0, 0),  # zero length time interval
-        (-1, -1, 1, 1, 0, 1, 0, 0),  # negative coordinates
-        (1, 1, 1, 1, 0, 1, 1, 0),  # positive release time
-        (0, 0, 1, 1, 0, 1, 0, 1),  # positive prize
+        (1, 1, 1, 1, 0, 1, 0, 0, "test name"),  # normal
+        (1, 1, 1, 0, 0, 1, 0, 0, "1234"),  # zero duration
+        (1, 1, 0, 1, 0, 1, 0, 0, "1,2,3,4"),  # zero demand
+        (1, 1, 1, 1, 0, 0, 0, 0, ""),  # zero length time interval
+        (-1, -1, 1, 1, 0, 1, 0, 0, ""),  # negative coordinates
+        (1, 1, 1, 1, 0, 1, 1, 0, ""),  # positive release time
+        (0, 0, 1, 1, 0, 1, 0, 1, ""),  # positive prize
     ],
 )
 def test_client_constructor_initialises_data_fields_correctly(
@@ -38,13 +39,22 @@ def test_client_constructor_initialises_data_fields_correctly(
     tw_late: int,
     release_time: int,
     prize: int,
+    name: str,
 ):
     """
     Tests that the access properties return the data that was given to the
     Client's constructor.
     """
     client = Client(
-        x, y, demand, service_duration, tw_early, tw_late, release_time, prize
+        x,
+        y,
+        demand,
+        service_duration,
+        tw_early,
+        tw_late,
+        release_time,
+        prize,
+        name=name,
     )
     assert_allclose(client.x, x)
     assert_allclose(client.y, y)
@@ -54,6 +64,9 @@ def test_client_constructor_initialises_data_fields_correctly(
     assert_allclose(client.tw_late, tw_late)
     assert_allclose(client.release_time, release_time)
     assert_allclose(client.prize, prize)
+
+    assert_equal(client.name, name)
+    assert_equal(str(client), name)
 
 
 @pytest.mark.parametrize(
@@ -466,6 +479,7 @@ def test_vehicle_type_default_values():
     assert_allclose(vehicle_type.fixed_cost, 0)
     assert_(vehicle_type.tw_early is None)
     assert_(vehicle_type.tw_late is None)
+    assert_equal(vehicle_type.name, "")
 
     # The C++ extensions can be compiled with support for either integer or
     # double precision. In each case, the default value for max_duration is
@@ -489,6 +503,7 @@ def test_vehicle_type_attribute_access():
         tw_early=17,
         tw_late=19,
         max_duration=23,
+        name="vehicle_type name",
     )
 
     assert_equal(vehicle_type.num_available, 7)
@@ -498,6 +513,9 @@ def test_vehicle_type_attribute_access():
     assert_allclose(vehicle_type.tw_early, 17)
     assert_allclose(vehicle_type.tw_late, 19)
     assert_allclose(vehicle_type.max_duration, 23)
+
+    assert_equal(vehicle_type.name, "vehicle_type name")
+    assert_equal(str(vehicle_type), "vehicle_type name")
 
 
 @pytest.mark.parametrize("idx", [5, 6])


### PR DESCRIPTION
This PR:

- [x] Closes #412.
- [x] Adds and passes relevant tests.
- [x] Has well-formatted code and documentation.

### Benchmarks on VRPTW

This PR w/ `std::string` (cbd36cebf38cf29739b37a8486cccbe265e9b863; 10x seeds, 1h; job ID 6975160):
```
               MEAN      MIN       MAX   COV
      inst
obj   C1    41365.0  41340.2   41406.6   0.0
      C2    16191.6  16188.8   16194.8   0.0
      R1    47279.6  47203.5   47411.3   0.1
      R2    27774.8  27731.4   27801.8   0.1
      RC1   44246.9  44190.2   44283.4   0.1
      RC2   23269.9  23253.1   23282.5   0.0
iters C1    59861.9  49358.3   66563.5   7.6
      C2    97626.2  77936.6  108538.2   9.6
      R1    32440.1  25192.6   36297.7  12.3
      R2    48749.3  35693.8   55939.6  13.1
      RC1   36444.3  26475.0   40933.9  13.5
      RC2   49916.8  37278.9   56831.7  14.3
```

From #411:
```
                MEAN      MIN       MAX   COV
      inst
obj   C1     41364.4  41339.2   41406.3   0.0
      C2     16190.8  16188.5   16193.2   0.0
      R1     47258.6  47186.1   47302.3   0.1
      R2     27766.2  27727.2   27796.0   0.1
      RC1    44235.4  44204.8   44253.1   0.0
      RC2    23266.7  23252.5   23302.3   0.1
iters C1     63203.5  47433.9   70698.7  12.6
      C2    106604.0  80918.5  119611.2  12.6
      R1     36559.1  27936.8   41311.5  13.1
      R2     54925.2  42722.3   62756.7  12.3
      RC1    39750.0  30405.4   44036.5  11.7
      RC2    56193.6  43259.6   61123.7  12.0
```

<details>

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
