### PR TITLE
Reduce iterations in slow tests

### DIFF
--- a/tests/test_GeneticAlgorithm.py
+++ b/tests/test_GeneticAlgorithm.py
@@ -121,11 +121,11 @@ def test_initial_solutions_added_when_restarting(rc208):
 
     params = GeneticAlgorithmParams(
         repair_probability=0,
-        nb_iter_no_improvement=100,
+        nb_iter_no_improvement=25,
     )
     algo = GeneticAlgorithm(rc208, pm, rng, pop, ls, srex, init, params=params)
 
-    algo.run(MaxIterations(100))
+    algo.run(MaxIterations(25))
 
     # There are precisely enough non-improving iterations to trigger the
     # restarting mechanism. GA should have cleared and re-initialised the
@@ -241,7 +241,7 @@ def test_never_repairs_when_zero_repair_probability(rc208):
     # manager. This should be OK.
     ga_params = GeneticAlgorithmParams(repair_probability=1.0)
     algo = GeneticAlgorithm(rc208, pm, rng, pop, ls, srex, init, ga_params)
-    algo.run(MaxIterations(50))
+    algo.run(MaxIterations(25))
 
     # Now we patch the penalty manager: when asked for a booster cost evaluator
     # (as used during repair), this will now raise a runtime error. Since the
@@ -251,10 +251,10 @@ def test_never_repairs_when_zero_repair_probability(rc208):
 
     pm.booster_cost_evaluator = MethodType(raise_when_called, pm)
     with assert_raises(RuntimeError):
-        algo.run(MaxIterations(50))
+        algo.run(MaxIterations(25))
 
     # But when we set the repair probability to 0%, the booster is no longer
     # needed, and nothing should raise.
     ga_params = GeneticAlgorithmParams(repair_probability=0.0)
     algo = GeneticAlgorithm(rc208, pm, rng, pop, ls, srex, init, ga_params)
-    algo.run(MaxIterations(50))
+    algo.run(MaxIterations(25))

--- a/tests/test_Population.py
+++ b/tests/test_Population.py
@@ -280,7 +280,7 @@ def test_tournament_ranks_by_fitness(rc208, k: int):
     sol2idx = {item.solution: idx for idx, item in enumerate(by_fitness)}
     infeas_count = np.zeros(len(infeas_pop))
 
-    for _ in range(10_000):
+    for _ in range(5_000):
         sol = pop.tournament(rng, cost_evaluator, k=k)
         infeas_count[sol2idx[sol]] += 1
 


### PR DESCRIPTION
This PR reduces the runtime spent in slow tests. In debug builds, these small changes save about 5s of runtime (out of 25s for the whole test suite) on my machine.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
