### PR TITLE
Ensure SwapTails move is evaluated when an empty route is involved

### DIFF
--- a/pyvrp/cpp/search/SwapTails.cpp
+++ b/pyvrp/cpp/search/SwapTails.cpp
@@ -13,8 +13,11 @@ pyvrp::Cost SwapTails::evaluate(Route::Node *U,
     auto const *uRoute = U->route();
     auto const *vRoute = V->route();
 
-    if (uRoute == vRoute || uRoute->idx() > vRoute->idx())
-        return 0;  // same route, or move will be tackled in a later iteration
+    if (uRoute == vRoute)
+        return 0;  // same route
+
+    if (uRoute->idx() > vRoute->idx() && !uRoute->empty() && !vRoute->empty())
+        return 0;  // move will be tackled in a later iteration
 
     Cost deltaCost = 0;
 

--- a/tests/search/test_SwapTails.py
+++ b/tests/search/test_SwapTails.py
@@ -115,15 +115,18 @@ def test_move_involving_empty_routes():
 
     # This move does not change the route structure, so the delta cost is 0.
     assert_equal(op.evaluate(route1[0], route2[2], cost_eval), 0)
+    assert_equal(op.evaluate(route2[2], route1[0], cost_eval), 0)
 
     # This move creates routes (depot -> 2 -> depot) and (depot -> 1 -> depot),
     # making route 1 non-empty and thus incurring its fixed cost of 10.
     assert_equal(op.evaluate(route1[0], route2[1], cost_eval), 10)
+    assert_equal(op.evaluate(route2[1], route1[0], cost_eval), 10)
 
     # This move creates routes (depot -> 1 -> 2 -> depot) and (depot -> depot),
     # making route 1 non-empty, while making route 2 empty. The total fixed
     # cost incurred is thus 10 - 100 = -90.
     assert_equal(op.evaluate(route1[0], route2[0], cost_eval), -90)
+    assert_equal(op.evaluate(route2[0], route1[0], cost_eval), -90)
 
 
 def test_move_involving_multiple_depots():


### PR DESCRIPTION
This PR:

- [ ] Closes #xxxx.
- [ ] Adds and passes relevant tests.
- [ ] Has well-formatted code and documentation.

`LocalSearch::applyNodeOps` is called in `LocalSearch::applyEmptyRouteMoves`  for a client node `U` (guaranteed to be in a route) and the first depot node `V` of an empty route. If the route index of node `U` is greater than the route index of node `V` (the empty route), then `SwapTails` will always evaluate the move to 0. Given that the "opposite" move `(V, U)` is never tried, the `SwapTails` move `(U, V)` is never properly evaluated. This can be fixed by only skipping the `SwapTails` move evaluation if no empty routes are involved. 

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
