### PR TITLE
Faster Route::insert and Route::clear

### DIFF
--- a/pyvrp/cpp/search/LocalSearch.cpp
+++ b/pyvrp/cpp/search/LocalSearch.cpp
@@ -393,20 +393,19 @@ void LocalSearch::loadSolution(Solution const &solution)
     // Load routes from solution.
     for (auto const &solRoute : solution.routes())
     {
-        // Determine index of next route of this type to load, where we rely
-        // on solution to be valid to not exceed the number of vehicles per
-        // vehicle type.
-        auto const r = vehicleOffset[solRoute.vehicleType()]++;
-        Route &route = routes[r];
-        assert(route.empty());  // should have been emptied above.
-
+        // Set up a container of all node visits. This lets us insert all nodes
+        // in one go, requiring no intermediate updates.
         std::vector<Route::Node *> visits;
         visits.reserve(solRoute.size());
         for (auto const client : solRoute)
             visits.push_back(&nodes[client]);
 
-        route.insert(1, visits.begin(), visits.end());
-        route.update();
+        // Determine index of next route of this type to load, where we rely
+        // on solution to be valid to not exceed the number of vehicles per
+        // vehicle type.
+        auto const idx = vehicleOffset[solRoute.vehicleType()]++;
+        routes[idx].insert(1, visits.begin(), visits.end());
+        routes[idx].update();
     }
 
     for (auto *routeOp : routeOps)

--- a/pyvrp/cpp/search/LocalSearch.cpp
+++ b/pyvrp/cpp/search/LocalSearch.cpp
@@ -398,11 +398,14 @@ void LocalSearch::loadSolution(Solution const &solution)
         // vehicle type.
         auto const r = vehicleOffset[solRoute.vehicleType()]++;
         Route &route = routes[r];
-
         assert(route.empty());  // should have been emptied above.
-        for (auto const client : solRoute)
-            route.push_back(&nodes[client]);
 
+        std::vector<Route::Node *> visits;
+        visits.reserve(solRoute.size());
+        for (auto const client : solRoute)
+            visits.push_back(&nodes[client]);
+
+        route.insert(1, visits.begin(), visits.end());
         route.update();
     }
 

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -105,8 +105,8 @@ void Route::clear()
 void Route::insert(size_t idx, Node *node)
 {
     assert(0 < idx && idx < nodes.size());
-
     nodes.insert(nodes.begin() + idx, node);
+
     for (size_t after = idx; after != nodes.size(); ++after)
         nodes[after]->assign(this, after);
 

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -11,7 +11,6 @@ Route::Node::Node(size_t loc) : loc_(loc), idx_(0), route_(nullptr) {}
 
 void Route::Node::assign(Route *route, size_t idx)
 {
-    assert(!route_);  // must not currently be assigned
     idx_ = idx;
     route_ = route;
 }
@@ -87,6 +86,9 @@ bool Route::overlapsWith(Route const &other, double tolerance) const
 
 void Route::clear()
 {
+    if (nodes.size() == 2)
+        return;
+
     for (auto *node : nodes)
         node->unassign();
 
@@ -104,11 +106,9 @@ void Route::insert(size_t idx, Node *node)
 {
     assert(0 < idx && idx < nodes.size());
 
-    node->assign(this, idx);
     nodes.insert(nodes.begin() + idx, node);
-
     for (size_t after = idx; after != nodes.size(); ++after)
-        nodes[after]->idx_ = after;
+        nodes[after]->assign(this, after);
 
 #ifndef NDEBUG
     dirty = true;

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -86,8 +86,8 @@ bool Route::overlapsWith(Route const &other, double tolerance) const
 
 void Route::clear()
 {
-    if (nodes.size() == 2)
-        return;
+    if (nodes.size() == 2)  // then the route is already empty and we have
+        return;             // nothing to do.
 
     for (auto *node : nodes)
         node->unassign();

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -404,10 +404,17 @@ public:
     void clear();
 
     /**
-     * Inserts the given node at index ``idx``. Assumes the given index is
+     * Inserts the given node before index ``idx``. Assumes the given index is
      * valid.
      */
     void insert(size_t idx, Node *node);
+
+    /**
+     * Inserts the given range of nodes before ``idx``. Assumes the given index
+     * is valid.
+     */
+    template <class InputIt>
+    void insert(size_t idx, InputIt first, InputIt last);
 
     /**
      * Inserts the given node at the back of the route.
@@ -829,6 +836,20 @@ LoadSegment Route::Proposal<Segments...>::loadSegment(size_t dimension) const
     };
 
     return std::apply(fn, segments);
+}
+
+template <class InputIt>
+void Route::insert(size_t idx, InputIt first, InputIt last)
+{
+    assert(0 < idx && idx < nodes.size());
+
+    nodes.insert(nodes.begin() + idx, first, last);
+    for (size_t after = idx; after != nodes.size(); ++after)
+        nodes[after]->assign(this, after);
+
+#ifndef NDEBUG
+    dirty = true;
+#endif
 }
 }  // namespace pyvrp::search
 

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -842,8 +842,8 @@ template <class InputIt>
 void Route::insert(size_t idx, InputIt first, InputIt last)
 {
     assert(0 < idx && idx < nodes.size());
-
     nodes.insert(nodes.begin() + idx, first, last);
+
     for (size_t after = idx; after != nodes.size(); ++after)
         nodes[after]->assign(this, after);
 

--- a/pyvrp/cpp/search/bindings.cpp
+++ b/pyvrp/cpp/search/bindings.cpp
@@ -352,12 +352,14 @@ PYBIND11_MODULE(_search, m)
              py::keep_alive<1, 2>(),  // keep node alive
              py::keep_alive<2, 1>())  // keep route alive
         .def("clear", &Route::clear)
-        .def("insert",
-             &Route::insert,
-             py::arg("idx"),
-             py::arg("node"),
-             py::keep_alive<1, 3>(),  // keep node alive
-             py::keep_alive<3, 1>())  // keep route alive
+        .def(
+            "insert",
+            [](Route &route, size_t idx, Route::Node *node)
+            { route.insert(idx, node); },
+            py::arg("idx"),
+            py::arg("node"),
+            py::keep_alive<1, 3>(),  // keep node alive
+            py::keep_alive<3, 1>())  // keep route alive
         .def_static("swap", &Route::swap, py::arg("first"), py::arg("second"))
         .def("update", &Route::update);
 


### PR DESCRIPTION
This PR is part of #533, and simplifies the loading of a solution into the `LocalSearch`. In HGS that's not really relevant (takes ~0.1% of the total run-time) but in ILS that balloons to ~15%. The changes in this PR bring that back down to a more manageable ~5%.

See also #719 for an idea about not updating unchanged routes.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
