### PR TITLE
Update tests to use assert_equal where possible

### DIFF
--- a/tests/search/test_Route.py
+++ b/tests/search/test_Route.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from numpy.testing import assert_, assert_allclose, assert_equal
+from numpy.testing import assert_, assert_equal
 
 from pyvrp import Depot, ProblemData, VehicleType
 from pyvrp.search._search import Node, Route
@@ -202,9 +202,9 @@ def test_excess_load(ok_small):
     # The only vehicle type in the instance has a capacity of 10, so this route
     # has excess load.
     assert_(route.has_excess_load())
-    assert_allclose(route.excess_load(), 8)
-    assert_allclose(route.load(), 18)
-    assert_allclose(route.capacity(), 10)
+    assert_equal(route.excess_load(), 8)
+    assert_equal(route.load(), 18)
+    assert_equal(route.capacity(), 10)
 
 
 @pytest.mark.parametrize("fixed_cost", [0, 9])
@@ -217,7 +217,7 @@ def test_fixed_vehicle_cost(ok_small, fixed_cost: int):
         vehicle_types=[VehicleType(2, capacity=10, fixed_cost=fixed_cost)]
     )
     route = Route(data, idx=0, vehicle_type=0)
-    assert_allclose(route.fixed_vehicle_cost(), fixed_cost)
+    assert_equal(route.fixed_vehicle_cost(), fixed_cost)
 
 
 @pytest.mark.parametrize("client", [1, 2, 3, 4])
@@ -253,8 +253,8 @@ def test_dist_and_load_for_single_client_routes(ok_small, client: int):
 
     # This should always be zero because distance is a property of the edges,
     # not the nodes.
-    assert_allclose(route.dist_at(0).distance(), 0)
-    assert_allclose(route.dist_at(1).distance(), 0)
+    assert_equal(route.dist_at(0).distance(), 0)
+    assert_equal(route.dist_at(1).distance(), 0)
 
 
 def test_route_overlaps_with_self_no_matter_the_tolerance_value(ok_small):
@@ -347,14 +347,14 @@ def test_duration_between_client_returns_node_duration(ok_small, loc: int):
 
     # Duration of the depot node DS's is zero, and for the client it is equal
     # to the service duration.
