### PR TITLE
Release GIL in heavy operations

### DIFF
--- a/pyvrp/cpp/crossover/bindings.cpp
+++ b/pyvrp/cpp/crossover/bindings.cpp
@@ -13,6 +13,7 @@ PYBIND11_MODULE(_crossover, m)
           py::arg("parents"),
           py::arg("data"),
           py::arg("indices"),
+          py::call_guard<py::gil_scoped_release>(),
           DOC(pyvrp, crossover, orderedCrossover));
 
     m.def("selective_route_exchange",
@@ -22,5 +23,6 @@ PYBIND11_MODULE(_crossover, m)
           py::arg("cost_evaluator"),
           py::arg("start_indices"),
           py::arg("num_moved_routes"),
+          py::call_guard<py::gil_scoped_release>(),
           DOC(pyvrp, crossover, selectiveRouteExchange));
 }

--- a/pyvrp/cpp/search/bindings.cpp
+++ b/pyvrp/cpp/search/bindings.cpp
@@ -199,20 +199,23 @@ PYBIND11_MODULE(_search, m)
         .def("__call__",
              &LocalSearch::operator(),
              py::arg("solution"),
-             py::arg("cost_evaluator"))
+             py::arg("cost_evaluator"),
+             py::call_guard<py::gil_scoped_release>())
         .def("search",
              py::overload_cast<pyvrp::Solution const &,
                                pyvrp::CostEvaluator const &>(
                  &LocalSearch::search),
              py::arg("solution"),
-             py::arg("cost_evaluator"))
+             py::arg("cost_evaluator"),
+             py::call_guard<py::gil_scoped_release>())
         .def("intensify",
              py::overload_cast<pyvrp::Solution const &,
                                pyvrp::CostEvaluator const &,
                                double const>(&LocalSearch::intensify),
              py::arg("solution"),
              py::arg("cost_evaluator"),
-             py::arg("overlap_tolerance") = 0.05)
+             py::arg("overlap_tolerance") = 0.05,
+             py::call_guard<py::gil_scoped_release>())
         .def("shuffle", &LocalSearch::shuffle, py::arg("rng"));
 
     py::class_<Route>(m, "Route", DOC(pyvrp, search, Route))


### PR DESCRIPTION
This PR is an experiment. I think we can release the GIL when calling into pure C++-side code, which is particularly relevant for heavy operations like crossover and local search. But I need to do some experimentation first to determine if that's actually valid and whether this works as intended. If it does, one can use multithreading from Python to enable parallel PyVRP work, and things should just work. Should be a lot lighter than default multiprocessing since the GIL will no longer be an issue.

This is a step towards parallelising PyVRP, although I am not entirely sure if we should (nor what such an algorithm should look like exactly).

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
