### PR TITLE
Default to int32_t, not int

### DIFF
--- a/pyvrp/cpp/Measure.h
+++ b/pyvrp/cpp/Measure.h
@@ -14,7 +14,7 @@ namespace pyvrp
 #ifdef PYVRP_DOUBLE_PRECISION
 using Value = double;
 #else
-using Value = int;
+using Value = int32_t;
 #endif
 
 enum class MeasureType

--- a/pyvrp/cpp/Measure.h
+++ b/pyvrp/cpp/Measure.h
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <cmath>
 #include <compare>
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <limits>


### PR DESCRIPTION
On the Python side we already assume in various places that our `int` types are 32 bits wide, but that is not explicit in the code yet. This PR sets `Value = int32_t`, which ensures the exact 4-byte width we already rely on.

<details>

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
