### PR TITLE
Do not copy TWS::merge arguments

### DIFF
--- a/pyvrp/cpp/TimeWindowSegment.h
+++ b/pyvrp/cpp/TimeWindowSegment.h
@@ -62,7 +62,7 @@ public:
     merge(Matrix<Duration> const &durationMatrix,
           TWS const &first,
           TWS const &second,
-          Args... args);
+          Args &&...args);
 
     /**
      * The total duration of this route segment.
@@ -150,7 +150,7 @@ TimeWindowSegment TimeWindowSegment::merge(
     [[maybe_unused]] Matrix<Duration> const &durationMatrix,
     [[maybe_unused]] TimeWindowSegment const &first,
     [[maybe_unused]] TimeWindowSegment const &second,
-    [[maybe_unused]] Args... args)
+    [[maybe_unused]] Args &&...args)
 {
 #ifdef PYVRP_NO_TIME_WINDOWS
     return {0, 0, 0, 0, 0, 0, 0};

--- a/pyvrp/cpp/bindings.cpp
+++ b/pyvrp/cpp/bindings.cpp
@@ -608,7 +608,7 @@ PYBIND11_MODULE(_pyvrp, m)
                     py::arg("first"),
                     py::arg("second"))
         .def_static("merge",
-                    &TWS::merge<TWS>,
+                    &TWS::merge<TWS const &>,
                     py::arg("duration_matrix"),
                     py::arg("first"),
                     py::arg("second"),


### PR DESCRIPTION
I'm not sure if this actually happens, but the forwarding reference should make it clear that we do not want to copy the TWS arguments.

<details>

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
