### PR TITLE
New README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ![PyVRP logo](docs/source/assets/images/logo.svg)
 
-[![PyPI version](https://badge.fury.io/py/pyvrp.svg)](https://badge.fury.io/py/pyvrp)
-[![CI](https://github.com/PyVRP/PyVRP/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/PyVRP/PyVRP/actions/workflows/CI.yml)
-[![DOC](https://github.com/PyVRP/PyVRP/actions/workflows/DOC.yml/badge.svg?branch=main)](https://pyvrp.org/)
-[![codecov](https://codecov.io/gh/PyVRP/PyVRP/branch/main/graph/badge.svg?token=G9JKIVZOHB)](https://codecov.io/gh/PyVRP/PyVRP)
-[![DOI:10.1287/ijoc.2023.0055](https://img.shields.io/badge/DOI-10.1287/ijoc.2023.0055-4CC61E.svg)](https://doi.org/10.1287/ijoc.2023.0055)
+[![PyPI version](https://img.shields.io/pypi/v/PyVRP?style=flat-square)](https://pypi.org/project/pyvrp/)
+[![CI](https://img.shields.io/github/actions/workflow/status/PyVRP/PyVRP/.github%2Fworkflows%2FCI.yml?branch=main&style=flat-square&label=CI)](https://github.com/PyVRP/PyVRP/actions/workflows/CI.yml)
+[![DOC](https://img.shields.io/github/actions/workflow/status/PyVRP/PyVRP/.github%2Fworkflows%2FDOC.yml?branch=main&style=flat-square&label=DOC)](https://pyvrp.org/)
+[![codecov](https://img.shields.io/codecov/c/github/PyVRP/PyVRP?style=flat-square&logo=codecov)](https://codecov.io/gh/PyVRP/PyVRP)
+[![DOI:10.1287/ijoc.2023.0055](https://img.shields.io/badge/DOI-ijoc.2023.0055-green?style=flat-square&color=blue)](https://doi.org/10.1287/ijoc.2023.0055)
 
 PyVRP is an open-source, state-of-the-art vehicle routing problem (VRP) solver.
 It currently supports VRPs with:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![PyVRP logo](docs/source/assets/images/logo.svg)
 
 [![PyPI version](https://img.shields.io/pypi/v/PyVRP?style=flat-square)](https://pypi.org/project/pyvrp/)
-[![CI](https://img.shields.io/github/actions/workflow/status/PyVRP/PyVRP/.github%2Fworkflows%2FCI.yml?branch=main&style=flat-square&label=CI)](https://github.com/PyVRP/PyVRP/actions/workflows/CI.yml)
-[![DOC](https://img.shields.io/github/actions/workflow/status/PyVRP/PyVRP/.github%2Fworkflows%2FDOC.yml?branch=main&style=flat-square&label=DOC)](https://pyvrp.org/)
+[![CI](https://img.shields.io/github/actions/workflow/status/PyVRP/PyVRP/.github%2Fworkflows%2FCI.yml?branch=main&style=flat-square&logo=github&label=CI)](https://github.com/PyVRP/PyVRP/actions/workflows/CI.yml)
+[![DOC](https://img.shields.io/github/actions/workflow/status/PyVRP/PyVRP/.github%2Fworkflows%2FDOC.yml?branch=main&style=flat-square&logo=github&label=DOC)](https://pyvrp.org/)
 [![codecov](https://img.shields.io/codecov/c/github/PyVRP/PyVRP?style=flat-square&logo=codecov)](https://codecov.io/gh/PyVRP/PyVRP)
 [![DOI:10.1287/ijoc.2023.0055](https://img.shields.io/badge/DOI-ijoc.2023.0055-green?style=flat-square&color=blue)](https://doi.org/10.1287/ijoc.2023.0055)
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ![PyVRP logo](docs/source/assets/images/logo.svg)
 
-[![PyPI version](https://img.shields.io/pypi/v/PyVRP?style=flat-square)](https://pypi.org/project/pyvrp/)
+[![PyPI version](https://img.shields.io/pypi/v/PyVRP?style=flat-square&label=PyPI)](https://pypi.org/project/pyvrp/)
 [![CI](https://img.shields.io/github/actions/workflow/status/PyVRP/PyVRP/.github%2Fworkflows%2FCI.yml?branch=main&style=flat-square&logo=github&label=CI)](https://github.com/PyVRP/PyVRP/actions/workflows/CI.yml)
 [![DOC](https://img.shields.io/github/actions/workflow/status/PyVRP/PyVRP/.github%2Fworkflows%2FDOC.yml?branch=main&style=flat-square&logo=github&label=DOC)](https://pyvrp.org/)
-[![codecov](https://img.shields.io/codecov/c/github/PyVRP/PyVRP?style=flat-square&logo=codecov)](https://codecov.io/gh/PyVRP/PyVRP)
+[![codecov](https://img.shields.io/codecov/c/github/PyVRP/PyVRP?style=flat-square&logo=codecov&label=Codecov)](https://codecov.io/gh/PyVRP/PyVRP)
 [![DOI:10.1287/ijoc.2023.0055](https://img.shields.io/badge/DOI-ijoc.2023.0055-green?style=flat-square&color=blue)](https://doi.org/10.1287/ijoc.2023.0055)
 
 PyVRP is an open-source, state-of-the-art vehicle routing problem (VRP) solver.


### PR DESCRIPTION
This PR replaces the README badges with ones from www.shields.io. Those badges have style options that have a more modern look and fit our logo better.