### PR TITLE
Add profile-guided optimisation option to build script

### DIFF
--- a/build_extensions.py
+++ b/build_extensions.py
@@ -109,6 +109,9 @@ def build(
 
 
 def workload():
+    # TODO if and when we actually start using PGO we should probably rethink
+    # what the profiling workload needs to be. For example, larger instances
+    # are harder to solve, so perhaps we should optimise for those?
     cmds = [
         "pytest",
         "pyvrp --seed 1 tests/data/X-n101-50-k13.vrp --max_runtime 5",

--- a/build_extensions.py
+++ b/build_extensions.py
@@ -111,8 +111,8 @@ def build(
 def workload():
     cmds = [
         "pytest",
-        "pyvrp --seed 1 instances/CVRP/X-n101-k25.vrp --max_runtime 5",
-        "pyvrp --seed 2 instances/VRPTW/RC1_10_1.vrp --max_runtime 5",
+        "pyvrp --seed 1 tests/data/X-n101-50-k13.vrp --max_runtime 5",
+        "pyvrp --seed 2 tests/data/RC208.vrp --max_runtime 5",
     ]
 
     for cmd in cmds:

--- a/build_extensions.py
+++ b/build_extensions.py
@@ -123,39 +123,27 @@ def main():
     args = parse_args()
     cwd = pathlib.Path.cwd()
     build_dir = cwd / args.build_dir
-    install_dir = cwd / "pyvrp"
 
     if args.clean or os.environ.get("CIBUILDWHEEL", "0") == "1":
         # Always start from an entirely clean build when building wheels in
         # the CI. Else only do so when expressly asked.
+        install_dir = cwd / "pyvrp"
         clean(build_dir, install_dir)
 
+    build_args = (
+        build_dir,
+        args.build_type,
+        args.problem,
+        args.verbose,
+        *args.additional,
+    )
+
     if args.use_pgo:
-        build(
-            build_dir,
-            args.build_type,
-            args.problem,
-            args.verbose,
-            *args.additional,
-            "-Db_pgo=generate",
-        )
+        build(*build_args, "-Db_pgo=generate")
         workload()
-        build(
-            build_dir,
-            args.build_type,
-            args.problem,
-            args.verbose,
-            *args.additional,
-            "-Db_pgo=use",
-        )
+        build(*build_args, "-Db_pgo=use")
     else:
-        build(
-            build_dir,
-            args.build_type,
-            args.problem,
-            args.verbose,
-            *args.additional,
-        )
+        build(*build_args)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,12 +88,10 @@ pytest-cov = ">=2.6.1"
 codecov = "*"
 
 # These are used in the build script: for compiling the library (meson, ninja)
-# and for generating docs (docblock), type stubs (mypy), and coverage reports
-# (gcovr).
+# and generating docs (docblock) and coverage reports (gcovr).
 meson = "^1.0.0"
 ninja = "^1.11.1"
 gcovr = "^7.2"
-mypy = "^0.991"
 docblock = "^0.1.5"
 
 


### PR DESCRIPTION
This PR:

- [x] Closes #556.
- [ ] Adds and passes relevant tests.
- [ ] Has well-formatted code and documentation.

### Benchmark on VRPTW

This PR (47f0dc2353b9d540743a124b53fe81dc4c537aad; job ID 7853551):
```
                MEAN       MIN       MAX  COV
      inst
obj   C1     41370.5   41337.2   41410.1  0.1
      C2     16201.1   16197.0   16204.4  0.0
      R1     47275.8   47227.9   47369.6  0.1
      R2     27810.9   27769.4   27856.3  0.1
      RC1    44286.4   44252.1   44336.9  0.1
      RC2    23294.8   23278.0   23331.1  0.1
iters C1     76502.0   60675.2   82545.9  7.9
      C2    112465.3  101503.5  117537.5  4.2
      R1     40315.5   33021.9   43240.8  7.6
      R2     70731.8   60786.7   76122.6  7.3
      RC1    41620.9   33969.7   44552.4  7.6
      RC2    78788.7   66588.6   85885.9  7.6
```

Current main (2feef56c67477d3e7e69ae7da6617962f53ad3ba; job ID 7852597):
```
                MEAN      MIN       MAX   COV
      inst
obj   C1     41372.7  41338.2   41409.0   0.1
      C2     16201.1  16197.4   16204.2   0.0
      R1     47269.2  47240.2   47317.9   0.0
      R2     27813.0  27767.3   27859.4   0.1
      RC1    44288.1  44258.0   44354.1   0.1
      RC2    23293.7  23277.6   23323.8   0.1
iters C1     77582.0  66226.6   84924.5   7.1
      C2    112501.9  96835.1  137578.3   9.4
      R1     41034.4  37063.8   47525.9   7.4
      R2     73104.5  59404.6   88665.7  11.5
      RC1    41734.7  35304.5   48645.4   9.5
      RC2    75931.1  61890.8   91481.5  10.0
```

<details>

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
