### PR TITLE
Simplify code coverage builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -89,11 +89,13 @@ jobs:
         run: |
           poetry install --only-root
           poetry run python build_extensions.py --build_type debug --clean
-      - name: Run tests and generate reports coverage
-        run: |
-          poetry run pytest
-          poetry run gcovr --filter pyvrp/cpp/ -o coverage.txt
-      - uses: codecov/codecov-action@v4
+      - name: Run tests
+        run: poetry run pytest
+      - if: matrix.compiler == 'gcc'
+        name: Generate coverage reports
+        run: poetry run gcovr --filter pyvrp/cpp/ -o coverage.txt
+      - if: matrix.compiler == 'gcc'
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,14 +92,11 @@ jobs:
       - name: Run tests
         run: poetry run pytest
       - if: matrix.compiler == 'gcc'
-        name: Generate coverage reports
-        run: poetry run gcovr --filter pyvrp/cpp/ -o coverage.txt
-      - if: matrix.compiler == 'gcc'
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.xml, coverage.txt
+          plugins: gcov, pycoverage
       - if: matrix.compiler == 'gcc'
         name: Install Valgrind
         run: sudo apt install valgrind

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           poetry install --only-root
           poetry run python build_extensions.py --build_type debug --clean
-      - name: Run tests
+      - name: Run tests and generate coverage reports
         run: |
           poetry run pytest
           poetry run ninja coverage-xml -C build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -89,16 +89,15 @@ jobs:
         run: |
           poetry install --only-root
           poetry run python build_extensions.py --build_type debug --clean
-      - name: Run tests
-        run: poetry run pytest
-      - if: matrix.compiler == 'gcc'
-        # Clang does not generate accurate coverage reports, so there is no
-        # point in uploading those.
-        uses: codecov/codecov-action@v4
+      - name: Run tests and generate reports coverage
+        run: |
+          poetry run pytest
+          poetry run gcovr --filter pyvrp/cpp/ -o coverage.txt
+      - uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
-          plugins: gcov, pycoverage
+          files: coverage.xml, coverage.txt
       - if: matrix.compiler == 'gcc'
         name: Install Valgrind
         run: sudo apt install valgrind

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -90,13 +90,15 @@ jobs:
           poetry install --only-root
           poetry run python build_extensions.py --build_type debug --clean
       - name: Run tests
-        run: poetry run pytest
-      - if: matrix.compiler == 'gcc'
-        uses: codecov/codecov-action@v4
+        run: |
+          poetry run pytest
+          poetry run ninja coverage-xml -C build
+      - uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
-          plugins: gcov, pycoverage
+          plugins: pycoverage
+          files: build/meson-logs/coverage.xml
       - if: matrix.compiler == 'gcc'
         name: Install Valgrind
         run: sudo apt install valgrind

--- a/.gitignore
+++ b/.gitignore
@@ -80,7 +80,6 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
-coverage.txt
 *.cover
 .hypothesis/
 .pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage.txt
 *.cover
 .hypothesis/
 .pytest_cache/

--- a/build_extensions.py
+++ b/build_extensions.py
@@ -93,6 +93,7 @@ def configure(
         f"-Dpython.platlibdir={cwd.absolute()}",
         f"-Dproblem={problem}",
         f"-Dstrip={'true' if build_type == 'release' else 'false'}",
+        f"-Db_coverage={'true' if build_type != 'release' else 'false'}",
         *additional,
         # fmt: on
     ]

--- a/gcovr.cfg
+++ b/gcovr.cfg
@@ -1,2 +1,3 @@
 exclude-unreachable-branches = yes
+exclude-throw-branches = yes
 filter = pyvrp/

--- a/gcovr.cfg
+++ b/gcovr.cfg
@@ -1,0 +1,2 @@
+exclude-unreachable-branches = yes
+filter = pyvrp/

--- a/meson.build
+++ b/meson.build
@@ -11,16 +11,6 @@ project(
     ]
 )
 
