### PR TITLE
Implement consistency checks in local search

### DIFF
--- a/build_extensions.py
+++ b/build_extensions.py
@@ -31,6 +31,11 @@ def parse_args():
         help="Double is more precise, integer faster. Defaults to 'integer'.",
     )
     parser.add_argument(
+        "--consistency_checks",
+        action="store_true",
+        help="Enable or disable consistency checks. Defaults to False.",
+    )
+    parser.add_argument(
         "--clean",
         action="store_true",
         help="Clean build and installation directories before building.",
@@ -85,6 +90,7 @@ def build(
     build_type: str,
     problem: str,
     precision: str,
+    consistency_checks: bool,
     additional: list[str],
 ):
     cwd = pathlib.Path.cwd()
@@ -95,6 +101,7 @@ def build(
         f"-Dproblem={problem}",
         f"-Dstrip={'true' if build_type == 'release' else 'false'}",
         f"-Dprecision={precision}",
+        f"-Dconsistency_checks={'true' if consistency_checks else 'false'}",
         *additional,
         # fmt: on
     ]
@@ -121,6 +128,7 @@ def main():
         args.build_type,
         args.problem,
         args.precision,
+        args.consistency_checks,
         args.additional,
     )
 

--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,13 @@ if get_option('precision') == 'double'  # default is integer
     add_project_arguments('-DPYVRP_DOUBLE_PRECISION', language: 'cpp')
 endif
 
+if get_option('consistency_checks')
+    add_project_arguments('-DPYVRP_CONSISTENCY_CHECKS', language: 'cpp')
+    # With this option, we also check for undefined behavior such as overflow
+    add_project_arguments('-fsanitize=undefined', language: 'cpp')
+    add_project_link_arguments('-fsanitize=undefined', language: 'cpp')
+endif
+
 # We first compile a common library that contains all regular, C++ code. This
 # is then linked against by the extension modules. We also define source and
 # installation directories here, as a shorthand.

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -13,3 +13,10 @@ option(
     choices: ['integer', 'double'], 
     description: 'Precision type to compile.'
 )
+
+option(
+    'consistency_checks',
+    type: 'boolean',
+    value: true,
+    description: 'Enable or disable consistency checks.'
+)

--- a/pyvrp/cpp/search/LocalSearch.h
+++ b/pyvrp/cpp/search/LocalSearch.h
@@ -72,6 +72,10 @@ class LocalSearch
     void intensify(CostEvaluator const &costEvaluator,
                    double overlapTolerance = 0.05);
 
+#ifdef PYVRP_CONSISTENCY_CHECKS
+    Cost getCost(CostEvaluator const &CostEvaluator) const;
+#endif
+
 public:
     /**
      * Adds a local search operator that works on node/client pairs U and V.


### PR DESCRIPTION
This PR adds a build option for optional internal consistency checks in local search. This helps catching bugs when introducing new features for which local search operators need to be adapted.
With the option enabled:
- Check that cost after applying local search move equals cost before + delta cost
- Check that solution is loaded correctly
- Add compiler checks for undefined behavior when using consistency checks

- [x] Adds and passes relevant tests.
- [x] Has well-formatted code and documentation.

<details>

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
