### PR TITLE
Fix integer overflow issue in DurationSegment

### DIFF
--- a/pyvrp/cpp/DurationSegment.h
+++ b/pyvrp/cpp/DurationSegment.h
@@ -135,7 +135,7 @@ DurationSegment DurationSegment::merge(Matrix<Duration> const &durationMatrix,
     // client, and atOther the time (after starting from our first client) at
     // which we arrive there.
     Dur const edgeDuration = durationMatrix(idxLast_, other.idxFirst_);
-    Dur const atOther = std::max<Dur>(duration_ - timeWarp_ + edgeDuration, 0);
+    Dur const atOther = duration_ - timeWarp_ + edgeDuration;
 
     // Time warp increases if we arrive at the other's first client after its
     // time window closes, whereas wait duration increases if we arrive there

--- a/pyvrp/cpp/DurationSegment.h
+++ b/pyvrp/cpp/DurationSegment.h
@@ -135,7 +135,7 @@ DurationSegment DurationSegment::merge(Matrix<Duration> const &durationMatrix,
     // client, and atOther the time (after starting from our first client) at
     // which we arrive there.
     Dur const edgeDuration = durationMatrix(idxLast_, other.idxFirst_);
-    Dur const atOther = duration_ - timeWarp_ + edgeDuration;
+    Dur const atOther = std::max<Dur>(duration_ - timeWarp_ + edgeDuration, 0);
 
     // Time warp increases if we arrive at the other's first client after its
     // time window closes, whereas wait duration increases if we arrive there

--- a/pyvrp/cpp/DurationSegment.h
+++ b/pyvrp/cpp/DurationSegment.h
@@ -146,15 +146,19 @@ DurationSegment DurationSegment::merge(Matrix<Duration> const &durationMatrix,
     Dur const diffWait = other.twEarly_ - atOther > twLate_
                              ? other.twEarly_ - atOther - twLate_
                              : 0;
-    Dur const otherTwLate
-        = atOther >= 0 ? other.twLate_ - atOther : other.twLate_;
+
+    // Only add atOther to other.twLate_ if it does not result in overflow.
+    Dur const maxDur = std::numeric_limits<Dur>::max();
+    Dur const twLateAtOther = atOther >= other.twLate_ - maxDur
+                                  ? other.twLate_ - atOther
+                                  : other.twLate_;
 
     return {idxFirst_,
             other.idxLast_,
             duration_ + other.duration_ + edgeDuration + diffWait,
             timeWarp_ + other.timeWarp_ + diffTw,
             std::max(other.twEarly_ - atOther, twEarly_) - diffWait,
-            std::min(otherTwLate, twLate_) + diffTw,
+            std::min(twLateAtOther, twLate_) + diffTw,
             std::max(releaseTime_, other.releaseTime_)};
 }
 

--- a/pyvrp/cpp/Measure.h
+++ b/pyvrp/cpp/Measure.h
@@ -207,12 +207,12 @@ template <pyvrp::MeasureType Type>
 class std::numeric_limits<pyvrp::Measure<Type>>
 {
 public:
-    static pyvrp::Value max()
+    static pyvrp::Measure<Type> max()
     {
         return std::numeric_limits<pyvrp::Value>::max();
     }
 
-    static pyvrp::Value min()
+    static pyvrp::Measure<Type> min()
     {
         return std::numeric_limits<pyvrp::Value>::min();
     }

--- a/tests/test_DurationSegment.py
+++ b/tests/test_DurationSegment.py
@@ -163,16 +163,21 @@ def test_OkSmall_with_time_warp(ok_small):
 
 def test_bug_fix_overflow_more_timewarp_than_duration():
     """
-    This test exercises the bug identified in issue #588, when merging a
-    duration segment that has more time warp than duration with another
-    duration segment that has ``twLate = INT_MAX``.
+    This test exercises the issue identified in #588, when merging a duration
+    segment that has more time warp than duration with another duration segment
+    that has ``twLate = INT_MAX`` results in integer overflow.
     """
     matrix = np.array([[0, 0], [0, 0]])
-    ds1 = DurationSegment(1, 1, 9, 18, 0, 18, 0)
-    ds2 = DurationSegment(0, 0, 0, 0, 0, np.iinfo(np.int64).max, 0)
-    ds = DurationSegment.merge(matrix, ds1, ds2)
 
-    # ds1 has 9 duration and 18 time warp, which results in an arrival time
-    # of -9 at ds2. Before enforcing non-negative arrival times, this would
-    # result in an integer overflow.
-    assert_(ds.time_warp() == 18)
+    ds1 = DurationSegment(1, 1, 9, 18, 0, 18, 0)
+    assert_(ds1.duration() < ds1.time_warp())
+
+    ds2 = DurationSegment(0, 0, 0, 0, 0, np.iinfo(np.int64).max, 0)
+    assert_equal(ds2.tw_late(), np.iinfo(np.int64).max)
+
+    # ds1 has 9 duration and 18 time warp, which results in an arrival time of
+    # -9 at ds2. Before enforcing non-negative arrival times, this would result
+    # in an integer overflow when subtracting this arrival time from ds2's
+    # tw_late.
+    ds = DurationSegment.merge(matrix, ds1, ds2)
+    assert_equal(ds.time_warp(), 18)

--- a/tests/test_DurationSegment.py
+++ b/tests/test_DurationSegment.py
@@ -175,5 +175,4 @@ def test_bug_fix_overflow_more_timewarp_than_duration():
     # ds1 has 9 duration and 18 time warp, which results in an arrival time
     # of -9 at ds2. Before enforcing non-negative arrival times, this would
     # result in an integer overflow.
-    assert_(ds.duration() == 9)
     assert_(ds.time_warp() == 18)

--- a/tests/test_DurationSegment.py
+++ b/tests/test_DurationSegment.py
@@ -159,3 +159,21 @@ def test_OkSmall_with_time_warp(ok_small):
     # drive 1427 and arrive at 3 at 15600 + 360 + 1427 = 17387. We then warp
     # back in time to 15300, for 17387 - 15300 = 2087 time warp.
     assert_equal(ds.time_warp(), 2087)
+
+
+def test_bug_fix_overflow_more_timewarp_than_duration():
+    """
+    This test exercises the bug identified in issue #588, when merging a
+    duration segment that has more time warp than duration with another
+    duration segment that has ``twLate = INT_MAX``.
+    """
+    matrix = np.array([[0, 0], [0, 0]])
+    ds1 = DurationSegment(1, 1, 9, 18, 0, 18, 0)
+    ds2 = DurationSegment(0, 0, 0, 0, 0, np.iinfo(np.int64).max, 0)
+    ds = DurationSegment.merge(matrix, ds1, ds2)
+
+    # ds1 has 9 duration and 18 time warp, which results in an arrival time
+    # of -9 at ds2. Before enforcing non-negative arrival times, this would
+    # result in an integer overflow.
+    assert_(ds.duration() == 9)
+    assert_(ds.time_warp() == 18)

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -7,15 +7,7 @@ from numpy.testing import (
     assert_warns,
 )
 
-from pyvrp import (
-    Client,
-    ClientGroup,
-    Depot,
-    Model,
-    Profile,
-    Route,
-    VehicleType,
-)
+from pyvrp import Client, ClientGroup, Depot, Model, Profile, VehicleType
 from pyvrp.constants import MAX_VALUE
 from pyvrp.exceptions import EmptySolutionWarning, ScalingWarning
 from pyvrp.stop import MaxIterations

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -454,45 +454,6 @@ def test_model_solves_small_instance_with_fixed_costs():
     assert_(res.is_feasible())
 
 
-def test_bug_fix_overflow_more_timewarp_than_duration():
-    """
-    This test exercises the bug identified in issue #588, where the solver
-    would hang on an instance with infeasible solutions that have more
-    time warp than duration. This resulted in an overflow because the
-    implementation allowed for negative arrival times.
-    """
-    m = Model()
-
-    m.add_depot(x=0, y=0)
-    m.add_vehicle_type(num_available=1)
-    m.add_client(x=1, y=1, tw_early=16, tw_late=16)
-    m.add_client(x=2, y=2, tw_early=0, tw_late=4)
-
-    durations = [
-        [0, 1, 1],
-        [1, 0, 6],
-        [1, 1, 0],
-    ]
-    for frm_idx, frm in enumerate(m.locations):
-        for to_idx, to in enumerate(m.locations):
-            distance = durations[frm_idx][to_idx]
-            duration = durations[frm_idx][to_idx]
-            m.add_edge(frm, to, distance=distance, duration=duration)
-
-    route = Route(m.data(), [1, 2], 0)
-
-    # Visiting client 1 takes 1 travel time. Leave as late as possible
-    # to incur no waiting time, so it leaves at time 15, arriving at time 16.
-    # Travel to client 2 takes 6 time units, arriving at 22. The time warp at
-    # client 2 is 22 - 4 = 18, warping back to time 4. Travel back to the depot
-    # takes 1 time unit, arriving at 5. Before the bug fix, the time warp
-    # exceeding duration led to a negative arrival times at the depot.
-    # Combined with the default late depot time window (INT_MAX), this
-    # caused a time warp overflow.
-    assert_(route.duration() == 1 + 6 + 1)
-    assert_(route.time_warp() == 18)
-
-
 def test_model_solves_small_instance_with_shift_durations():
     """
     High-level test that creates and solves a small instance with shift


### PR DESCRIPTION
This PR fixes an overflow bug in DurationSegment. This happens when the time warp exceeds the duration, allow for negative `atOther`. When calculating the time warp for the resulting DurationSegment, combined with `other.twLate = INT_MAX`, this would result in an integer overflow.

- [x] Closes #588.
- [x] Adds and passes relevant tests.
- [x] Has well-formatted code and documentation.

<details>

**Notes**:

- It is essential that you add a test when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.

</details>
