### PR TITLE
Require at least one vehicle type

### DIFF
--- a/pyvrp/cpp/ProblemData.cpp
+++ b/pyvrp/cpp/ProblemData.cpp
@@ -447,6 +447,9 @@ void ProblemData::validate() const
     }
 
     // Vehicle type checks.
+    if (vehicleTypes_.empty())
+        throw std::invalid_argument("Expected at least one vehicle type.");
+
     for (auto const &vehicleType : vehicleTypes_)
     {
         if (vehicleType.startDepot >= numDepots())

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -660,7 +660,7 @@ def test_to_data_client_group():
     """
     m = Model()
     m.add_depot(1, 1)
-    m.add_vehicle_type(1)
+    m.add_vehicle_type()
 
     group = m.add_client_group()
     m.add_client(1, 1, required=False, group=group)
@@ -827,7 +827,7 @@ def test_profiles_build_on_base_edges():
 
     depot = m.add_depot(x=1, y=1)
     client = m.add_client(x=2, y=2)
-    m.add_vehicle_type(1)
+    m.add_vehicle_type()
 
     # Add base edges. These edges are used to construct base matrices that the
     # profiles build on. Essentially, if an edge is not specifically provided

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -660,6 +660,7 @@ def test_to_data_client_group():
     """
     m = Model()
     m.add_depot(1, 1)
+    m.add_vehicle_type(1)
 
     group = m.add_client_group()
     m.add_client(1, 1, required=False, group=group)
@@ -826,6 +827,7 @@ def test_profiles_build_on_base_edges():
 
     depot = m.add_depot(x=1, y=1)
     client = m.add_client(x=2, y=2)
+    m.add_vehicle_type(1)
 
     # Add base edges. These edges are used to construct base matrices that the
     # profiles build on. Essentially, if an edge is not specifically provided

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -158,6 +158,30 @@ def test_problem_data_raises_when_no_depot_is_provided():
     )
 
 
+def test_problem_data_raises_when_no_vehicle_type_is_provided():
+    """
+    Tests that the ``ProblemData`` constructor raises a ``ValueError`` when
+    no vehicle types are provided.
+    """
+    with assert_raises(ValueError):
+        ProblemData(
+            clients=[],
+            depots=[Depot(x=0, y=0)],
+            vehicle_types=[],
+            distance_matrices=[np.asarray([[]], dtype=int)],
+            duration_matrices=[np.asarray([[]], dtype=int)],
+        )
+
+    # One (or more) vehicle types should not raise.
+    ProblemData(
+        clients=[],
+        depots=[Depot(x=0, y=0)],
+        vehicle_types=[VehicleType(2, capacity=1)],
+        distance_matrices=[np.asarray([[0]])],
+        duration_matrices=[np.asarray([[0]])],
+    )
+
+
 @pytest.mark.parametrize(
     "matrix",
     [

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -168,15 +168,15 @@ def test_problem_data_raises_when_no_vehicle_type_is_provided():
             clients=[],
             depots=[Depot(x=0, y=0)],
             vehicle_types=[],
-            distance_matrices=[np.asarray([[]], dtype=int)],
-            duration_matrices=[np.asarray([[]], dtype=int)],
+            distance_matrices=[np.asarray([[0]])],
+            duration_matrices=[np.asarray([[0]])],
         )
 
     # One (or more) vehicle types should not raise.
     ProblemData(
         clients=[],
         depots=[Depot(x=0, y=0)],
-        vehicle_types=[VehicleType(2, capacity=1)],
+        vehicle_types=[VehicleType()],
         distance_matrices=[np.asarray([[0]])],
         duration_matrices=[np.asarray([[0]])],
     )


### PR DESCRIPTION
This PR introduces a check that ProblemData instances have at least one vehicle type. Noticed this when reviewing #645. 

Having no vehicle type currently also raises because `compute_neighbourhood` requires at least one vehicle type. Since it doesn't make sense to have zero vehicle types, it's just easier to require one vehicle type and add a more descriptive message.



<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
