### PR TITLE
Do not store intermediate cost matrices when determining average costs

### DIFF
--- a/pyvrp/PenaltyManager.py
+++ b/pyvrp/PenaltyManager.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from functools import reduce
 from statistics import fmean
 from warnings import warn
 
@@ -167,6 +166,8 @@ class PenaltyManager:
         distances = data.distance_matrices()
         durations = data.duration_matrices()
 
+        # We first determine the elementwise minimum cost across all vehicle
+        # types. This is the cheapest way any edge can be traversed.
         unique_edge_costs = {
             (
                 veh_type.unit_distance_cost,
@@ -175,19 +176,18 @@ class PenaltyManager:
             )
             for veh_type in data.vehicle_types()
         }
-        min_edge_cost = reduce(
-            lambda x, y: np.minimum.reduce([x, y]),
-            (
-                unit_distance_cost * distances[profile]
-                + unit_duration_cost * durations[profile]
-                for unit_distance_cost, unit_duration_cost, profile in unique_edge_costs
-            ),
-        )
+
+        first, *rest = unique_edge_costs
+        unit_dist, unit_dur, prof = first
+        edge_costs = unit_dist * distances[prof] + unit_dur * durations[prof]
+        for unit_dist, unit_dur, prof in rest:
+            mat = unit_dist * distances[prof] + unit_dur * durations[prof]
+            np.minimum(edge_costs, mat, out=edge_costs)
 
         # Best edge cost/distance/duration over all vehicle types and profiles,
         # and then average that for the entire matrix to obtain an "average
         # best" edge cost/distance/duration.
-        avg_cost = min_edge_cost.mean()
+        avg_cost = edge_costs.mean()
         avg_distance = np.minimum.reduce(distances).mean()
         avg_duration = np.minimum.reduce(durations).mean()
 

--- a/pyvrp/search/neighbourhood.py
+++ b/pyvrp/search/neighbourhood.py
@@ -179,7 +179,7 @@ def _compute_proximity(
     # Proximity is based on edge costs (and rewards) and penalties for known
     # time-related violations.
     return (
-        edge_costs
+        edge_costs.astype(float)
         - prize[None, :]
         + weight_wait_time * np.maximum(min_wait, 0)
         + weight_time_warp * np.maximum(min_tw, 0)

--- a/pyvrp/search/neighbourhood.py
+++ b/pyvrp/search/neighbourhood.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import reduce
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -155,11 +156,22 @@ def _compute_proximity(
     # This is the cheapest way any edge can be traversed.
     distances = data.distance_matrices()
     durations = data.duration_matrices()
-    edge_costs = [  # edge costs per vehicle type
-        veh_type.unit_distance_cost * distances[veh_type.profile]
-        + veh_type.unit_duration_cost * durations[veh_type.profile]
+    unique_edge_costs = {
+        (
+            veh_type.unit_distance_cost,
+            veh_type.unit_duration_cost,
+            veh_type.profile,
+        )
         for veh_type in data.vehicle_types()
-    ]
+    }
+    min_edge_cost = reduce(
+        lambda x, y: np.minimum.reduce([x, y]),
+        (
+            unit_distance_cost * distances[profile]
+            + unit_duration_cost * durations[profile]
+            for unit_distance_cost, unit_duration_cost, profile in unique_edge_costs
+        ),
+    )
 
     # Minimum wait time and time warp of visiting j directly after i.
     min_duration = np.minimum.reduce(durations)
@@ -169,7 +181,7 @@ def _compute_proximity(
     # Proximity is based on edge costs (and rewards) and penalties for known
     # time-related violations.
     return (
-        np.minimum.reduce(edge_costs, dtype=float)
+        min_edge_cost
         - prize[None, :]
         + weight_wait_time * np.maximum(min_wait, 0)
         + weight_time_warp * np.maximum(min_tw, 0)


### PR DESCRIPTION
This PR attempts to fix a memory inefficiency in PyVRP. See #730 for details.

- [x] Closes #730.
- [ ] Adds and passes relevant tests.
- [x] Has well-formatted code and documentation.