### PR TITLE
Bump sphinx-immaterial to >=0.11.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ sphinx = "~7.2.0"
 nbsphinx = ">=0.8.9"
 ipython = ">=8.6.0"
 numpydoc = ">=1.5.0"
-sphinx-immaterial = ">=0.11.11"
+sphinx-immaterial = ">=0.11.12"
 
 
 [tool.poetry.group.examples]


### PR DESCRIPTION
This PR pulls in the fix to [this issue](https://github.com/jbms/sphinx-immaterial/issues/312), so our footnotes render nicely in the docs.

Current:
![image](https://github.com/PyVRP/PyVRP/assets/16272507/ccf2e7bb-f393-4b54-989b-c77f8f12a885)

New:
![image](https://github.com/PyVRP/PyVRP/assets/16272507/906cb4e8-680f-40e3-9a10-3313cf158f81)

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
