### PR TITLE
Run CD also on pushed to main

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-22.04, windows-2022, macos-11 ]
+        os: [ ubuntu-22.04, windows-2022, macos-13 ]
     steps:
       - uses: actions/checkout@v4
       - name: Install rtools

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -35,7 +35,7 @@ jobs:
           output-dir: dist
       - uses: actions/upload-artifact@v4  # upload all wheels
         with:
-          name: dist
+          name: dist-${{ matrix.os }}
           path: ./dist/*
 
   deploy:
@@ -55,7 +55,8 @@ jobs:
           pip install poetry
       - uses: actions/download-artifact@v4  # download previously built wheels
         with:
-          name: dist
+          pattern: dist-*
+          merge-multiple: true
           path: dist/
       - name: Build sdist
         run: poetry build --format sdist

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-22.04, windows-2022, macos-12 ]
+        os: [ ubuntu-22.04, windows-2022, macos-14 ]
     steps:
       - uses: actions/checkout@v4
       - name: Install rtools

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -29,7 +29,7 @@ jobs:
           choco install rtools -y --no-progress --force --version=4.0.0.20220206
           echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.3
+        uses: pypa/cibuildwheel@v2.16.5
         with:
           package-dir: .
           output-dir: dist

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -3,6 +3,10 @@ name: CD
 on:
   release:
     types: [ created ]
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 concurrency:
   group: ${{ github.ref }}
@@ -14,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-22.04, windows-2022, macos-11 ]
     steps:
       - uses: actions/checkout@v4
       - name: Install rtools
@@ -37,7 +41,8 @@ jobs:
   deploy:
     name: Deploy to PyPI
     needs: [ build ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'release' && github.event.action == 'created'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-22.04, windows-2022, macos-13 ]
+        os: [ ubuntu-22.04, windows-2022, macos-12 ]
     steps:
       - uses: actions/checkout@v4
       - name: Install rtools

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -5,8 +5,6 @@ on:
     types: [ created ]
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 concurrency:
   group: ${{ github.ref }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
     name: >
       Build and test pyvrp using ${{ matrix.compiler }} 
       ${{ matrix.compiler-version }} and Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/DOC.yml
+++ b/.github/workflows/DOC.yml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: "pages"
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   deploy:

--- a/.github/workflows/DOC.yml
+++ b/.github/workflows/DOC.yml
@@ -20,7 +20,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up pages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyvrp"
-version = "0.8.0"
+version = "0.8.1"
 description = "A state-of-the-art vehicle routing problem solver."
 authors = [
     "Niels Wouda <nielswouda@gmail.com>",

--- a/pyvrp/cpp/ProblemData.cpp
+++ b/pyvrp/cpp/ProblemData.cpp
@@ -320,10 +320,10 @@ void ProblemData::validate() const
         if (!client.group)
             continue;
 
-        if (client.group.value() >= numGroups())
+        if (*client.group >= numGroups())
             throw std::out_of_range("Client references invalid group.");
 
-        auto const &group = groups_[client.group.value()];
+        auto const &group = groups_[*client.group];
         if (std::find(group.begin(), group.end(), idx) == group.end())
         {
             auto const *msg = "Client not in the group it references.";
@@ -355,7 +355,7 @@ void ProblemData::validate() const
                 throw std::out_of_range("Group references invalid client.");
 
             ProblemData::Client const &clientData = location(client);
-            if (!clientData.group || clientData.group.value() != idx)
+            if (!clientData.group || *clientData.group != idx)
             {
                 auto const *msg = "Group references client not in group.";
                 throw std::invalid_argument(msg);

--- a/pyvrp/cpp/search/LocalSearch.cpp
+++ b/pyvrp/cpp/search/LocalSearch.cpp
@@ -278,7 +278,7 @@ void LocalSearch::applyGroupMoves(Route::Node *U,
     if (!uData.group)
         return;
 
-    auto const &group = data.group(uData.group.value());
+    auto const &group = data.group(*uData.group);
     assert(group.mutuallyExclusive);
 
     std::vector<size_t> inSol;


### PR DESCRIPTION
This PR:
- fixes a CD build issue on Windows by bumping to CIBW 2.16.5
- provides a workaround for macOS's inability to handle `std::optional::value`
- fixes uploading and downloading artefacts of the same name

Since this stuff's horribly annoying, from now on we're also going to test run the CD every time we push to main.