### PR TITLE
Make name argument keyword only

### DIFF
--- a/pyvrp/Model.py
+++ b/pyvrp/Model.py
@@ -99,10 +99,10 @@ class Model:
         locs = depots + clients
         edges = [
             Edge(
-                locs[frm],
-                locs[to],
-                data.dist(frm, to),
-                data.duration(frm, to),
+                frm=locs[frm],
+                to=locs[to],
+                distance=data.dist(frm, to),
+                duration=data.duration(frm, to),
             )
             for frm in range(data.num_locations)
             for to in range(data.num_locations)
@@ -135,17 +135,17 @@ class Model:
         created :class:`~pyvrp._pyvrp.Client` instance.
         """
         client = Client(
-            x,
-            y,
-            delivery,
-            pickup,
-            service_duration,
-            tw_early,
-            tw_late,
-            release_time,
-            prize,
-            required,
-            name,
+            x=x,
+            y=y,
+            delivery=delivery,
+            pickup=pickup,
+            service_duration=service_duration,
+            tw_early=tw_early,
+            tw_late=tw_late,
+            release_time=release_time,
+            prize=prize,
+            required=required,
+            name=name,
         )
 
         self._clients.append(client)
@@ -163,7 +163,7 @@ class Model:
         Adds a depot with the given attributes to the model. Returns the
         created :class:`~pyvrp._pyvrp.Depot` instance.
         """
-        depot = Depot(x, y, tw_early=tw_early, tw_late=tw_late, name=name)
+        depot = Depot(x=x, y=y, tw_early=tw_early, tw_late=tw_late, name=name)
         self._depots.append(depot)
         return depot
 
@@ -199,7 +199,7 @@ class Model:
             """
             warn(msg, ScalingWarning)
 
-        edge = Edge(frm, to, distance, duration)
+        edge = Edge(frm=frm, to=to, distance=distance, duration=duration)
         self._edges.append(edge)
         return edge
 
@@ -238,15 +238,15 @@ class Model:
             raise ValueError("The given depot is not in this model instance.")
 
         vehicle_type = VehicleType(
-            num_available,
-            capacity,
-            depot_idx,
-            fixed_cost,
-            tw_early,
-            tw_late,
-            max_duration,
-            max_distance,
-            name,
+            num_available=num_available,
+            capacity=capacity,
+            depot=depot_idx,
+            fixed_cost=fixed_cost,
+            tw_early=tw_early,
+            tw_late=tw_late,
+            max_duration=max_duration,
+            max_distance=max_distance,
+            name=name,
         )
 
         self._vehicle_types.append(vehicle_type)

--- a/pyvrp/_pyvrp.pyi
+++ b/pyvrp/_pyvrp.pyi
@@ -52,6 +52,7 @@ class Client:
         release_time: int = 0,
         prize: int = 0,
         required: bool = True,
+        *,
         name: str = "",
     ) -> None: ...
 
@@ -67,6 +68,7 @@ class Depot:
         y: int,
         tw_early: int = 0,
         tw_late: int = ...,
+        *,
         name: str = "",
     ) -> None: ...
 
@@ -90,6 +92,7 @@ class VehicleType:
         tw_late: int = ...,
         max_duration: int = ...,
         max_distance: int = ...,
+        *,
         name: str = "",
     ) -> None: ...
 

--- a/pyvrp/cpp/bindings.cpp
+++ b/pyvrp/cpp/bindings.cpp
@@ -84,6 +84,7 @@ PYBIND11_MODULE(_pyvrp, m)
              py::arg("release_time") = 0,
              py::arg("prize") = 0,
              py::arg("required") = true,
+             py::kw_only(),
              py::arg("name") = "")
         .def_readonly("x", &ProblemData::Client::x)
         .def_readonly("y", &ProblemData::Client::y)
@@ -113,6 +114,7 @@ PYBIND11_MODULE(_pyvrp, m)
              py::arg("y"),
              py::arg("tw_early") = 0,
              py::arg("tw_late") = std::numeric_limits<pyvrp::Duration>::max(),
+             py::kw_only(),
              py::arg("name") = "")
         .def_readonly("x", &ProblemData::Depot::x)
         .def_readonly("y", &ProblemData::Depot::y)
@@ -147,6 +149,7 @@ PYBIND11_MODULE(_pyvrp, m)
              = std::numeric_limits<pyvrp::Duration>::max(),
              py::arg("max_distance")
              = std::numeric_limits<pyvrp::Distance>::max(),
+             py::kw_only(),
              py::arg("name") = "")
         .def_readonly("num_available", &ProblemData::VehicleType::numAvailable)
         .def_readonly("depot", &ProblemData::VehicleType::depot)


### PR DESCRIPTION
@wouterkool and I discussed this a little while back. We'd like to have the `name` argument at the end, but that, combined with positional arguments, would make any new attribute positioned before `name` a breaking change. Making `name` keyword only solves that problem.

<details>

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