-if get_option('buildtype') == 'debug'
-    compiler = meson.get_compiler('cpp')
-
-    if compiler.has_argument('-fprofile-abs-path')
-        # clang does not have this particular flag, so we only add it when
-        # compiling with gcc. It's helpful in determining code coverage.
-        add_project_arguments('-fprofile-abs-path', language: 'cpp')
-    endif
-endif
-
 if get_option('problem') == 'cvrp'
     # CVRP does not have time windows, so we set a flag that compiles time 
     # window stuff out of the extension modules.

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,16 @@ project(
     ]
 )
 
+if get_option('buildtype') == 'debug'
+    compiler = meson.get_compiler('cpp')
+
+    if compiler.has_argument('-fprofile-abs-path')
+        # clang does not have this particular flag, so we only add it when
+        # compiling with gcc. It's helpful in determining code coverage.
+        add_project_arguments('-fprofile-abs-path', language: 'cpp')
+    endif
+endif
+
 if get_option('problem') == 'cvrp'
     # CVRP does not have time windows, so we set a flag that compiles time 
     # window stuff out of the extension modules.

--- a/meson.build
+++ b/meson.build
@@ -11,19 +11,6 @@ project(
     ]
 )
 
-if get_option('buildtype') == 'debug'
-    compiler = meson.get_compiler('cpp')
-
-    if compiler.has_argument('-fprofile-abs-path')
-        # clang does not have this particular flag, so we only add it when
-        # compiling with gcc. It's helpful in determining code coverage.
-        add_project_arguments('-fprofile-abs-path', language: 'cpp')
-    endif
-
-    add_project_arguments('--coverage', language: 'cpp')
-    add_project_link_arguments('--coverage', language: 'cpp')
-endif
-
 if get_option('problem') == 'cvrp'
     # CVRP does not have time windows, so we set a flag that compiles time 
     # window stuff out of the extension modules.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ tabulate = "^0.9.0"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^2.20.0"
+gcovr = "^7.2"
 pytest = ">=6.0.0"
 pytest-cov = ">=2.6.1"
 codecov = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,6 @@ tabulate = "^0.9.0"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^2.20.0"
-gcovr = "^7.2"
 pytest = ">=6.0.0"
 pytest-cov = ">=2.6.1"
 codecov = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,9 +88,11 @@ pytest-cov = ">=2.6.1"
 codecov = "*"
 
 # These are used in the build script: for compiling the library (meson, ninja)
-# and for generating doc or type stubs (docblock, mypy).
+# and for generating docs (docblock), type stubs (mypy), and coverage reports
+# (gcovr).
 meson = "^1.0.0"
 ninja = "^1.11.1"
+gcovr = "^7.2"
 mypy = "^0.991"
 docblock = "^0.1.5"
 

--- a/pyvrp/cpp/search/SwapTails.cpp
+++ b/pyvrp/cpp/search/SwapTails.cpp
@@ -20,10 +20,10 @@ pyvrp::Cost SwapTails::evaluate(Route::Node *U,
 
     // We're going to incur fixed cost if a route is currently empty but
     // becomes non-empty due to the proposed move.
-    if (uRoute->empty() && U->isDepot() && !n(V)->isDepot())
+    if (uRoute->empty() && !n(V)->isDepot())
         deltaCost += uRoute->fixedVehicleCost();
 
-    if (vRoute->empty() && V->isDepot() && !n(U)->isDepot())
+    if (vRoute->empty() && !n(U)->isDepot())
         deltaCost += vRoute->fixedVehicleCost();
 
     // We lose fixed cost if a route becomes empty due to the proposed move.


### PR DESCRIPTION
This PR uses Meson's `b_coverage` setting to handle code coverage builds. That now also works with clang (rather than just gcc before). So, this PR:

- [x] Closes #68.
- [x] Adds and passes relevant tests.
- [x] Has well-formatted code and documentation.

<details>

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
