### PR TITLE
Use standard constructs for ThreeBest

### DIFF
--- a/pyvrp/cpp/search/SwapStar.cpp
+++ b/pyvrp/cpp/search/SwapStar.cpp
@@ -42,11 +42,10 @@ void SwapStar::updateInsertPoints(Route *R,
         Cost deltaCost = 0;
         costEvaluator.deltaCost<true, true>(deltaCost, proposal);
 
-        auto *V = (*R)[idx];
-
         if (deltaCost >= insertPositions[2].first)
             continue;
 
+        auto *V = (*R)[idx];
         if (deltaCost >= insertPositions[1].first)
             insertPositions[2] = {deltaCost, V};
         else if (deltaCost >= insertPositions[0].first)

--- a/pyvrp/cpp/search/SwapStar.h
+++ b/pyvrp/cpp/search/SwapStar.h
@@ -27,15 +27,8 @@ namespace pyvrp::search
  */
 class SwapStar : public LocalSearchOperator<Route>
 {
-    struct ThreeBest  // stores three best SWAP* insertion points
-    {
-        std::array<Route::Node *, 3> locs = {nullptr, nullptr, nullptr};
-        std::array<Cost, 3> costs = {std::numeric_limits<Cost>::max(),
-                                     std::numeric_limits<Cost>::max(),
-                                     std::numeric_limits<Cost>::max()};
-
-        void maybeAdd(Cost costInsert, Route::Node *placeInsert);
-    };
+    using InsertPoint = std::pair<Cost, Route::Node *>;
+    using ThreeBest = std::array<InsertPoint, 3>;
 
     struct BestMove  // tracks the best SWAP* move
     {

--- a/pyvrp/cpp/search/SwapStar.h
+++ b/pyvrp/cpp/search/SwapStar.h
@@ -60,18 +60,17 @@ class SwapStar : public LocalSearchOperator<Route>
 
     // Updates the cache storing the three best positions in the given route for
     // the passed-in node (client).
-    void updateInsertionCost(Route *R,
-                             Route::Node *U,
-                             CostEvaluator const &costEvaluator);
+    void updateInsertPoints(Route *R,
+                            Route::Node *U,
+                            CostEvaluator const &costEvaluator);
 
     Cost deltaLoadCost(Route::Node *U,
                        Route::Node *V,
                        CostEvaluator const &costEvaluator) const;
 
-    // Gets the delta cost and reinsert point for U in the route of V, assuming
-    // V is removed.
-    std::pair<Cost, Route::Node *> getBestInsertPoint(
-        Route::Node *U, Route::Node *V, CostEvaluator const &costEvaluator);
+    InsertPoint bestInsertPoint(Route::Node *U,
+                                Route::Node *V,
+                                CostEvaluator const &costEvaluator);
 
     // Evaluates the delta cost for ``V``'s route of inserting ``U`` after
     // ``V``, while removing ``remove`` from ``V``'s route.


### PR DESCRIPTION
This PR simplifies `SwapStar::ThreeBest` to use standard constructions from the STL.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
