### PR TITLE
Fixes some typos, small imperfections

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
     orcid: "https://orcid.org/0000-0002-1837-1454"
 title: "PyVRP"
 version: "v0.5.0"
-date-released: "2023-10-12"
+date-released: "2023-08-02"
 doi: "10.1287/ijoc.2023.0055.cd"
 url: "https://github.com/PyVRP/PyVRP"
 preferred-citation:
@@ -29,5 +29,5 @@ preferred-citation:
     orcid: "https://orcid.org/0000-0002-1837-1454"
   title: "PyVRP: a high-performance VRP solver package"
   journal: "INFORMS Journal on Computing"
-  year: 2023
+  year: 2024
   doi: "10.1287/ijoc.2023.0055"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you are looking for help, please follow the instructions [here][3].
 
 If you use PyVRP in your research, please consider citing the following paper:
 
-> Wouda, N.A., L. Lan, and W. Kool (2023).
+> Wouda, N.A., L. Lan, and W. Kool (2024).
 > PyVRP: a high-performance VRP solver package.
 > _INFORMS Journal on Computing_, forthcoming.
 > https://doi.org/10.1287/ijoc.2023.0055
@@ -64,10 +64,10 @@ If you use PyVRP in your research, please consider citing the following paper:
 Or, using the following BibTeX entry:
 
 ```bibtex
-@article{Wouda_Lan_Kool_PyVRP_2023,
+@article{Wouda_Lan_Kool_PyVRP_2024,
   doi = {10.1287/ijoc.2023.0055},
   url = {https://doi.org/10.1287/ijoc.2023.0055},
-  year = {2023},
+  year = {2024},
   publisher = {INFORMS},
   author = {Niels A. Wouda and Leon Lan and Wouter Kool},
   title = {{PyVRP}: a high-performance {VRP} solver package},

--- a/docs/source/dev/new_vrp_variants.rst
+++ b/docs/source/dev/new_vrp_variants.rst
@@ -62,7 +62,7 @@ In the :mod:`pyvrp.search` module, either changes need to be made to the operato
 In the case of prize-collecting, it was the latter: we added support for evaluating (and applying) moves that inserted a client into the solution, or removed a client from it.
 The required evaluation logic was easy to write by looking at the implementation of :class:`~pyvrp.search._search.Exchange10`.
 
-With those changes in place, an basic implementation supporting the new VRP variant is typically already functional.
+With those changes in place, a basic implementation supporting the new VRP variant is typically already functional.
 This is more than sufficient for an initial patch, so please open a pull request around this time.
 To get that pull request merged, two more things are required:
 

--- a/docs/source/setup/citing.rst
+++ b/docs/source/setup/citing.rst
@@ -3,7 +3,7 @@ Citing PyVRP
 
 If you use PyVRP in your research, please consider citing the following paper:
 
-   Wouda, N.A., L. Lan, and W. Kool (2023). 
+   Wouda, N.A., L. Lan, and W. Kool (2024). 
    PyVRP: a high-performance VRP solver package. *INFORMS Journal on Computing*, forthcoming.
    `<https://doi.org/10.1287/ijoc.2023.0055>`_.
 
@@ -11,10 +11,10 @@ Or, using the following BibTeX entry:
 
 .. code-block:: latex
 
-   @article{Wouda_Lan_Kool_PyVRP_2023,
+   @article{Wouda_Lan_Kool_PyVRP_2024,
      doi = {10.1287/ijoc.2023.0055},
      url = {https://doi.org/10.1287/ijoc.2023.0055},
-     year = {2023},
+     year = {2024},
      publisher = {INFORMS},
      author = {Niels A. Wouda and Leon Lan and Wouter Kool},
      title = {{PyVRP}: a high-performance {VRP} solver package},

--- a/pyvrp/cli.py
+++ b/pyvrp/cli.py
@@ -82,13 +82,13 @@ def write_solution(where: Path, data: ProblemData, result: Result):
             for vehicle_type in data.vehicle_types()
         ]
 
-        routes = [f"Route {idx + 1}: " for idx in range(data.num_vehicles)]
+        routes = [f"Route #{idx + 1}: " for idx in range(data.num_vehicles)]
         for route in result.best.get_routes():
             visits = map(str, route.visits())
             vehicle = next(type2vehicle[route.vehicle_type()])
             routes[vehicle] += " ".join(visits)
 
-        fh.writelines(route + "\n" for route in routes)
+        fh.writelines(route.strip() + "\n" for route in routes)
         fh.write(f"Cost: {round(result.cost(), 2)}\n")
 
 

--- a/pyvrp/cli.py
+++ b/pyvrp/cli.py
@@ -82,13 +82,13 @@ def write_solution(where: Path, data: ProblemData, result: Result):
             for vehicle_type in data.vehicle_types()
         ]
 
-        routes = [f"Route #{idx + 1}: " for idx in range(data.num_vehicles)]
+        routes = [f"Route #{idx + 1}:" for idx in range(data.num_vehicles)]
         for route in result.best.get_routes():
             visits = map(str, route.visits())
             vehicle = next(type2vehicle[route.vehicle_type()])
-            routes[vehicle] += " ".join(visits)
+            routes[vehicle] += " " + " ".join(visits)
 
-        fh.writelines(route.strip() + "\n" for route in routes)
+        fh.writelines(route + "\n" for route in routes)
         fh.write(f"Cost: {round(result.cost(), 2)}\n")
 
 


### PR DESCRIPTION
This PR fixes minor imperfections:
- The year is wrong in the citation metadata; it's 2024 now and that's when the paper got published.
- The `Route {idx}: {visits}` should have a `#` before `{idx}` when printing solutions, and strip any superfluous whitespace.
- Fixes a typo in the docs.

<details>

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
