### PR TITLE
Add overlap tolerance argument to LocalSearch __call__

### DIFF
--- a/pyvrp/cpp/search/LocalSearch.cpp
+++ b/pyvrp/cpp/search/LocalSearch.cpp
@@ -10,14 +10,15 @@ using pyvrp::Solution;
 using pyvrp::search::LocalSearch;
 
 Solution LocalSearch::operator()(Solution const &solution,
-                                 CostEvaluator const &costEvaluator)
+                                 CostEvaluator const &costEvaluator,
+                                 double overlapTolerance)
 {
     loadSolution(solution);
 
     while (true)
     {
         search(costEvaluator);
-        intensify(costEvaluator);
+        intensify(costEvaluator, overlapTolerance);
 
         if (numMoves == 0)  // then the current solution is locally optimal.
             break;

--- a/pyvrp/cpp/search/LocalSearch.h
+++ b/pyvrp/cpp/search/LocalSearch.h
@@ -72,8 +72,7 @@ class LocalSearch
     void search(CostEvaluator const &costEvaluator);
 
     // Performs intensify on the currently loaded solution.
-    void intensify(CostEvaluator const &costEvaluator,
-                   double overlapTolerance = 0.05);
+    void intensify(CostEvaluator const &costEvaluator, double overlapTolerance);
 
     // Evaluate and apply inserting U after one of its neighbours if it's an
     // improving move or required for feasibility.
@@ -108,7 +107,8 @@ public:
      * improvements are made.
      */
     Solution operator()(Solution const &solution,
-                        CostEvaluator const &costEvaluator);
+                        CostEvaluator const &costEvaluator,
+                        double overlapTolerance = 0.05);
 
     /**
      * Performs regular (node-based) local search around the given solution,

--- a/pyvrp/cpp/search/bindings.cpp
+++ b/pyvrp/cpp/search/bindings.cpp
@@ -200,6 +200,7 @@ PYBIND11_MODULE(_search, m)
              &LocalSearch::operator(),
              py::arg("solution"),
              py::arg("cost_evaluator"),
+             py::arg("overlap_tolerance") = 0.05,
              py::call_guard<py::gil_scoped_release>())
         .def("search",
              py::overload_cast<pyvrp::Solution const &,

--- a/pyvrp/search/LocalSearch.py
+++ b/pyvrp/search/LocalSearch.py
@@ -80,6 +80,7 @@ class LocalSearch:
         self,
         solution: Solution,
         cost_evaluator: CostEvaluator,
+        overlap_tolerance: float = 0.05,
     ) -> Solution:
         """
         This method uses the :meth:`~search` and :meth:`~intensify` methods to
@@ -94,6 +95,8 @@ class LocalSearch:
             The solution to improve through local search.
         cost_evaluator
             Cost evaluator to use.
+        overlap_tolerance
+            See :meth:`~intensify` for details.
 
         Returns
         -------
@@ -102,7 +105,7 @@ class LocalSearch:
             solution that was passed in.
         """
         self._ls.shuffle(self._rng)
-        return self._ls(solution, cost_evaluator)
+        return self._ls(solution, cost_evaluator, overlap_tolerance)
 
     def intensify(
         self,

--- a/pyvrp/search/_search.pyi
+++ b/pyvrp/search/_search.pyi
@@ -51,6 +51,7 @@ class LocalSearch:
         self,
         solution: Solution,
         cost_evaluator: CostEvaluator,
+        overlap_tolerance: float = 0.05,
     ) -> Solution: ...
     def shuffle(self, rng: RandomNumberGenerator) -> None: ...
     def intensify(


### PR DESCRIPTION
Seemed weird that we did not already have this.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
