### PR TITLE
Fix multi-depot test

### DIFF
--- a/pyvrp/tests/test_Model.py
+++ b/pyvrp/tests/test_Model.py
@@ -463,7 +463,8 @@ def test_model_solves_line_instance_with_multiple_depots():
 
     # Test that there are two routes, with the clients closest to depot 0
     # assigned to the first route, and clients closest to depot 1 assigned to
-    # the second route.
+    # the second route. Route membership is compared using sets because the
+    # optimal visit order is not unique.
     routes = res.best.get_routes()
     assert_equal(set(routes[0].visits()), {2, 3})
     assert_equal(set(routes[1].visits()), {4, 5})

--- a/pyvrp/tests/test_Model.py
+++ b/pyvrp/tests/test_Model.py
@@ -465,8 +465,8 @@ def test_model_solves_line_instance_with_multiple_depots():
     # assigned to the first route, and clients closest to depot 1 assigned to
     # the second route.
     routes = res.best.get_routes()
-    assert_equal(routes[0].visits(), [2, 3])
-    assert_equal(routes[1].visits(), [5, 4])
+    assert_equal(set(routes[0].visits()), {2, 3})
+    assert_equal(set(routes[1].visits()), {4, 5})
 
 
 def test_client_depot_and_vehicle_type_name_fields():


### PR DESCRIPTION
This PR fixes the `test_model_solves_line_instance_with_multiple_depots` test, which has multiple optimal solutions.
Specifically, routes (2, 3) and (3, 2) have the same distance, as well as routes (4, 5) and (5, 4).

Because of different platform implementations of random shuffle (see #207) the mentioned test computes a different optimal solution on macOS than ubuntu (CI). The proposed change is to check the set of client visits instead of the ordered clients visits.