### PR TITLE
Print "-" as cost when population is empty

### DIFF
--- a/pyvrp/ProgressPrinter.py
+++ b/pyvrp/ProgressPrinter.py
@@ -69,11 +69,11 @@ class ProgressPrinter:
             iters=stats.num_iterations,
             elapsed=round(sum(stats.runtimes)),
             feas_size=feas.size,
-            feas_avg=round(feas.avg_cost),
-            feas_best=round(feas.best_cost),
+            feas_avg=round(feas.avg_cost) if feas.size else "-",
+            feas_best=round(feas.best_cost) if feas.size else "-",
             infeas_size=infeas.size,
-            infeas_avg=round(infeas.avg_cost),
-            infeas_best=round(infeas.best_cost),
+            infeas_avg=round(infeas.avg_cost) if infeas.size else "-",
+            infeas_best=round(infeas.best_cost) if infeas.size else "-",
         )
         print(msg)
 

--- a/tests/test_ProgressPrinter.py
+++ b/tests/test_ProgressPrinter.py
@@ -1,3 +1,4 @@
+import pytest
 from numpy.testing import assert_, assert_equal
 
 from pyvrp import (
@@ -147,3 +148,48 @@ def test_should_print_false_no_output(ok_small, capsys):
 
     out = capsys.readouterr().out
     assert_equal(out, "")
+
+
+@pytest.mark.parametrize(
+    "routes",
+    [
+        [[1, 2], [3, 4]],  # feasible
+        [[1, 2, 3, 4]],  # infeasible
+    ],
+)
+def test_print_dash_when_subpopulation_is_empty(ok_small, routes, capsys):
+    """
+    Tests that a "-" is printed as cost when one of the subpopulations is
+    empty.
+    """
+    pop = Population(bpd)
+    cost_eval = CostEvaluator(1, 1, 0)
+
+    solution = Solution(ok_small, routes)
+    pop.add(solution, cost_eval)
+
+    stats = Statistics()
+    stats.collect_from(pop, cost_eval)
+    stats.num_iterations = 500  # force printing
+
+    printer = ProgressPrinter(should_print=True)
+    printer.iteration(stats)
+
+    # Population contains either one feasible or one infeasible solution, so
+    # the costs of the empty subpopulation should be printed as "-".
+    out = capsys.readouterr().out
+    assert_("-" in out)
+
+    # Add many solutions to make both subpopulations non-empty.
+    rng = RandomNumberGenerator(seed=42)
+    for _ in range(100):
+        pop.add(Solution.make_random(ok_small, rng), cost_eval)
+
+    stats.collect_from(pop, cost_eval)
+    stats.num_iterations = 500  # force printing
+    printer.iteration(stats)
+
+    # The "-" should not be printed anymore, but there should be some output.
+    out = capsys.readouterr().out
+    assert_("-" not in out)
+    assert_(out != "")

--- a/tests/test_ProgressPrinter.py
+++ b/tests/test_ProgressPrinter.py
@@ -159,8 +159,7 @@ def test_should_print_false_no_output(ok_small, capsys):
 )
 def test_print_dash_when_subpopulation_is_empty(ok_small, routes, capsys):
     """
-    Tests that a "-" is printed as cost when one of the subpopulations is
-    empty.
+    Tests that a "-" is printed as cost if one of the subpopulations is empty.
     """
     pop = Population(bpd)
     cost_eval = CostEvaluator(1, 1, 0)
@@ -180,7 +179,7 @@ def test_print_dash_when_subpopulation_is_empty(ok_small, routes, capsys):
     out = capsys.readouterr().out
     assert_("-" in out)
 
-    # Add many solutions to make both subpopulations non-empty.
+    # Now we add many solutions to make both subpopulations non-empty.
     rng = RandomNumberGenerator(seed=42)
     for _ in range(100):
         pop.add(Solution.make_random(ok_small, rng), cost_eval)

--- a/tests/test_ProgressPrinter.py
+++ b/tests/test_ProgressPrinter.py
@@ -178,17 +178,3 @@ def test_print_dash_when_subpopulation_is_empty(ok_small, routes, capsys):
     # the costs of the empty subpopulation should be printed as "-".
     out = capsys.readouterr().out
     assert_("-" in out)
-
-    # Now we add many solutions to make both subpopulations non-empty.
-    rng = RandomNumberGenerator(seed=42)
-    for _ in range(100):
-        pop.add(Solution.make_random(ok_small, rng), cost_eval)
-
-    stats.collect_from(pop, cost_eval)
-    stats.num_iterations = 500  # force printing
-    printer.iteration(stats)
-
-    # The "-" should not be printed anymore, but there should be some output.
-    out = capsys.readouterr().out
-    assert_("-" not in out)
-    assert_(out != "")


### PR DESCRIPTION
This PR prints a dash as cost in the progress printer whenever the subpopulation is empty. This fixes a ValueError that is raised because of rounding NaN values.

<details>

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
