### PR TITLE
Randomly select optional clients in Solution random constructor

### DIFF
--- a/pyvrp/cpp/RandomNumberGenerator.cpp
+++ b/pyvrp/cpp/RandomNumberGenerator.cpp
@@ -34,3 +34,8 @@ std::array<uint32_t, 4> const &RandomNumberGenerator::state() const
 {
     return state_;
 }
+
+double RandomNumberGenerator::rand()
+{
+    return operator()() / static_cast<double>(max());
+}

--- a/pyvrp/cpp/RandomNumberGenerator.h
+++ b/pyvrp/cpp/RandomNumberGenerator.h
@@ -55,7 +55,7 @@ public:
      *
      * @return A pseudo-random number in the range [0, 1].
      */
-    template <typename T> T rand();
+    double rand();
 
     /**
      * Generates one pseudo-random integer in the range <code>[0, high)</code>.
@@ -80,12 +80,6 @@ constexpr size_t RandomNumberGenerator::min()
 constexpr size_t RandomNumberGenerator::max()
 {
     return std::numeric_limits<result_type>::max();
-}
-
-template <typename T> T RandomNumberGenerator::rand()
-{
-    static_assert(std::is_floating_point<T>::value);
-    return operator()() / static_cast<T>(max());
 }
 
 template <typename T>

--- a/pyvrp/cpp/Solution.cpp
+++ b/pyvrp/cpp/Solution.cpp
@@ -163,8 +163,7 @@ Solution::Solution(ProblemData const &data, RandomNumberGenerator &rng)
 
     // ...but we select only one client per mutually exclusive group.
     for (auto const &group : data.groups())
-        if (!group.empty())
-            clients.push_back(group.clients()[rng.randint(group.size())]);
+        clients.push_back(group.clients()[rng.randint(group.size())]);
 
     // Shuffle clients to create random routes.
     std::shuffle(clients.begin(), clients.end(), rng);

--- a/pyvrp/cpp/Solution.cpp
+++ b/pyvrp/cpp/Solution.cpp
@@ -150,20 +150,13 @@ Solution::Solution(ProblemData const &data, RandomNumberGenerator &rng)
 {
     std::vector<size_t> clients;
 
-    // First we add all required clients and some groupless optional clients...
+    // Add all required clients, but randomly select optional clients.
     for (size_t idx = data.numDepots(); idx != data.numLocations(); ++idx)
     {
         pyvrp::ProblemData::Client const &clientData = data.location(idx);
-
-        if (clientData.required)
-            clients.push_back(idx);
-        else if (!clientData.group && rng.randint(2))  // select randomly
+        if (clientData.required || rng.rand() < 0.5)
             clients.push_back(idx);
     }
-
-    // ...but we select only one client per mutually exclusive group.
-    for (auto const &group : data.groups())
-        clients.push_back(group.clients()[rng.randint(group.size())]);
 
     // Shuffle clients to create random routes.
     std::shuffle(clients.begin(), clients.end(), rng);

--- a/pyvrp/cpp/Solution.cpp
+++ b/pyvrp/cpp/Solution.cpp
@@ -148,16 +148,33 @@ bool Solution::operator==(Solution const &other) const
 Solution::Solution(ProblemData const &data, RandomNumberGenerator &rng)
     : neighbours_(data.numLocations(), std::nullopt)
 {
+    std::vector<size_t> clients;
+
+    // First add all required clients and some groupless optional clients...
+    for (size_t idx = data.numDepots(); idx != data.numLocations(); ++idx)
+    {
+        pyvrp::ProblemData::Client const &clientData = data.location(idx);
+
+        if (clientData.required)
+            clients.push_back(idx);
+        else if (!clientData.group && rng.randint(2))
+            clients.push_back(idx);
+    }
+
+    // ...but we select only one client per mutually exclusive group.
+    for (auto const &group : data.groups())
+        if (!group.empty())
+            clients.push_back(group.clients()[rng.randint(group.size())]);
+
+
     // Shuffle clients to create random routes.
-    auto clients = std::vector<size_t>(data.numClients());
-    std::iota(clients.begin(), clients.end(), data.numDepots());
     std::shuffle(clients.begin(), clients.end(), rng);
 
     // Distribute clients evenly over the routes: the total number of clients
     // per vehicle, with an adjustment in case the division is not perfect and
     // there are not enough vehicles for single-client routes.
     auto const numVehicles = data.numVehicles();
-    auto const numClients = data.numClients();
+    auto const numClients = clients.size();
     auto const perVehicle = std::max<size_t>(numClients / numVehicles, 1);
     auto const adjustment
         = numClients > numVehicles && numClients % numVehicles != 0;

--- a/pyvrp/cpp/Solution.cpp
+++ b/pyvrp/cpp/Solution.cpp
@@ -150,14 +150,14 @@ Solution::Solution(ProblemData const &data, RandomNumberGenerator &rng)
 {
     std::vector<size_t> clients;
 
-    // First add all required clients and some groupless optional clients...
+    // First we add all required clients and some groupless optional clients...
     for (size_t idx = data.numDepots(); idx != data.numLocations(); ++idx)
     {
         pyvrp::ProblemData::Client const &clientData = data.location(idx);
 
         if (clientData.required)
             clients.push_back(idx);
-        else if (!clientData.group && rng.randint(2))
+        else if (!clientData.group && rng.randint(2))  // select randomly
             clients.push_back(idx);
     }
 

--- a/pyvrp/cpp/Solution.cpp
+++ b/pyvrp/cpp/Solution.cpp
@@ -166,7 +166,6 @@ Solution::Solution(ProblemData const &data, RandomNumberGenerator &rng)
         if (!group.empty())
             clients.push_back(group.clients()[rng.randint(group.size())]);
 
-
     // Shuffle clients to create random routes.
     std::shuffle(clients.begin(), clients.end(), rng);
 

--- a/pyvrp/cpp/bindings.cpp
+++ b/pyvrp/cpp/bindings.cpp
@@ -812,7 +812,7 @@ PYBIND11_MODULE(_pyvrp, m)
         .def("min", &RandomNumberGenerator::min)
         .def("max", &RandomNumberGenerator::max)
         .def("__call__", &RandomNumberGenerator::operator())
-        .def("rand", &RandomNumberGenerator::rand<double>)
+        .def("rand", &RandomNumberGenerator::rand)
         .def("randint", &RandomNumberGenerator::randint<int>, py::arg("high"))
         .def("state", &RandomNumberGenerator::state);
 }

--- a/tests/search/test_LocalSearch.py
+++ b/tests/search/test_LocalSearch.py
@@ -192,6 +192,7 @@ def test_prize_collecting(prize_collecting):
     improved = ls.search(sol, cost_evaluator)
     improved_cost = cost_evaluator.penalised_cost(improved)
 
+    assert_(improved.num_clients() < prize_collecting.num_clients)
     assert_(improved_cost < sol_cost)
 
 

--- a/tests/search/test_LocalSearch.py
+++ b/tests/search/test_LocalSearch.py
@@ -465,7 +465,7 @@ def test_mutually_exclusive_group(gtsp):
     cost_eval = CostEvaluator(20, 6, 0)
     improved = ls(sol, cost_eval)
 
-    assert_(sol.is_group_feasible())
+    assert_(not sol.is_group_feasible())
     assert_(improved.is_group_feasible())
 
     sol_cost = cost_eval.penalised_cost(sol)

--- a/tests/search/test_LocalSearch.py
+++ b/tests/search/test_LocalSearch.py
@@ -184,9 +184,6 @@ def test_prize_collecting(prize_collecting):
     sol = Solution.make_random(prize_collecting, rng)
     sol_cost = cost_evaluator.penalised_cost(sol)
 
-    # Random solutions are complete...
-    assert_equal(sol.num_clients(), prize_collecting.num_clients)
-
     neighbours = compute_neighbours(prize_collecting)
     ls = LocalSearch(prize_collecting, rng, neighbours)
     ls.add_node_operator(Exchange10(prize_collecting))  # relocate
@@ -195,8 +192,6 @@ def test_prize_collecting(prize_collecting):
     improved = ls.search(sol, cost_evaluator)
     improved_cost = cost_evaluator.penalised_cost(improved)
 
-    # ...but an optimised prize-collecting solution is likely not complete.
-    assert_(improved.num_clients() < sol.num_clients())
     assert_(improved_cost < sol_cost)
 
 
@@ -470,7 +465,7 @@ def test_mutually_exclusive_group(gtsp):
     cost_eval = CostEvaluator(20, 6, 0)
     improved = ls(sol, cost_eval)
 
-    assert_(not sol.is_group_feasible())
+    assert_(sol.is_group_feasible())
     assert_(improved.is_group_feasible())
 
     sol_cost = cost_eval.penalised_cost(sol)

--- a/tests/test_Solution.py
+++ b/tests/test_Solution.py
@@ -1049,6 +1049,26 @@ def test_solution_feasibility_with_mutually_exclusive_groups(
     assert_equal(sol.is_group_feasible(), feasible)
 
 
+def test_mutually_exclusive_group_feasibility_bug(
+    ok_small_mutually_exclusive_groups,
+):
+    """
+    This tests a bug where the make_random() classmethod did not set the group
+    feasibility flag correctly, leading it to believe that every solution was
+    feasible w.r.t. the client groups.
+    """
+    rng = RandomNumberGenerator(seed=42)
+
+    group_feasible = []
+    for _ in range(10):
+        sol = Solution.make_random(ok_small_mutually_exclusive_groups, rng)
+        group_feasible.append(sol.is_group_feasible())
+
+    # Randomly constructed solutions can be group feasible or not.
+    assert_(True in group_feasible)
+    assert_(False in group_feasible)
+
+
 def test_optional_mutually_exclusive_group(ok_small):
     """
     Tests that mutually exclusive client groups can be skipped if they are

--- a/tests/test_Solution.py
+++ b/tests/test_Solution.py
@@ -148,8 +148,8 @@ def test_random_constructor_uniformly_selects_groupless_optional_clients(
     sols = [Solution.make_random(ok_small_prizes, rng) for _ in range(100)]
     avg_num_clients = np.mean([sol.num_clients() for sol in sols])
 
-    # There are 4 clients, three which are optional, so the average number of
-    # clients should be close to 2.5.
+    # There are 4 clients, three of which are optional, so the average number
+    # of clients should be close to 2.5.
     assert_allclose(avg_num_clients, 2.5, atol=0.1)
 
 

--- a/tests/test_Solution.py
+++ b/tests/test_Solution.py
@@ -136,12 +136,12 @@ def test_random_constructor_uses_all_routes(ok_small, num_vehicles):
     assert_equal(len(routes), data.num_clients)
 
 
-def test_random_constructor_uniformly_selects_groupless_optional_clients(
+def test_random_constructor_randomly_selects_optional_clients(
     ok_small_prizes,
 ):
     """
-    Tests that the randomly constructed solution selects groupless optional
-    clients uniformly at random.
+    Tests that the randomly constructed solution selects optional clients
+    uniformly at random.
     """
     rng = RandomNumberGenerator(seed=42)
 
@@ -151,17 +151,6 @@ def test_random_constructor_uniformly_selects_groupless_optional_clients(
     # There are 4 clients, three of which are optional, so the average number
     # of clients should be close to 2.5.
     assert_allclose(avg_num_clients, 2.5, atol=0.1)
-
-
-def test_random_constructor_creates_group_feasible_solutions(ok_small):
-    """
-    Tests that the randomly constructed solution is always group feasible.
-    """
-    rng = RandomNumberGenerator(seed=42)
-    sol = Solution.make_random(ok_small, rng)
-
-    for _ in range(50):
-        assert_(sol.is_group_feasible())
 
 
 def test_route_constructor_raises_too_many_vehicles(ok_small):

--- a/tests/test_Solution.py
+++ b/tests/test_Solution.py
@@ -1049,26 +1049,6 @@ def test_solution_feasibility_with_mutually_exclusive_groups(
     assert_equal(sol.is_group_feasible(), feasible)
 
 
-def test_mutually_exclusive_group_feasibility_bug(
-    ok_small_mutually_exclusive_groups,
-):
-    """
-    This tests a bug where the make_random() classmethod did not set the group
-    feasibility flag correctly, leading it to believe that every solution was
-    feasible w.r.t. the client groups.
-    """
-    rng = RandomNumberGenerator(seed=42)
-
-    group_feasible = []
-    for _ in range(10):
-        sol = Solution.make_random(ok_small_mutually_exclusive_groups, rng)
-        group_feasible.append(sol.is_group_feasible())
-
-    # Randomly constructed solutions can be group feasible or not.
-    assert_(True in group_feasible)
-    assert_(False in group_feasible)
-
-
 def test_optional_mutually_exclusive_group(ok_small):
     """
     Tests that mutually exclusive client groups can be skipped if they are

--- a/tests/test_Solution.py
+++ b/tests/test_Solution.py
@@ -136,6 +136,34 @@ def test_random_constructor_uses_all_routes(ok_small, num_vehicles):
     assert_equal(len(routes), data.num_clients)
 
 
+def test_random_constructor_uniformly_selects_groupless_optional_clients(
+    ok_small_prizes,
+):
+    """
+    Tests that the randomly constructed solution selects groupless optional
+    clients uniformly at random.
+    """
+    rng = RandomNumberGenerator(seed=42)
+
+    sols = [Solution.make_random(ok_small_prizes, rng) for _ in range(100)]
+    avg_num_clients = np.mean([sol.num_clients() for sol in sols])
+
+    # There are 4 clients, three which are optional, so the average number of
+    # clients should be close to 2.5.
+    assert_allclose(avg_num_clients, 2.5, atol=0.1)
+
+
+def test_random_constructor_creates_group_feasible_solutions(ok_small):
+    """
+    Tests that the randomly constructed solution is always group feasible.
+    """
+    rng = RandomNumberGenerator(seed=42)
+    sol = Solution.make_random(ok_small, rng)
+
+    for _ in range(50):
+        assert_(sol.is_group_feasible())
+
+
 def test_route_constructor_raises_too_many_vehicles(ok_small):
     """
     Tests that constructing a solution with more routes than available in the
@@ -1030,10 +1058,6 @@ def test_solution_feasibility_with_mutually_exclusive_groups(
     sol = Solution(data, routes)
     assert_equal(sol.is_feasible(), feasible)
     assert_equal(sol.is_group_feasible(), feasible)
-
-def test_random_solution_randomly_selects_groupless_optional_clients(ok_small):
-    pass
-    #    sol = Solution.make_random(prize_collecting, rng) 
 
 
 def test_optional_mutually_exclusive_group(ok_small):

--- a/tests/test_Solution.py
+++ b/tests/test_Solution.py
@@ -1031,20 +1031,9 @@ def test_solution_feasibility_with_mutually_exclusive_groups(
     assert_equal(sol.is_feasible(), feasible)
     assert_equal(sol.is_group_feasible(), feasible)
 
-
-def test_mutually_exclusive_group_feasibility_bug(
-    ok_small_mutually_exclusive_groups,
-):
-    """
-    This tests a bug where the make_random() classmethod did not set the group
-    feasibility flag correctly, leading it to believe that every solution was
-    feasible w.r.t. the client groups.
-    """
-    rng = RandomNumberGenerator(seed=42)
-    sol = Solution.make_random(ok_small_mutually_exclusive_groups, rng)
-
-    assert_(not sol.is_feasible())
-    assert_(not sol.is_group_feasible())
+def test_random_solution_randomly_selects_groupless_optional_clients(ok_small):
+    pass
+    #    sol = Solution.make_random(prize_collecting, rng) 
 
 
 def test_optional_mutually_exclusive_group(ok_small):


### PR DESCRIPTION
This PR solves the problem identified in #539, in which a small PCTSP instance could not be solved to optimality. The proposed fix is to change the way we initialize random solutions, which now 1) always produces group feasible solutions and 2) randomly selects groupless, optional clients.

Note: this also now optimally solves the PCTSP instance :-)

- [x] Closes #539.
- [x] Adds and passes relevant tests.
- [ ] Has well-formatted code and documentation.

<details>

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
