### PR TITLE
Do not deref route_ when determining when node is a depot node

### DIFF
--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -470,7 +470,8 @@ bool Route::Node::isDepot() const
 {
     // We need to be in a route to be the depot. If we are, then we need to
     // be either the route's start or end depot.
-    return route_ && (idx_ == 0 || idx_ == route_->size() + 1);
+    return route_
+           && (this == &route_->startDepot_ || this == &route_->endDepot_);
 }
 
 Route::SegmentAt::SegmentAt(Route const &route, size_t idx)

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -468,8 +468,6 @@ Route *Route::Node::route() const { return route_; }
 
 bool Route::Node::isDepot() const
 {
-    // We need to be in a route to be the depot. If we are, then we need to
-    // be either the route's start or end depot.
     return route_
            && (this == &route_->startDepot_ || this == &route_->endDepot_);
 }


### PR DESCRIPTION
Part of our push for performance / #416. This PR removes the dereferencing that happens inside `Route::Node::isDepot()` to determine if the node is a depot node. Currently, we do this by index: a node is a depot node if its index in a route is `0` or `route.size() + 1`. For this, we need to access `route.size()`. We can avoid this with some simple pointer checks: the node is a depot if its address corresponds with `startDepot_` or `endDepot_` on the route it's in. Those addresses are fixed offsets from the `route_` address, which is more efficient.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