-    assert_allclose(route.duration_between(0, 0).duration(), 0)
-    assert_allclose(
+    assert_equal(route.duration_between(0, 0).duration(), 0)
+    assert_equal(
         route.duration_between(1, 1).duration(), client.service_duration
     )
-    assert_allclose(route.duration_between(2, 2).duration(), 0)
+    assert_equal(route.duration_between(2, 2).duration(), 0)
 
     # Single route solutions are all feasible for this instance.
-    assert_allclose(route.time_warp(), 0)
+    assert_equal(route.time_warp(), 0)
 
 
 def test_duration_between_equal_to_before_after_when_one_is_depot(ok_small):
@@ -418,7 +418,7 @@ def test_distance_is_equal_to_dist_between_over_whole_route(ok_small):
         route.append(Node(loc=client))
     route.update()
 
-    assert_allclose(
+    assert_equal(
         route.distance(), route.dist_between(0, len(route) + 1).distance()
     )
 
@@ -455,8 +455,8 @@ def test_shift_duration_depot_time_window_interaction(
 
     for idx in [0, 1]:
         ds = route.duration_at(idx)
-        assert_allclose(ds.tw_early(), expected_tw[0])
-        assert_allclose(ds.tw_late(), expected_tw[1])
+        assert_equal(ds.tw_early(), expected_tw[0])
+        assert_equal(ds.tw_late(), expected_tw[1])
 
 
 @pytest.mark.parametrize("clients", [(1, 2, 3, 4), (1, 2), (3, 4)])
@@ -472,7 +472,7 @@ def test_route_centroid(ok_small, clients):
 
     x = [ok_small.location(client).x for client in clients]
     y = [ok_small.location(client).y for client in clients]
-    assert_allclose(route.centroid(), (np.mean(x), np.mean(y)))
+    assert_equal(route.centroid(), (np.mean(x), np.mean(y)))
 
 
 @pytest.mark.parametrize(
@@ -497,7 +497,7 @@ def test_max_duration(ok_small: ProblemData, max_duration: int, expected: int):
 
     route.update()
     assert_(route.has_time_warp())
-    assert_allclose(route.time_warp(), expected)
+    assert_equal(route.time_warp(), expected)
 
 
 @pytest.mark.parametrize(
@@ -521,9 +521,9 @@ def test_max_distance(ok_small: ProblemData, max_distance: int, expected: int):
         route.append(Node(loc=client))
 
     route.update()
-    assert_allclose(route.distance(), 6_450)
+    assert_equal(route.distance(), 6_450)
     assert_equal(route.has_excess_distance(), expected > 0)
-    assert_allclose(route.excess_distance(), expected)
+    assert_equal(route.excess_distance(), expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/search/test_Route.py
+++ b/tests/search/test_Route.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from numpy.testing import assert_, assert_equal
+from numpy.testing import assert_, assert_allclose, assert_equal
 
 from pyvrp import Depot, ProblemData, VehicleType
 from pyvrp.search._search import Node, Route
@@ -472,7 +472,7 @@ def test_route_centroid(ok_small, clients):
 
     x = [ok_small.location(client).x for client in clients]
     y = [ok_small.location(client).y for client in clients]
-    assert_equal(route.centroid(), (np.mean(x), np.mean(y)))
+    assert_allclose(route.centroid(), (np.mean(x), np.mean(y)))
 
 
 @pytest.mark.parametrize(

--- a/tests/search/test_SwapRoutes.py
+++ b/tests/search/test_SwapRoutes.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from numpy.testing import assert_, assert_allclose, assert_equal
+from numpy.testing import assert_, assert_equal
 
 from pyvrp import Client, CostEvaluator, Depot, ProblemData, VehicleType
 from pyvrp.search import SwapRoutes
@@ -64,7 +64,7 @@ def test_evaluate_same_vehicle_type(ok_small):
 
     op = SwapRoutes(ok_small)
     cost_eval = CostEvaluator(1, 1, 0)
-    assert_allclose(op.evaluate(route1, route2, cost_eval), 0)
+    assert_equal(op.evaluate(route1, route2, cost_eval), 0)
 
 
 def test_same_route(ok_small):
@@ -78,7 +78,7 @@ def test_same_route(ok_small):
 
     op = SwapRoutes(ok_small)
     cost_eval = CostEvaluator(1, 1, 0)
-    assert_allclose(op.evaluate(route, route, cost_eval), 0)
+    assert_equal(op.evaluate(route, route, cost_eval), 0)
 
 
 def test_evaluate_empty_routes(ok_small):
@@ -107,12 +107,12 @@ def test_evaluate_empty_routes(ok_small):
     # Vehicle types are no longer the same, but one of the routes is empty.
     # That situation is not currently handled.
     assert_(route1.vehicle_type != route2.vehicle_type)
-    assert_allclose(op.evaluate(route1, route2, cost_eval), 0)
-    assert_allclose(op.evaluate(route2, route1, cost_eval), 0)
+    assert_equal(op.evaluate(route1, route2, cost_eval), 0)
+    assert_equal(op.evaluate(route2, route1, cost_eval), 0)
 
     # Both routes are empty, but of different vehicle type as well.
     assert_equal(len(route2), len(route3))
-    assert_allclose(op.evaluate(route3, route2, cost_eval), 0)
+    assert_equal(op.evaluate(route3, route2, cost_eval), 0)
 
 
 def test_evaluate_capacity_differences(ok_small):
@@ -136,11 +136,11 @@ def test_evaluate_capacity_differences(ok_small):
     # route1 has vehicle type 0, which has capacity 10. So there is excess load
     # since its client delivery demand sums to 15.
     assert_(route1.has_excess_load())
-    assert_allclose(route1.load(), 15)
+    assert_equal(route1.load(), 15)
 
     # route2, on the other hand, has capacity 20 and a load of only 3.
     assert_(not route2.has_excess_load())
-    assert_allclose(route2.load(), 3)
+    assert_equal(route2.load(), 3)
 
     op = SwapRoutes(data)
     cost_eval = CostEvaluator(40, 1, 0)
@@ -149,7 +149,7 @@ def test_evaluate_capacity_differences(ok_small):
     # of 15 on route1 is below route2's capacity, and similarly for route2's
     # load and route1's capacity. Since we price unit load violations at 40,
     # this should result in a delta cost of -200.
-    assert_allclose(op.evaluate(route1, route2, cost_eval), -200)
+    assert_equal(op.evaluate(route1, route2, cost_eval), -200)
 
     # Apply the move, update the routes, and then check if they're now both
     # feasible.
@@ -223,19 +223,19 @@ def test_evaluate_max_duration_constraints(ok_small):
     # First route takes 5'332, which is 2'332 more than its maximum duration
     # allows. There is no other source of time warp, so the total route time
     # warp must be 2'332.
-    assert_allclose(route1.duration(), 5_332)
-    assert_allclose(route1.time_warp(), 2_332)
+    assert_equal(route1.duration(), 5_332)
+    assert_equal(route1.time_warp(), 2_332)
 
     # Second route takes 5'323, and has no maximum duration constraint. There
     # is no other source of time warp, so total route time warp must be zero.
-    assert_allclose(route2.duration(), 5_323)
-    assert_allclose(route2.time_warp(), 0)
+    assert_equal(route2.duration(), 5_323)
+    assert_equal(route2.time_warp(), 0)
 
     # Swapping the routes results in a reduction of 5'332 - 5'323 = 9 units of
     # time warp.
     op = SwapRoutes(data)
     cost_eval = CostEvaluator(1, 1, 0)
-    assert_allclose(op.evaluate(route1, route2, cost_eval), -9)
+    assert_equal(op.evaluate(route1, route2, cost_eval), -9)
 
 
 def test_evaluate_with_different_depots():
@@ -272,6 +272,6 @@ def test_evaluate_with_different_depots():
     # The routes each cost 16 distance which is not as efficient as swapping
     # them, as that would reduce each route's cost to 4, for an improvement
     # of 2 * 12 = 24.
-    assert_allclose(route1.distance(), 16)
-    assert_allclose(route2.distance(), 16)
-    assert_allclose(op.evaluate(route1, route2, cost_eval), -24)
+    assert_equal(route1.distance(), 16)
+    assert_equal(route2.distance(), 16)
+    assert_equal(op.evaluate(route1, route2, cost_eval), -24)

--- a/tests/search/test_SwapStar.py
+++ b/tests/search/test_SwapStar.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_, assert_allclose, assert_equal
+from numpy.testing import assert_, assert_equal
 from pytest import mark
 
 from pyvrp import (
@@ -214,11 +214,11 @@ def test_max_distance(ok_small):
     cost_eval = CostEvaluator(0, 0, 10)  # only max distance is penalised
 
     route1, route2 = make_routes(ok_small)
-    assert_allclose(route1.distance(), 6_220)
-    assert_allclose(route2.distance(), 2_951)
+    assert_equal(route1.distance(), 6_220)
+    assert_equal(route2.distance(), 2_951)
 
     swap_star = SwapStar(ok_small)
-    assert_allclose(swap_star.evaluate(route1, route2, cost_eval), -1_043)
+    assert_equal(swap_star.evaluate(route1, route2, cost_eval), -1_043)
     swap_star.apply(route1, route2)
 
     # New route1 is 0 -> 2 -> 3 -> 4 -> 0, and route2 0 -> 1 -> 0. These new
@@ -227,9 +227,9 @@ def test_max_distance(ok_small):
     # reduction.
     route1.update()
     route2.update()
-    assert_allclose(route1.distance(), 4_858)
-    assert_allclose(route2.distance(), 3_270)
-    assert_allclose(6_220 + 2_951 - 1_043, 4_858 + 3_270)
+    assert_equal(route1.distance(), 4_858)
+    assert_equal(route2.distance(), 3_270)
+    assert_equal(6_220 + 2_951 - 1_043, 4_858 + 3_270)
 
     # Now restrict the maximum route distance to 5_000, so that aspect needs
     # to be taken into account as well.
@@ -242,5 +242,5 @@ def test_max_distance(ok_small):
     # distance difference as before.
     swap_star = SwapStar(data)
     route1, route2 = make_routes(data)
-    assert_allclose(swap_star.evaluate(route1, route2, cost_eval), -13_243)
-    assert_allclose(10 * (6_220 - 5_000) + 1_043, 13_243)
+    assert_equal(swap_star.evaluate(route1, route2, cost_eval), -13_243)
+    assert_equal(10 * (6_220 - 5_000) + 1_043, 13_243)

--- a/tests/search/test_SwapTails.py
+++ b/tests/search/test_SwapTails.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_, assert_allclose, assert_equal
+from numpy.testing import assert_, assert_equal
 from pytest import mark
 
 from pyvrp import (
@@ -92,16 +92,16 @@ def test_move_involving_empty_routes():
     cost_eval = CostEvaluator(0, 0, 0)
 
     # This move does not change the route structure, so the delta cost is 0.
-    assert_allclose(op.evaluate(route1[2], route2[0], cost_eval), 0)
+    assert_equal(op.evaluate(route1[2], route2[0], cost_eval), 0)
 
     # This move creates routes (depot -> 1 -> depot) and (depot -> 2 -> depot),
     # making route 2 non-empty and thus incurring its fixed cost of 100.
-    assert_allclose(op.evaluate(route1[1], route2[0], cost_eval), 100)
+    assert_equal(op.evaluate(route1[1], route2[0], cost_eval), 100)
 
     # This move creates routes (depot -> depot) and (depot -> 1 -> 2 -> depot),
     # making route 1 empty, while making route 2 non-empty. The total fixed
     # cost incurred is thus -10 + 100 = 90.
-    assert_allclose(op.evaluate(route1[0], route2[0], cost_eval), 90)
+    assert_equal(op.evaluate(route1[0], route2[0], cost_eval), 90)
 
     # Now we reverse the visits of route 1 and 2, so that we can hit the cases
     # where route 1 is empty.
@@ -114,16 +114,16 @@ def test_move_involving_empty_routes():
     route2.update()  # depot -> 1 -> 2 -> depot
 
     # This move does not change the route structure, so the delta cost is 0.
-    assert_allclose(op.evaluate(route1[0], route2[2], cost_eval), 0)
+    assert_equal(op.evaluate(route1[0], route2[2], cost_eval), 0)
 
     # This move creates routes (depot -> 2 -> depot) and (depot -> 1 -> depot),
     # making route 1 non-empty and thus incurring its fixed cost of 10.
-    assert_allclose(op.evaluate(route1[0], route2[1], cost_eval), 10)
+    assert_equal(op.evaluate(route1[0], route2[1], cost_eval), 10)
 
     # This move creates routes (depot -> 1 -> 2 -> depot) and (depot -> depot),
     # making route 1 non-empty, while making route 2 empty. The total fixed
     # cost incurred is thus 10 - 100 = -90.
-    assert_allclose(op.evaluate(route1[0], route2[0], cost_eval), -90)
+    assert_equal(op.evaluate(route1[0], route2[0], cost_eval), -90)
 
 
 def test_move_involving_multiple_depots():
@@ -155,18 +155,18 @@ def test_move_involving_multiple_depots():
     route2.append(Node(loc=2))
     route2.update()
 
-    assert_allclose(route1.distance(), 16)
-    assert_allclose(route2.distance(), 16)
+    assert_equal(route1.distance(), 16)
+    assert_equal(route2.distance(), 16)
 
     op = SwapTails(data)
     cost_eval = CostEvaluator(1, 1, 0)
 
-    assert_allclose(op.evaluate(route1[1], route2[1], cost_eval), 0)  # no-op
+    assert_equal(op.evaluate(route1[1], route2[1], cost_eval), 0)  # no-op
 
     # First would be 0 -> 3 -> 2 -> 0, second 1 -> 1. Distance on route2 would
     # be zero, and on route1 16. Thus delta cost is -16.
-    assert_allclose(op.evaluate(route1[1], route2[0], cost_eval), -16)
+    assert_equal(op.evaluate(route1[1], route2[0], cost_eval), -16)
 
     # First would be 0 -> 0, second 1 -> 2 -> 3 -> 1. Distance on route1 would
     # be zero, and on route2 16. Thus delta cost is -16.
-    assert_allclose(op.evaluate(route1[0], route2[1], cost_eval), -16)
+    assert_equal(op.evaluate(route1[0], route2[1], cost_eval), -16)

--- a/tests/search/test_primitives.py
+++ b/tests/search/test_primitives.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_equal
 
 from pyvrp import Client, CostEvaluator, Depot, ProblemData, VehicleType
 from pyvrp.search._search import Node, Route, insert_cost, remove_cost
@@ -18,11 +18,11 @@ def test_insert_cost_zero_when_not_allowed(ok_small):
     route.update()
 
     # Inserting the depot is not possible.
-    assert_allclose(insert_cost(route[0], route[1], ok_small, cost_eval), 0)
-    assert_allclose(insert_cost(route[3], route[2], ok_small, cost_eval), 0)
+    assert_equal(insert_cost(route[0], route[1], ok_small, cost_eval), 0)
+    assert_equal(insert_cost(route[3], route[2], ok_small, cost_eval), 0)
 
     # Inserting after a node that's not in a route is not possible.
-    assert_allclose(insert_cost(route[1], Node(loc=3), ok_small, cost_eval), 0)
+    assert_equal(insert_cost(route[1], Node(loc=3), ok_small, cost_eval), 0)
 
 
 def test_insert_cost(ok_small):
@@ -41,15 +41,11 @@ def test_insert_cost(ok_small):
     # delivery demand, which exceeds the vehicle capacity by 5, so we get an
     # additional load penalty of 5. There is no time warp. Total delta cost:
     #     1593 + 1090 - 1992 + 5 = 696.
-    assert_allclose(
-        insert_cost(Node(loc=4), route[1], ok_small, cost_eval), 696
-    )
+    assert_equal(insert_cost(Node(loc=4), route[1], ok_small, cost_eval), 696)
 
     # +5 load penalty, and delta dist is 1090 + 1475 - 1965 = 600. So total
     # delta cost is 605 (again no time warp).
-    assert_allclose(
-        insert_cost(Node(loc=4), route[2], ok_small, cost_eval), 605
-    )
+    assert_equal(insert_cost(Node(loc=4), route[2], ok_small, cost_eval), 605)
 
     # Now we do have some time warp changes. +3 load penalty, delta dist is
     # 1427 + 647 - 1992 = 82, but time warp increases because we cannot get to
@@ -59,9 +55,7 @@ def test_insert_cost(ok_small):
     # closing time window of 15300. So we add 17387 - 15300 = 2087 time warp.
     # Tallying it all up, total delta cost:
     #      3 + 82 + 2087 = 2172.
-    assert_allclose(
-        insert_cost(Node(loc=3), route[1], ok_small, cost_eval), 2172
-    )
+    assert_equal(insert_cost(Node(loc=3), route[1], ok_small, cost_eval), 2172)
 
     # +3 load penalty, delta dist is 621 + 2063 - 1965 = 719. Time warp
     # increases because we have to visit clients 1 and 2 before we visit
@@ -70,9 +64,7 @@ def test_insert_cost(ok_small):
     # we arrive at 18933, after its closing time window of 15300. This adds
     # 18933 - 15300 = 3633 time warp. Tallying it all up, total delta cost:
     #     3 + 719 + 3633 = 4355.
-    assert_allclose(
-        insert_cost(Node(loc=3), route[2], ok_small, cost_eval), 4355
-    )
+    assert_equal(insert_cost(Node(loc=3), route[2], ok_small, cost_eval), 4355)
 
 
 def test_remove_cost_zero_when_not_allowed(ok_small):
@@ -88,11 +80,11 @@ def test_remove_cost_zero_when_not_allowed(ok_small):
     route.update()
 
     # Removing the depot is not possible.
-    assert_allclose(remove_cost(route[0], ok_small, cost_eval), 0)
-    assert_allclose(remove_cost(route[3], ok_small, cost_eval), 0)
+    assert_equal(remove_cost(route[0], ok_small, cost_eval), 0)
+    assert_equal(remove_cost(route[3], ok_small, cost_eval), 0)
 
     # Removing a node that's not in a route is not possible.
-    assert_allclose(remove_cost(Node(loc=3), ok_small, cost_eval), 0)
+    assert_equal(remove_cost(Node(loc=3), ok_small, cost_eval), 0)
 
 
 def test_remove(ok_small):
@@ -108,11 +100,11 @@ def test_remove(ok_small):
 
     # Purely distance. Removes arcs 0 -> 1 -> 2, adds arc 0 -> 2. This change
     # has delta distance of 1944 - 1544 - 1992 = -1592.
-    assert_allclose(remove_cost(route[1], ok_small, cost_eval), -1592)
+    assert_equal(remove_cost(route[1], ok_small, cost_eval), -1592)
 
     # Purely distance. Removes arcs 1 -> 2 -> 0, adds arcs 1 -> 0. This change
     # has delta distance of 1726 - 1992 - 1965 = -2231.
-    assert_allclose(remove_cost(route[2], ok_small, cost_eval), -2231)
+    assert_equal(remove_cost(route[2], ok_small, cost_eval), -2231)
 
 
 def test_insert_fixed_vehicle_cost():
@@ -133,12 +125,12 @@ def test_insert_fixed_vehicle_cost():
     # client into an empty route. That adds the fixed vehicle cost of 7 for
     # this vehicle type.
     route = Route(data, idx=0, vehicle_type=0)
-    assert_allclose(insert_cost(Node(loc=1), route[0], data, cost_eval), 7)
+    assert_equal(insert_cost(Node(loc=1), route[0], data, cost_eval), 7)
 
     # Same story for this route, but now we have a different vehicle type with
     # fixed cost 13.
     route = Route(data, idx=0, vehicle_type=1)
-    assert_allclose(insert_cost(Node(loc=1), route[0], data, cost_eval), 13)
+    assert_equal(insert_cost(Node(loc=1), route[0], data, cost_eval), 13)
 
 
 def test_remove_fixed_vehicle_cost():
@@ -162,11 +154,11 @@ def test_remove_fixed_vehicle_cost():
     route = Route(data, idx=0, vehicle_type=0)
     route.append(Node(loc=1))
     route.update()
-    assert_allclose(remove_cost(route[1], data, cost_eval), -7)
+    assert_equal(remove_cost(route[1], data, cost_eval), -7)
 
     # Same story for this route, but now we have a different vehicle type with
     # fixed cost 13.
     route = Route(data, idx=0, vehicle_type=1)
     route.append(Node(loc=1))
     route.update()
-    assert_allclose(remove_cost(route[1], data, cost_eval), -13)
+    assert_equal(remove_cost(route[1], data, cost_eval), -13)

--- a/tests/test_CostEvaluator.py
+++ b/tests/test_CostEvaluator.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_, assert_allclose
+from numpy.testing import assert_, assert_equal
 from pytest import mark
 
 from pyvrp import CostEvaluator, Route, Solution, VehicleType
@@ -11,22 +11,22 @@ def test_load_penalty():
     """
     cost_evaluator = CostEvaluator(2, 1, 0)
 
-    assert_allclose(cost_evaluator.load_penalty(0, 1), 0)  # below capacity
-    assert_allclose(cost_evaluator.load_penalty(1, 1), 0)  # at capacity
+    assert_equal(cost_evaluator.load_penalty(0, 1), 0)  # below capacity
+    assert_equal(cost_evaluator.load_penalty(1, 1), 0)  # at capacity
 
     # Penalty per unit excess capacity is 2
     # 1 unit above capacity
-    assert_allclose(cost_evaluator.load_penalty(2, 1), 2)
+    assert_equal(cost_evaluator.load_penalty(2, 1), 2)
     # 2 units above capacity
-    assert_allclose(cost_evaluator.load_penalty(3, 1), 4)
+    assert_equal(cost_evaluator.load_penalty(3, 1), 4)
 
     # Penalty per unit excess capacity is 4
     cost_evaluator = CostEvaluator(4, 1, 0)
 
     # 1 unit above capacity
-    assert_allclose(cost_evaluator.load_penalty(2, 1), 4)
+    assert_equal(cost_evaluator.load_penalty(2, 1), 4)
     # 2 units above capacity
-    assert_allclose(cost_evaluator.load_penalty(3, 1), 8)
+    assert_equal(cost_evaluator.load_penalty(3, 1), 8)
 
 
 @mark.parametrize("cap", [5, 15, 29, 51, 103])
@@ -38,11 +38,11 @@ def test_load_penalty_always_zero_when_below_capacity(cap: int):
     penalty = 2
     cost_eval = CostEvaluator(penalty, 1, 0)
 
-    assert_allclose(cost_eval.load_penalty(0, cap), 0)  # below cap
-    assert_allclose(cost_eval.load_penalty(cap - 1, cap), 0)
-    assert_allclose(cost_eval.load_penalty(cap, cap), 0)  # at cap
-    assert_allclose(cost_eval.load_penalty(cap + 1, cap), penalty)  # above cap
-    assert_allclose(cost_eval.load_penalty(cap + 2, cap), 2 * penalty)
+    assert_equal(cost_eval.load_penalty(0, cap), 0)  # below cap
+    assert_equal(cost_eval.load_penalty(cap - 1, cap), 0)
+    assert_equal(cost_eval.load_penalty(cap, cap), 0)  # at cap
+    assert_equal(cost_eval.load_penalty(cap + 1, cap), penalty)  # above cap
+    assert_equal(cost_eval.load_penalty(cap + 2, cap), 2 * penalty)
 
 
 def test_tw_penalty():
@@ -52,16 +52,16 @@ def test_tw_penalty():
     cost_evaluator = CostEvaluator(1, 2, 0)
 
     # Penalty per unit time warp is 2.
-    assert_allclose(cost_evaluator.tw_penalty(0), 0)
-    assert_allclose(cost_evaluator.tw_penalty(1), 2)
-    assert_allclose(cost_evaluator.tw_penalty(2), 4)
+    assert_equal(cost_evaluator.tw_penalty(0), 0)
+    assert_equal(cost_evaluator.tw_penalty(1), 2)
+    assert_equal(cost_evaluator.tw_penalty(2), 4)
 
     cost_evaluator = CostEvaluator(1, 4, 0)
 
     # Penalty per unit excess capacity is now 4.
-    assert_allclose(cost_evaluator.tw_penalty(0), 0)
-    assert_allclose(cost_evaluator.tw_penalty(1), 4)
-    assert_allclose(cost_evaluator.tw_penalty(2), 8)
+    assert_equal(cost_evaluator.tw_penalty(0), 0)
+    assert_equal(cost_evaluator.tw_penalty(1), 4)
+    assert_equal(cost_evaluator.tw_penalty(2), 8)
 
 
 def test_dist_penalty():
@@ -71,18 +71,18 @@ def test_dist_penalty():
     cost_eval = CostEvaluator(1, 1, 2)
 
     # Penalty per unit excess distance is 2.
-    assert_allclose(cost_eval.dist_penalty(-1, 0), 0)
-    assert_allclose(cost_eval.dist_penalty(0, 0), 0)
-    assert_allclose(cost_eval.dist_penalty(1, 0), 2)
-    assert_allclose(cost_eval.dist_penalty(2, 0), 4)
+    assert_equal(cost_eval.dist_penalty(-1, 0), 0)
+    assert_equal(cost_eval.dist_penalty(0, 0), 0)
+    assert_equal(cost_eval.dist_penalty(1, 0), 2)
+    assert_equal(cost_eval.dist_penalty(2, 0), 4)
 
     cost_eval = CostEvaluator(1, 1, 4)
 
     # Penalty per unit excess capacity is now 4.
-    assert_allclose(cost_eval.dist_penalty(-1, 0), 0)
-    assert_allclose(cost_eval.dist_penalty(0, 0), 0)
-    assert_allclose(cost_eval.dist_penalty(1, 0), 4)
-    assert_allclose(cost_eval.dist_penalty(2, 0), 8)
+    assert_equal(cost_eval.dist_penalty(-1, 0), 0)
+    assert_equal(cost_eval.dist_penalty(0, 0), 0)
+    assert_equal(cost_eval.dist_penalty(1, 0), 4)
+    assert_equal(cost_eval.dist_penalty(2, 0), 8)
 
 
 def test_cost(ok_small):
@@ -97,15 +97,15 @@ def test_cost(ok_small):
     feas_sol = Solution(ok_small, [[1, 2], [3], [4]])  # feasible solution
     distance = feas_sol.distance()
 
-    assert_allclose(cost_evaluator.cost(feas_sol), distance)
-    assert_allclose(default_cost_evaluator.cost(feas_sol), distance)
+    assert_equal(cost_evaluator.cost(feas_sol), distance)
+    assert_equal(default_cost_evaluator.cost(feas_sol), distance)
 
     infeas_sol = Solution(ok_small, [[1, 2, 3, 4]])  # infeasible solution
     assert_(not infeas_sol.is_feasible())
 
     infeas_cost = np.iinfo(np.int64).max
-    assert_allclose(cost_evaluator.cost(infeas_sol), infeas_cost)
-    assert_allclose(default_cost_evaluator.cost(infeas_sol), infeas_cost)
+    assert_equal(cost_evaluator.cost(infeas_sol), infeas_cost)
+    assert_equal(default_cost_evaluator.cost(infeas_sol), infeas_cost)
 
 
 def test_cost_with_prizes(prize_collecting):
@@ -124,9 +124,9 @@ def test_cost_with_prizes(prize_collecting):
     collected = sum(prizes[:5])
     uncollected = sum(prizes) - collected
 
-    assert_allclose(sol.prizes(), collected)
-    assert_allclose(sol.uncollected_prizes(), uncollected)
-    assert_allclose(sol.distance() + sol.uncollected_prizes(), cost)
+    assert_equal(sol.prizes(), collected)
+    assert_equal(sol.uncollected_prizes(), uncollected)
+    assert_equal(sol.distance() + sol.uncollected_prizes(), cost)
 
 
 def test_penalised_cost(ok_small):
@@ -145,8 +145,8 @@ def test_penalised_cost(ok_small):
     assert_(feas.is_feasible())
 
     # For a feasible solution, cost and penalised_cost equal distance.
-    assert_allclose(cost_evaluator.penalised_cost(feas), feas.distance())
-    assert_allclose(default_evaluator.penalised_cost(feas), feas.distance())
+    assert_equal(cost_evaluator.penalised_cost(feas), feas.distance())
+    assert_equal(default_evaluator.penalised_cost(feas), feas.distance())
 
     infeas = Solution(ok_small, [[1, 2, 3, 4]])
     assert_(not infeas.is_feasible())
@@ -158,10 +158,10 @@ def test_penalised_cost(ok_small):
 
     # Test penalised cost
     expected_cost = infeas_dist + load_penalty_cost + tw_penalty_cost
-    assert_allclose(cost_evaluator.penalised_cost(infeas), expected_cost)
+    assert_equal(cost_evaluator.penalised_cost(infeas), expected_cost)
 
     # Default cost evaluator has 0 weights and only computes distance as cost
-    assert_allclose(default_evaluator.penalised_cost(infeas), infeas_dist)
+    assert_equal(default_evaluator.penalised_cost(infeas), infeas_dist)
 
 
 def test_excess_distance_penalised_cost(ok_small):
@@ -176,16 +176,16 @@ def test_excess_distance_penalised_cost(ok_small):
 
     routes = sol.routes()
 
-    assert_allclose(sol.distance(), 5501 + 4224)
-    assert_allclose(routes[0].distance(), 5501)
-    assert_allclose(routes[1].distance(), 4224)
+    assert_equal(sol.distance(), 5501 + 4224)
+    assert_equal(routes[0].distance(), 5501)
+    assert_equal(routes[1].distance(), 4224)
 
-    assert_allclose(sol.excess_distance(), 501)
-    assert_allclose(routes[0].excess_distance(), 501)
-    assert_allclose(routes[1].excess_distance(), 0)
+    assert_equal(sol.excess_distance(), 501)
+    assert_equal(routes[0].excess_distance(), 501)
+    assert_equal(routes[1].excess_distance(), 0)
 
     cost_eval = CostEvaluator(0, 0, 10)
-    assert_allclose(cost_eval.penalised_cost(sol), 5501 + 4224 + 10 * 501)
+    assert_equal(cost_eval.penalised_cost(sol), 5501 + 4224 + 10 * 501)
 
 
 @mark.parametrize(
@@ -218,5 +218,5 @@ def test_cost_with_fixed_vehicle_cost(
     # Solution is feasible, so penalised cost and regular cost are equal. Both
     # should contain the fixed vehicle cost.
     assert_(sol.is_feasible())
-    assert_allclose(cost_eval.cost(sol), sol.distance() + expected)
-    assert_allclose(cost_eval.penalised_cost(sol), sol.distance() + expected)
+    assert_equal(cost_eval.cost(sol), sol.distance() + expected)
+    assert_equal(cost_eval.penalised_cost(sol), sol.distance() + expected)

--- a/tests/test_DistanceSegment.py
+++ b/tests/test_DistanceSegment.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
+from numpy.testing import assert_equal
 
 from pyvrp._pyvrp import DistanceSegment
 
@@ -13,7 +13,7 @@ def test_attribute_getter(distance: int):
     Tests that the distance segment correctly returns the passed-in distance.
     """
     dist_segment = DistanceSegment(0, 1, distance)
-    assert_allclose(dist_segment.distance(), distance)
+    assert_equal(dist_segment.distance(), distance)
 
 
 @pytest.mark.parametrize(
@@ -43,4 +43,4 @@ def test_merge_two(
         ]
     )
     merged = DistanceSegment.merge(dist_mat, first, second)
-    assert_allclose(merged.distance(), exp_distance)
+    assert_equal(merged.distance(), exp_distance)

--- a/tests/test_DurationSegment.py
+++ b/tests/test_DurationSegment.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from numpy.testing import assert_, assert_allclose, assert_equal
+from numpy.testing import assert_, assert_equal
 
 from pyvrp._pyvrp import DurationSegment
 
@@ -112,9 +112,9 @@ def test_max_duration_argument():
     """
     ds = DurationSegment(0, 0, 5, 0, 0, 0, 0)  # five duration
 
-    assert_allclose(ds.time_warp(), 0)  # default not duration limited
-    assert_allclose(ds.time_warp(max_duration=2), 3)
-    assert_allclose(ds.time_warp(max_duration=0), 5)
+    assert_equal(ds.time_warp(), 0)  # default not duration limited
+    assert_equal(ds.time_warp(max_duration=2), 3)
+    assert_equal(ds.time_warp(max_duration=0), 5)
 
 
 def test_OkSmall_with_time_warp(ok_small):
@@ -152,10 +152,10 @@ def test_OkSmall_with_time_warp(ok_small):
     #   Service times:
     #       - 1: 360
     #       - 3: 420
-    assert_allclose(ds.duration(), 1544 + 1427 + 2063 + 360 + 420)
+    assert_equal(ds.duration(), 1544 + 1427 + 2063 + 360 + 420)
 
     # But there is time warp as well, because 1's time window opens at 15600,
     # while 3's time window closes at 15300. So we leave 1 at 15600 + 360, then
     # drive 1427 and arrive at 3 at 15600 + 360 + 1427 = 17387. We then warp
     # back in time to 15300, for 17387 - 15300 = 2087 time warp.
-    assert_allclose(ds.time_warp(), 2087)
+    assert_equal(ds.time_warp(), 2087)

--- a/tests/test_LoadSegment.py
+++ b/tests/test_LoadSegment.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
+from numpy.testing import assert_equal
 
 from pyvrp._pyvrp import LoadSegment
 
@@ -16,9 +16,9 @@ def test_attribute_getters(delivery: int, pickup: int, load: int):
     Tests that the attribute member functions return the passed in values.
     """
     load_segment = LoadSegment(delivery, pickup, load)
-    assert_allclose(load_segment.delivery(), delivery)
-    assert_allclose(load_segment.pickup(), pickup)
-    assert_allclose(load_segment.load(), load)
+    assert_equal(load_segment.delivery(), delivery)
+    assert_equal(load_segment.pickup(), pickup)
+    assert_equal(load_segment.load(), load)
 
 
 @pytest.mark.parametrize(
@@ -51,6 +51,6 @@ def test_merge_two(
     Tests merging two load segments.
     """
     merged = LoadSegment.merge(first, second)
-    assert_allclose(merged.delivery(), exp_delivery)
-    assert_allclose(merged.pickup(), exp_pickup)
-    assert_allclose(merged.load(), exp_load)
+    assert_equal(merged.delivery(), exp_delivery)
+    assert_equal(merged.pickup(), exp_pickup)
+    assert_equal(merged.load(), exp_load)

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -1,7 +1,6 @@
 import pytest
 from numpy.testing import (
     assert_,
-    assert_allclose,
     assert_equal,
     assert_raises,
     assert_warns,
@@ -153,12 +152,12 @@ def test_add_vehicle_type():
     )
 
     assert_equal(vehicle_type.num_available, 10)
-    assert_allclose(vehicle_type.capacity, 998)
-    assert_allclose(vehicle_type.fixed_cost, 1_001)
-    assert_allclose(vehicle_type.tw_early, 17)
-    assert_allclose(vehicle_type.tw_late, 19)
-    assert_allclose(vehicle_type.max_duration, 93)
-    assert_allclose(vehicle_type.max_distance, 97)
+    assert_equal(vehicle_type.capacity, 998)
+    assert_equal(vehicle_type.fixed_cost, 1_001)
+    assert_equal(vehicle_type.tw_early, 17)
+    assert_equal(vehicle_type.tw_late, 19)
+    assert_equal(vehicle_type.max_duration, 93)
+    assert_equal(vehicle_type.max_distance, 97)
 
 
 def test_add_vehicle_type_default_depot():
@@ -594,4 +593,4 @@ def test_model_solves_instances_with_pickups_and_deliveries(
     route = res.best.routes()[0]
 
     assert_equal(route.has_excess_load(), expected_excess_load > 0)
-    assert_allclose(route.excess_load(), expected_excess_load)
+    assert_equal(route.excess_load(), expected_excess_load)

--- a/tests/test_PenaltyManager.py
+++ b/tests/test_PenaltyManager.py
@@ -1,4 +1,4 @@
-from numpy.testing import assert_, assert_allclose, assert_equal, assert_raises
+from numpy.testing import assert_, assert_equal, assert_raises
 from pytest import mark
 
 from pyvrp import PenaltyManager, PenaltyParams, Solution, VehicleType
@@ -277,7 +277,7 @@ def test_does_not_update_penalties_before_sufficient_registrations(ok_small):
     # Both have four initial penalty, and vehicle capacity is one.
     assert_equal(pm.cost_evaluator().tw_penalty(1), 4)
     assert_equal(pm.cost_evaluator().load_penalty(2, 1), 4)
-    assert_allclose(pm.cost_evaluator().dist_penalty(2, 1), 4)
+    assert_equal(pm.cost_evaluator().dist_penalty(2, 1), 4)
 
     # Register three times. We need at least four registrations before the
     # penalties are updated, so this should not change anything.
@@ -285,7 +285,7 @@ def test_does_not_update_penalties_before_sufficient_registrations(ok_small):
         pm.register(sol)
         assert_equal(pm.cost_evaluator().tw_penalty(1), 4)
         assert_equal(pm.cost_evaluator().load_penalty(2, 1), 4)
-        assert_allclose(pm.cost_evaluator().dist_penalty(1, 0), 4)
+        assert_equal(pm.cost_evaluator().dist_penalty(1, 0), 4)
 
     # Register a fourth time. Now the penalties should change. Since there are
     # more feasible registrations than desired, the penalties should decrease.

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -62,15 +62,15 @@ def test_client_constructor_initialises_data_fields_correctly(
         name=name,
     )
 
-    assert_allclose(client.x, x)
-    assert_allclose(client.y, y)
-    assert_allclose(client.delivery, delivery)
-    assert_allclose(client.pickup, pickup)
-    assert_allclose(client.service_duration, service_duration)
-    assert_allclose(client.tw_early, tw_early)
-    assert_allclose(client.tw_late, tw_late)
-    assert_allclose(client.release_time, release_time)
-    assert_allclose(client.prize, prize)
+    assert_equal(client.x, x)
+    assert_equal(client.y, y)
+    assert_equal(client.delivery, delivery)
+    assert_equal(client.pickup, pickup)
+    assert_equal(client.service_duration, service_duration)
+    assert_equal(client.tw_early, tw_early)
+    assert_equal(client.tw_late, tw_late)
+    assert_equal(client.release_time, release_time)
+    assert_equal(client.prize, prize)
     assert_equal(client.required, required)
     assert_equal(client.name, name)
     assert_equal(str(client), name)
@@ -249,10 +249,10 @@ def test_problem_data_replace_no_changes():
         assert_equal(new_veh_type.num_available, og_veh_type.num_available)
 
     assert_(new.distance_matrix() is not original.distance_matrix())
-    assert_allclose(new.distance_matrix(), original.distance_matrix())
+    assert_equal(new.distance_matrix(), original.distance_matrix())
 
     assert_(new.duration_matrix() is not original.duration_matrix())
-    assert_allclose(new.duration_matrix(), original.duration_matrix())
+    assert_equal(new.duration_matrix(), original.duration_matrix())
 
     assert_equal(new.num_clients, original.num_clients)
     assert_equal(new.num_vehicle_types, original.num_vehicle_types)
@@ -293,10 +293,10 @@ def test_problem_data_replace_with_changes():
 
     assert_(new.distance_matrix() is not original.distance_matrix())
     with assert_raises(AssertionError):
-        assert_allclose(new.distance_matrix(), original.distance_matrix())
+        assert_equal(new.distance_matrix(), original.distance_matrix())
 
     assert_(new.duration_matrix() is not original.duration_matrix())
-    assert_allclose(new.duration_matrix(), original.duration_matrix())
+    assert_equal(new.duration_matrix(), original.duration_matrix())
 
     assert_equal(new.num_clients, original.num_clients)
     assert_(new.num_vehicle_types != original.num_vehicle_types)
@@ -365,13 +365,13 @@ def test_matrix_access():
         duration_matrix=dur_mat,
     )
 
-    assert_allclose(data.distance_matrix(), dist_mat)
-    assert_allclose(data.duration_matrix(), dur_mat)
+    assert_equal(data.distance_matrix(), dist_mat)
+    assert_equal(data.duration_matrix(), dur_mat)
 
     for frm in range(size):
         for to in range(size):
-            assert_allclose(data.dist(frm, to), dist_mat[frm, to])
-            assert_allclose(data.duration(frm, to), dur_mat[frm, to])
+            assert_equal(data.dist(frm, to), dist_mat[frm, to])
+            assert_equal(data.duration(frm, to), dur_mat[frm, to])
 
 
 def test_matrices_are_not_writeable():
@@ -501,12 +501,12 @@ def test_vehicle_type_does_not_raise_for_all_zero_edge_case():
 
     assert_equal(vehicle_type.num_available, 1)
     assert_equal(vehicle_type.depot, 0)
-    assert_allclose(vehicle_type.capacity, 0)
-    assert_allclose(vehicle_type.fixed_cost, 0)
-    assert_allclose(vehicle_type.tw_early, 0)
-    assert_allclose(vehicle_type.tw_late, 0)
-    assert_allclose(vehicle_type.max_duration, 0)
-    assert_allclose(vehicle_type.max_distance, 0)
+    assert_equal(vehicle_type.capacity, 0)
+    assert_equal(vehicle_type.fixed_cost, 0)
+    assert_equal(vehicle_type.tw_early, 0)
+    assert_equal(vehicle_type.tw_late, 0)
+    assert_equal(vehicle_type.max_duration, 0)
+    assert_equal(vehicle_type.max_distance, 0)
 
 
 def test_vehicle_type_default_values():
@@ -517,9 +517,9 @@ def test_vehicle_type_default_values():
     vehicle_type = VehicleType()
     assert_equal(vehicle_type.num_available, 1)
     assert_equal(vehicle_type.depot, 0)
-    assert_allclose(vehicle_type.capacity, 0)
-    assert_allclose(vehicle_type.fixed_cost, 0)
-    assert_allclose(vehicle_type.tw_early, 0)
+    assert_equal(vehicle_type.capacity, 0)
+    assert_equal(vehicle_type.fixed_cost, 0)
+    assert_equal(vehicle_type.tw_early, 0)
     assert_equal(vehicle_type.name, "")
 
     # The default value for the following fields is the largest representable
@@ -548,12 +548,12 @@ def test_vehicle_type_attribute_access():
 
     assert_equal(vehicle_type.num_available, 7)
     assert_equal(vehicle_type.depot, 29)
-    assert_allclose(vehicle_type.capacity, 13)
-    assert_allclose(vehicle_type.fixed_cost, 3)
-    assert_allclose(vehicle_type.tw_early, 17)
-    assert_allclose(vehicle_type.tw_late, 19)
-    assert_allclose(vehicle_type.max_duration, 23)
-    assert_allclose(vehicle_type.max_distance, 29)
+    assert_equal(vehicle_type.capacity, 13)
+    assert_equal(vehicle_type.fixed_cost, 3)
+    assert_equal(vehicle_type.tw_early, 17)
+    assert_equal(vehicle_type.tw_late, 19)
+    assert_equal(vehicle_type.max_duration, 23)
+    assert_equal(vehicle_type.max_distance, 29)
 
     assert_equal(vehicle_type.name, "vehicle_type name")
     assert_equal(str(vehicle_type), "vehicle_type name")

--- a/tests/test_Solution.py
+++ b/tests/test_Solution.py
@@ -310,7 +310,7 @@ def test_feasibility_release_times():
     # time warp of 23'896 - 19'500 = 4'396.
     sol = Solution(data, [[1, 2], [3], [4]])
     assert_(not sol.is_feasible())
-    assert_allclose(sol.time_warp(), 4396)
+    assert_equal(sol.time_warp(), 4396)
 
     # Visiting clients 2 and 3 together is feasible: both clients are released
     # at time 5'000. We arrive at client 2 at 5'000 + 1'944 and wait till the
@@ -341,9 +341,9 @@ def test_feasibility_max_duration(ok_small):
     # First route has duration 6'221, and the second route duration 5'004.
     # Since the maximum duration is 3'000, these routes incur time warp of
     # 3'221 + 2'004 = 5'225, and the solution is thus no longer feasible.
-    assert_allclose(routes[0].duration(), 6_221)
-    assert_allclose(routes[1].duration(), 5_004)
-    assert_allclose(sol.time_warp(), 5_225)
+    assert_equal(routes[0].duration(), 6_221)
+    assert_equal(routes[1].duration(), 5_004)
+    assert_equal(sol.time_warp(), 5_225)
 
     assert_(not routes[0].is_feasible())
     assert_(not routes[1].is_feasible())
@@ -364,16 +364,16 @@ def test_feasibility_max_distance(ok_small):
     sol = Solution(data, [[1, 2], [3, 4]])
     routes = sol.routes()
 
-    assert_allclose(routes[0].distance(), 5501)
-    assert_allclose(routes[0].excess_distance(), 501)
+    assert_equal(routes[0].distance(), 5501)
+    assert_equal(routes[0].excess_distance(), 501)
     assert_(not routes[0].has_time_warp())
     assert_(not routes[0].is_feasible())
 
-    assert_allclose(routes[1].distance(), 4224)
-    assert_allclose(routes[1].excess_distance(), 0)
+    assert_equal(routes[1].distance(), 4224)
+    assert_equal(routes[1].excess_distance(), 0)
     assert_(routes[1].is_feasible())
 
-    assert_allclose(sol.excess_distance(), 501)
+    assert_equal(sol.excess_distance(), 501)
     assert_(sol.has_excess_distance())
     assert_(not sol.is_feasible())
 
@@ -392,16 +392,16 @@ def test_distance_calculation(ok_small):
 
     # Solution distance should be equal to all routes' distances. These we
     # check separately.
-    assert_allclose(sol.distance(), sum(route.distance() for route in routes))
+    assert_equal(sol.distance(), sum(route.distance() for route in routes))
 
     expected = ok_small.dist(0, 1) + ok_small.dist(1, 2) + ok_small.dist(2, 0)
-    assert_allclose(routes[0].distance(), expected)
+    assert_equal(routes[0].distance(), expected)
 
     expected = ok_small.dist(0, 3) + ok_small.dist(3, 0)
-    assert_allclose(routes[1].distance(), expected)
+    assert_equal(routes[1].distance(), expected)
 
     expected = ok_small.dist(0, 4) + ok_small.dist(4, 0)
-    assert_allclose(routes[2].distance(), expected)
+    assert_equal(routes[2].distance(), expected)
 
 
 def test_excess_load_calculation(ok_small):
@@ -414,7 +414,7 @@ def test_excess_load_calculation(ok_small):
 
     # All clients are visited on the same route/by the same vehicle. The total
     # delivery demand is 18, but the vehicle capacity is only 10.
-    assert_allclose(sol.excess_load(), 18 - ok_small.vehicle_type(0).capacity)
+    assert_equal(sol.excess_load(), 18 - ok_small.vehicle_type(0).capacity)
 
 
 def test_excess_load_calculation_with_multiple_vehicle_capacities(ok_small):
@@ -431,12 +431,12 @@ def test_excess_load_calculation_with_multiple_vehicle_capacities(ok_small):
     # excess_load is 18 - 10 = 8.
     sol = Solution(data, [Route(data, [1, 2, 3, 4], 0)])
     assert_(sol.has_excess_load())
-    assert_allclose(sol.excess_load(), 8)
+    assert_equal(sol.excess_load(), 8)
 
     # With vehicle type 1, the capacity 20 is larger than 18.
     sol = Solution(data, [Route(data, [1, 2, 3, 4], 1)])
     assert_(not sol.has_excess_load())
-    assert_allclose(sol.excess_load(), 0)
+    assert_equal(sol.excess_load(), 0)
 
 
 def test_route_access_methods(ok_small):
@@ -453,17 +453,17 @@ def test_route_access_methods(ok_small):
 
     # There's no excess load, so all excess load should be zero.
     assert_(not sol.has_excess_load())
-    assert_allclose(routes[0].excess_load(), 0)
-    assert_allclose(routes[1].excess_load(), 0)
+    assert_equal(routes[0].excess_load(), 0)
+    assert_equal(routes[1].excess_load(), 0)
 
     # Total route delivery demand (and pickups, which are all zero for this
     # instance).
     deliveries = [0] + [client.delivery for client in ok_small.clients()]
-    assert_allclose(routes[0].delivery(), deliveries[1] + deliveries[3])
-    assert_allclose(routes[1].delivery(), deliveries[2] + deliveries[4])
+    assert_equal(routes[0].delivery(), deliveries[1] + deliveries[3])
+    assert_equal(routes[1].delivery(), deliveries[2] + deliveries[4])
 
-    assert_allclose(routes[0].pickup(), 0)
-    assert_allclose(routes[1].pickup(), 0)
+    assert_equal(routes[0].pickup(), 0)
+    assert_equal(routes[1].pickup(), 0)
 
     # The first route is not feasible due to time warp, but the second one is.
     # See also the tests below.
@@ -472,8 +472,8 @@ def test_route_access_methods(ok_small):
 
     # Total service duration.
     services = [0] + [client.service_duration for client in ok_small.clients()]
-    assert_allclose(routes[0].service_duration(), services[1] + services[3])
-    assert_allclose(routes[1].service_duration(), services[2] + services[4])
+    assert_equal(routes[0].service_duration(), services[1] + services[3])
+    assert_equal(routes[1].service_duration(), services[2] + services[4])
 
 
 def test_route_time_warp_calculations(ok_small):
@@ -490,13 +490,13 @@ def test_route_time_warp_calculations(ok_small):
     # window). This is where we incur time warp: we need to 'warp' to 15'300.
     assert_(sol.has_time_warp())
     assert_(routes[0].has_time_warp())
-    assert_allclose(routes[0].time_warp(), 15_600 + 360 + 1_427 - 15_300)
+    assert_equal(routes[0].time_warp(), 15_600 + 360 + 1_427 - 15_300)
 
     # The second route has no time warp, so the overall solution time warp is
     # all incurred on the first route.
     assert_(not routes[1].has_time_warp())
-    assert_allclose(routes[1].time_warp(), 0)
-    assert_allclose(sol.time_warp(), routes[0].time_warp())
+    assert_equal(routes[1].time_warp(), 0)
+    assert_equal(sol.time_warp(), routes[0].time_warp())
 
 
 def test_route_wait_time_calculations():
@@ -513,15 +513,15 @@ def test_route_wait_time_calculations():
     #   twEarly(4) - duration(2, 4) - serv(2) - twLate(2)
     #     = 18'000 - 1'090 - 360 - 15'000
     #     = 1'550.
-    assert_allclose(routes[1].wait_duration(), 1_550)
+    assert_equal(routes[1].wait_duration(), 1_550)
 
     # Since there is waiting time, there is no slack in the schedule. We should
     # thus start as late as possible, at:
     #   twLate(2) - duration(0, 2)
     #     = 15'000 - 1'944
     #     = 13'056.
-    assert_allclose(routes[1].slack(), 0)
-    assert_allclose(routes[1].start_time(), 13_056)
+    assert_equal(routes[1].slack(), 0)
+    assert_equal(routes[1].start_time(), 13_056)
 
     # So far we have tested a route that had wait duration, but not time warp.
     # We now test a solution with a route that has both.
@@ -533,13 +533,13 @@ def test_route_wait_time_calculations():
     #   twEarly(1) + serv(1) + duration(1, 2) - twLate(2)
     #     = 15'600 + 360 + 1'992 - 15'000
     #     = 2'952.
-    assert_allclose(route.time_warp(), 2_952)
-    assert_allclose(route.wait_duration(), 1_550)
-    assert_allclose(route.slack(), 0)
+    assert_equal(route.time_warp(), 2_952)
+    assert_equal(route.wait_duration(), 1_550)
+    assert_equal(route.slack(), 0)
 
     # Finally, the overall route duration should be equal to the sum of the
     # travel, service, and waiting durations.
-    assert_allclose(
+    assert_equal(
         route.duration(),
         route.travel_duration()
         + route.service_duration()
@@ -562,9 +562,9 @@ def test_route_start_and_end_time_calculations(ok_small):
     end_time = start_time + routes[0].duration() - routes[0].time_warp()
 
     assert_(routes[0].has_time_warp())
-    assert_allclose(routes[0].slack(), 0)
-    assert_allclose(routes[0].start_time(), start_time)
-    assert_allclose(routes[0].end_time(), end_time)
+    assert_equal(routes[0].slack(), 0)
+    assert_equal(routes[0].start_time(), start_time)
+    assert_equal(routes[0].end_time(), end_time)
 
     # The second route has no time warp. The latest it can start is calculated
     # backwards from the closing of client 4's time window:
@@ -580,16 +580,16 @@ def test_route_start_and_end_time_calculations(ok_small):
     #     = 12'000 - 1'944
     #     = 10'056.
     assert_(not routes[1].has_time_warp())
-    assert_allclose(routes[1].wait_duration(), 0)
-    assert_allclose(routes[1].start_time(), 10_056)
-    assert_allclose(routes[1].slack(), 16_106 - 10_056)
+    assert_equal(routes[1].wait_duration(), 0)
+    assert_equal(routes[1].start_time(), 10_056)
+    assert_equal(routes[1].slack(), 16_106 - 10_056)
 
     # The overall route duration is given by:
     #   duration(0, 2) + serv(2) + duration(2, 4) + serv(4) + duration(4, 0)
     #     = 1'944 + 360 + 1'090 + 360 + 1'475
     #     = 5'229.
-    assert_allclose(routes[1].duration(), 1_944 + 360 + 1_090 + 360 + 1_475)
-    assert_allclose(routes[1].end_time(), 10_056 + 5_229)
+    assert_equal(routes[1].duration(), 1_944 + 360 + 1_090 + 360 + 1_475)
+    assert_equal(routes[1].end_time(), 10_056 + 5_229)
 
 
 def test_route_release_time():
@@ -604,8 +604,8 @@ def test_route_release_time():
     # The client release times are 20'000, 5'000, 5'000 and 1'000. So the first
     # route has a release time of max(20'000, 5'000) = 20'000, and the second
     # has a release time of max(5'000, 1'000) = 5'000.
-    assert_allclose(routes[0].release_time(), 20_000)
-    assert_allclose(routes[1].release_time(), 5_000)
+    assert_equal(routes[0].release_time(), 20_000)
+    assert_equal(routes[1].release_time(), 5_000)
 
     # Second route is feasible, so should have start time not smaller than
     # release time.
@@ -657,7 +657,7 @@ def test_time_warp_for_a_very_constrained_problem(dist_mat):
     assert_(not feasible.has_excess_load())
     assert_(feasible.is_feasible())
 
-    assert_allclose(
+    assert_equal(
         feasible.distance(),
         dist_mat[0, 1] + dist_mat[1, 2] + dist_mat[2, 0],
     )
@@ -681,9 +681,9 @@ def test_time_warp_return_to_depot():
 
     # Travel from depot to client and back gives duration 1 + 1 = 2. This is 1
     # more than the depot time window 1, giving a time warp of 1.
-    assert_allclose(route.duration(), 2)
-    assert_allclose(data.location(0).tw_late, 1)
-    assert_allclose(sol.time_warp(), 1)
+    assert_equal(route.duration(), 2)
+    assert_equal(data.location(0).tw_late, 1)
+    assert_equal(sol.time_warp(), 1)
 
 
 def tests_that_not_specifying_the_vehicle_type_assumes_a_default(ok_small):
@@ -964,7 +964,7 @@ def test_fixed_vehicle_cost(
     ]
 
     sol = Solution(data, routes)
-    assert_allclose(sol.fixed_vehicle_cost(), expected)
+    assert_equal(sol.fixed_vehicle_cost(), expected)
 
 
 @mark.parametrize(
@@ -996,4 +996,4 @@ def test_route_shift_duration(
     # 1'544 to get there from the depot, so we leave at 14'056. Thus, the
     # earliest complete time is 14'056 + 6'221 = 20'277.
     route = Route(data, [1, 2], vehicle_type=0)
-    assert_allclose(route.time_warp(), expected)
+    assert_equal(route.time_warp(), expected)

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -59,7 +59,7 @@ def test_reading_OkSmall_instance():
     assert_equal(data.num_clients, 4)
     assert_equal(data.num_vehicles, 3)
     assert_equal(data.num_vehicle_types, 1)
-    assert_allclose(data.vehicle_type(0).capacity, 10)
+    assert_equal(data.vehicle_type(0).capacity, 10)
 
     # From the NODE_COORD_SECTION in the file
     expected = [
@@ -71,8 +71,8 @@ def test_reading_OkSmall_instance():
     ]
 
     for loc in range(data.num_locations):
-        assert_allclose(data.location(loc).x, expected[loc][0])
-        assert_allclose(data.location(loc).y, expected[loc][1])
+        assert_equal(data.location(loc).x, expected[loc][0])
+        assert_equal(data.location(loc).y, expected[loc][1])
 
     # From the EDGE_WEIGHT_SECTION in the file
     expected = [
@@ -87,14 +87,14 @@ def test_reading_OkSmall_instance():
     # dist/durs should be the same as the expected edge weights above.
     for frm in range(data.num_locations):
         for to in range(data.num_locations):
-            assert_allclose(data.dist(frm, to), expected[frm][to])
-            assert_allclose(data.duration(frm, to), expected[frm][to])
+            assert_equal(data.dist(frm, to), expected[frm][to])
+            assert_equal(data.duration(frm, to), expected[frm][to])
 
     # From the DEMAND_SECTION in the file
     expected = [0, 5, 5, 3, 5]
 
     for loc in range(1, data.num_locations):  # excl. depot (has no delivery)
-        assert_allclose(data.location(loc).delivery, expected[loc])
+        assert_equal(data.location(loc).delivery, expected[loc])
 
     # From the TIME_WINDOW_SECTION in the file
     expected = [
@@ -106,14 +106,14 @@ def test_reading_OkSmall_instance():
     ]
 
     for loc in range(data.num_locations):
-        assert_allclose(data.location(loc).tw_early, expected[loc][0])
-        assert_allclose(data.location(loc).tw_late, expected[loc][1])
+        assert_equal(data.location(loc).tw_early, expected[loc][0])
+        assert_equal(data.location(loc).tw_late, expected[loc][1])
 
     # From the SERVICE_TIME_SECTION in the file
     expected = [0, 360, 360, 420, 360]
 
     for loc in range(1, data.num_locations):  # excl. depot (has no service)
-        assert_allclose(data.location(loc).service_duration, expected[loc])
+        assert_equal(data.location(loc).service_duration, expected[loc])
 
 
 def test_reading_vrplib_instance():
@@ -125,18 +125,18 @@ def test_reading_vrplib_instance():
     assert_equal(data.num_clients, 21)
     assert_equal(data.num_depots, 1)
     assert_equal(data.num_locations, 22)
-    assert_allclose(data.vehicle_type(0).capacity, 60_000)
+    assert_equal(data.vehicle_type(0).capacity, 60_000)
 
     assert_equal(len(data.depots()), data.num_depots)
     assert_equal(len(data.clients()), data.num_clients)
     assert_equal(data.num_locations, data.num_depots + data.num_clients)
 
     # Coordinates are scaled by 10 to align with 1 decimal distance precision
-    assert_allclose(data.location(0).x, 1450)  # depot [x, y] location
-    assert_allclose(data.location(0).y, 2150)
+    assert_equal(data.location(0).x, 1450)  # depot [x, y] location
+    assert_equal(data.location(0).y, 2150)
 
-    assert_allclose(data.location(1).x, 1510)  # first customer [x, y] location
-    assert_allclose(data.location(1).y, 2640)
+    assert_equal(data.location(1).x, 1510)  # first customer [x, y] location
+    assert_equal(data.location(1).y, 2640)
 
     # The data file specifies distances as 2D Euclidean. We take that and
     # should compute integer equivalents with up to one decimal precision.
@@ -146,16 +146,16 @@ def test_reading_vrplib_instance():
     #      dY = 264 - 215 = 49
     #      dist = sqrt(dX^2 + dY^2) = 49.37
     #      int(10 * dist) = 493
-    assert_allclose(data.dist(0, 1), 493)
-    assert_allclose(data.dist(1, 0), 493)
+    assert_equal(data.dist(0, 1), 493)
+    assert_equal(data.dist(1, 0), 493)
 
     # This is a CVRP instance, so all other fields should have default values.
     for loc in range(1, data.num_locations):
-        assert_allclose(data.location(loc).service_duration, 0)
-        assert_allclose(data.location(loc).tw_early, 0)
-        assert_allclose(data.location(loc).tw_late, np.iinfo(np.int64).max)
-        assert_allclose(data.location(loc).release_time, 0)
-        assert_allclose(data.location(loc).prize, 0)
+        assert_equal(data.location(loc).service_duration, 0)
+        assert_equal(data.location(loc).tw_early, 0)
+        assert_equal(data.location(loc).tw_late, np.iinfo(np.int64).max)
+        assert_equal(data.location(loc).release_time, 0)
+        assert_equal(data.location(loc).prize, 0)
         assert_equal(data.location(loc).required, True)
 
 
@@ -180,16 +180,16 @@ def test_round_func_round_nearest():
 
     # We're going to test dist(0, 1) and dist(1, 0), which should be the same
     # since the distances are symmetric/Euclidean.
-    assert_allclose(data.location(0).x, 40)
-    assert_allclose(data.location(0).y, 50)
+    assert_equal(data.location(0).x, 40)
+    assert_equal(data.location(0).y, 50)
 
-    assert_allclose(data.location(1).x, 25)
-    assert_allclose(data.location(1).y, 85)
+    assert_equal(data.location(1).x, 25)
+    assert_equal(data.location(1).y, 85)
 
     # Compute the distance, and assert that it is indeed correctly rounded.
     dist = sqrt((40 - 25) ** 2 + (85 - 50) ** 2)
-    assert_allclose(data.dist(0, 1), round(dist))
-    assert_allclose(data.dist(1, 0), round(dist))
+    assert_equal(data.dist(0, 1), round(dist))
+    assert_equal(data.dist(1, 0), round(dist))
 
 
 def test_round_func_exact():
@@ -202,16 +202,16 @@ def test_round_func_exact():
 
     # We're going to test dist(0, 1) and dist(1, 0), which should be the same
     # since the distances are symmetric/Euclidean.
-    assert_allclose(data.location(0).x, 40_000)
-    assert_allclose(data.location(0).y, 50_000)
+    assert_equal(data.location(0).x, 40_000)
+    assert_equal(data.location(0).y, 50_000)
 
-    assert_allclose(data.location(1).x, 25_000)
-    assert_allclose(data.location(1).y, 85_000)
+    assert_equal(data.location(1).x, 25_000)
+    assert_equal(data.location(1).y, 85_000)
 
     # Compute the distance, and assert that it is indeed correctly rounded.
     dist = sqrt((40 - 25) ** 2 + (85 - 50) ** 2) * 1_000
-    assert_allclose(data.dist(0, 1), round(dist))
-    assert_allclose(data.dist(1, 0), round(dist))
+    assert_equal(data.dist(0, 1), round(dist))
+    assert_equal(data.dist(1, 0), round(dist))
 
 
 def test_service_time_specification():
@@ -254,17 +254,17 @@ def test_multiple_depots():
 
     # Test that the depot data has been parsed correctly. The first depot has
     # not changed.
-    assert_allclose(depot1.x, 2_334)
-    assert_allclose(depot1.y, 726)
-    assert_allclose(depot1.tw_early, 0)
-    assert_allclose(depot1.tw_late, 45_000)
+    assert_equal(depot1.x, 2_334)
+    assert_equal(depot1.y, 726)
+    assert_equal(depot1.tw_early, 0)
+    assert_equal(depot1.tw_late, 45_000)
 
     # But the second depot has the location data of what used to be the first
     # client, and a tighter time window than the other depot.
-    assert_allclose(depot2.x, 226)
-    assert_allclose(depot2.y, 1_297)
-    assert_allclose(depot2.tw_early, 5_000)
-    assert_allclose(depot2.tw_late, 20_000)
+    assert_equal(depot2.x, 226)
+    assert_equal(depot2.y, 1_297)
+    assert_equal(depot2.tw_early, 5_000)
+    assert_equal(depot2.tw_late, 20_000)
 
 
 def test_mdvrptw_instance():
@@ -286,8 +286,8 @@ def test_mdvrptw_instance():
         # capacities and maximum route durations.
         assert_equal(vehicle_type.num_available, 10)
         assert_equal(vehicle_type.depot, idx)
-        assert_allclose(vehicle_type.capacity, 200)
-        assert_allclose(vehicle_type.max_duration, 450)
+        assert_equal(vehicle_type.capacity, 200)
+        assert_equal(vehicle_type.max_duration, 450)
 
         # Essentially all vehicle indices for each depot, separated by a comma.
         # Each depot has ten vehicles, and they are nicely grouped (so the
@@ -320,7 +320,7 @@ def test_vrpspd_instance():
 
     vehicle_type = data.vehicle_type(0)
     assert_equal(vehicle_type.num_available, 4)
-    assert_allclose(vehicle_type.capacity, 200)
+    assert_equal(vehicle_type.capacity, 200)
 
     # The first client is a linehaul client (only delivery, no pickup), and
     # the second client is a backhaul client (only pickup, no delivery). All
@@ -329,12 +329,12 @@ def test_vrpspd_instance():
     pickups = [0, 3, 10, 40]
 
     for idx, client in enumerate(data.clients()):
-        assert_allclose(client.delivery, deliveries[idx])
-        assert_allclose(client.pickup, pickups[idx])
+        assert_equal(client.delivery, deliveries[idx])
+        assert_equal(client.pickup, pickups[idx])
 
     # Test that distance/duration are not set to a large value, as in VRPB.
-    assert_allclose(np.max(data.distance_matrix()), 39)
-    assert_allclose(np.max(data.duration_matrix()), 39)
+    assert_equal(np.max(data.distance_matrix()), 39)
+    assert_equal(np.max(data.duration_matrix()), 39)
 
 
 def test_vrpb_instance():
@@ -354,18 +354,18 @@ def test_vrpb_instance():
 
     vehicle_type = data.vehicle_type(0)
     assert_equal(vehicle_type.num_available, 100)
-    assert_allclose(vehicle_type.capacity, 206)
+    assert_equal(vehicle_type.capacity, 206)
 
     # The first 50 clients are linehaul, the rest are backhaul.
     clients = data.clients()
 
     for client in clients[:50]:
-        assert_allclose(client.pickup, 0)
+        assert_equal(client.pickup, 0)
         assert_(client.delivery > 0)
 
     for client in clients[50:]:
         assert_(client.pickup > 0)
-        assert_allclose(client.delivery, 0)
+        assert_equal(client.delivery, 0)
 
     # Tests that distance/duration from depot to backhaul clients is set to
     # ``MAX_VALUE``, as well as for backhaul to linehaul clients.
@@ -378,8 +378,8 @@ def test_vrpb_instance():
             back2line = frm in backhauls and to in linehauls
 
             if depot2back or back2line:
-                assert_allclose(data.dist(frm, to), MAX_VALUE)
-                assert_allclose(data.duration(frm, to), MAX_VALUE)
+                assert_equal(data.dist(frm, to), MAX_VALUE)
+                assert_equal(data.duration(frm, to), MAX_VALUE)
             else:
                 assert_(data.dist(frm, to) < MAX_VALUE)
                 assert_(data.duration(frm, to) < MAX_VALUE)
@@ -392,4 +392,4 @@ def test_max_distance_constraint():
     """
     data = read("data/OkSmallMaxDistance.txt")
     for vehicle_type in data.vehicle_types():
-        assert_allclose(vehicle_type.max_distance, 5_000)
+        assert_equal(vehicle_type.max_distance, 5_000)


### PR DESCRIPTION
Update tests to use assert_equal where possible, rather than assert_allclose, which we used when we had float support as well.

<details>

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
