### PR TITLE
Add "don't email us" to the getting help section of the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ one!
 
 ### Getting help
 
-If you are looking for help, please follow the instructions [here][3].
+Feel free to open an issue or a new discussion thread here on GitHub.
+Please do not e-mail us with questions, modelling issues, or code examples.
+Those are much easier to discuss via GitHub than over e-mail.
+When writing your issue or discussion, please follow the instructions [here][3].
 
 ### How to cite PyVRP
 

--- a/docs/source/setup/getting_help.rst
+++ b/docs/source/setup/getting_help.rst
@@ -2,11 +2,13 @@ Getting help
 ============
 
 All conversations take place in the `GitHub repository <https://github.com/PyVRP/PyVRP/>`_.
+If you are looking for help using PyVRP, please browse our `discussions <https://github.com/PyVRP/PyVRP/discussions>`_ overview first for relevant discussions, questions and answers, modelling tricks, and more.
+Feel free to open your own discussion thread if you have something new to discuss!
 
-.. hint::
+.. note::
 
-   If you are looking for help using PyVRP, please browse our `discussions <https://github.com/PyVRP/PyVRP/discussions>`_ overview first for relevant discussions, questions and answers, modelling tricks, and more.
-   Feel free to open your own discussion thread if you have something new to discuss!
+   Please do not e-mail us with questions, modelling issues, or code examples.
+   Those are much easier to discuss via GitHub than over e-mail.
 
 
 Submitting a bug report


### PR DESCRIPTION
No big deal, but I've gotten about four emails about PyVRP just in the past week and I want to make it a bit clearer that most of those could/should have been GitHub issues or discussions. This should hopefully make that a bit clearer.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
