### PR TITLE
Bugfix: SwapRoutes always evaluates to zero 

### DIFF
--- a/pyvrp/cpp/search/LocalSearch.cpp
+++ b/pyvrp/cpp/search/LocalSearch.cpp
@@ -134,7 +134,7 @@ void LocalSearch::intensify(CostEvaluator const &costEvaluator,
             auto const lastTested = lastTestedRoutes[U.idx()];
             lastTestedRoutes[U.idx()] = numMoves;
 
-            for (size_t rV = 0; rV != U.idx(); ++rV)
+            for (size_t rV = U.idx() + 1; rV != data.numVehicles(); ++rV)
             {
                 auto &V = routes[rV];
 

--- a/tests/search/test_LocalSearch.py
+++ b/tests/search/test_LocalSearch.py
@@ -396,7 +396,8 @@ def test_intensify_can_improve_solution_further(rc208):
 
 def test_intensify_can_swap_routes(ok_small):
     """
-    Tests that the intensify method can improve a solution by swapping routes.
+    Tests that the bug identified in #742 is fixed. The intensify method should
+    be able to improve a solution by swapping routes.
     """
     rng = RandomNumberGenerator(seed=42)
 
@@ -420,11 +421,11 @@ def test_intensify_can_swap_routes(ok_small):
 
     # This solution can be improved by using the intensifying route operators
     # to swap the routes in the solution.
-    intensify_opt = ls.intensify(init_sol, cost_eval, overlap_tolerance=1)
-    intensify_cost = cost_eval.penalised_cost(intensify_opt)
+    intensify_sol = ls.intensify(init_sol, cost_eval, overlap_tolerance=1)
+    intensify_cost = cost_eval.penalised_cost(intensify_sol)
 
     assert_(intensify_cost < init_cost)
-    assert_equal(intensify_opt.excess_load(), [0])
+    assert_equal(intensify_sol.excess_load(), [0])
 
 
 def test_local_search_completes_incomplete_solutions(ok_small_prizes):


### PR DESCRIPTION
This PR:

- [ ] Closes #xxxx.
- [x] Adds and passes relevant tests.
- [x] Has well-formatted code and documentation.

**Problem**
There is a bug in the `LocalSearch::intensify` method that prevents `SwapRoutes` moves to be ever applied. The issue arises because `applyRouteOps` is invoked for each route pair `(U, V)` such that the index of route U (`rU`) is always greater than that of route V (`rV`), meaning `rU > rV` consistently holds true. When the `SwapRoutes::evaluate` function is triggered, it calls `SwapTails::evaluate`, which immediately returns a delta cost of 0 if `rU > rV`. As a result, `SwapRoutes` moves are never properly evaluated and thus never applied, as the condition `rU > rV` is always met during the execution of `LocalSearch::intensify`.

**Solution approach**

In the `LocalSearch::intensify` method only consider route pairs `(U, V)` for which holds that the index of route U (`rU`) is always smaller than that of route V (`rV`), meaning that `rU < rV` consistently holds true. This means that the `SwapRoutes` moves will be evaluated in `SwapTails::evaluate`.

Note that `ApplyRouteOps` (and therefore `SwapRoutes`) is only called when there is enough overlap between routes `U` and `V`. Whether a `SwapRoutes` move is an improving move, has no relation with the overlap between the routes, so it is questionable if this overlap restriction is in the right place. This issue is addressed in #744 .


<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
