### PR TITLE
Simplify reloading using depots and indices

### DIFF
--- a/docs/source/api/pyvrp.rst
+++ b/docs/source/api/pyvrp.rst
@@ -97,9 +97,6 @@ This object can be used to obtain the best observed solution, and detailed runti
    .. autoclass:: Depot
       :members:
 
-   .. autoclass:: Reload
-      :members:
-
    .. autoclass:: VehicleType
       :members:
 

--- a/pyvrp/Model.py
+++ b/pyvrp/Model.py
@@ -10,7 +10,6 @@ from pyvrp._pyvrp import (
     ClientGroup,
     Depot,
     ProblemData,
-    Reload,
     VehicleType,
 )
 from pyvrp.constants import MAX_VALUE
@@ -310,31 +309,6 @@ class Model:
         self._profiles.append(profile)
         return profile
 
-    def add_reload(
-        self,
-        depot: Depot | None = None,
-        tw_early: int = 0,
-        tw_late: int = np.iinfo(np.int64).max,
-        load_duration: int = 0,
-    ) -> Reload:
-        """
-        Adds a new reload location the given attributes to the model. Returns
-        the created :class:`~pyvrp._pyvrp.Reload` instance.
-        """
-        if depot is None:
-            depot_idx = 0
-        elif (idx := _idx_by_id(depot, self._depots)) is not None:
-            depot_idx = idx
-        else:
-            raise ValueError("The given reload depot is not in this model.")
-
-        return Reload(
-            depot=depot_idx,
-            tw_early=tw_early,
-            tw_late=tw_late,
-            load_duration=load_duration,
-        )
-
     def add_vehicle_type(
         self,
         num_available: int = 1,
@@ -351,7 +325,7 @@ class Model:
         profile: Profile | None = None,
         start_late: int | None = None,
         initial_load: int | list[int] = [],
-        reloads: list[Reload] = [],
+        reload_depots: list[Depot] = [],
         *,
         name: str = "",
     ) -> VehicleType:
@@ -391,6 +365,15 @@ class Model:
         else:
             raise ValueError("The given profile is not in this model.")
 
+        reloads: list[int] = []
+        for depot in reload_depots:
+            depot_idx = _idx_by_id(depot, self._depots)
+            if depot_idx is not None:
+                reloads.append(depot_idx)
+            else:
+                msg = "The given reload depot is not in this model."
+                raise ValueError(msg)
+
         init_load = initial_load
         if isinstance(init_load, int):
             init_load = [init_load]
@@ -410,7 +393,7 @@ class Model:
             profile=profile_idx,
             start_late=start_late,
             initial_load=init_load,
-            reloads=reloads,
+            reload_depots=reloads,
             name=name,
         )
 

--- a/pyvrp/__init__.py
+++ b/pyvrp/__init__.py
@@ -16,7 +16,6 @@ from ._pyvrp import Depot as Depot
 from ._pyvrp import DynamicBitset as DynamicBitset
 from ._pyvrp import ProblemData as ProblemData
 from ._pyvrp import RandomNumberGenerator as RandomNumberGenerator
-from ._pyvrp import Reload as Reload
 from ._pyvrp import Route as Route
 from ._pyvrp import Solution as Solution
 from ._pyvrp import VehicleType as VehicleType

--- a/pyvrp/_pyvrp.pyi
+++ b/pyvrp/_pyvrp.pyi
@@ -99,22 +99,6 @@ class Depot:
     def __getstate__(self) -> tuple: ...
     def __setstate__(self, state: tuple, /) -> None: ...
 
-class Reload:
-    depot: int
-    tw_early: int
-    tw_late: int
-    load_duration: int
-    def __init__(
-        self,
-        depot: int = 0,
-        tw_early: int = 0,
-        tw_late: int = ...,
-        load_duration: int = 0,
-    ) -> None: ...
-    def __eq__(self, other: object) -> bool: ...
-    def __getstate__(self) -> tuple: ...
-    def __setstate__(self, state: tuple, /) -> None: ...
-
 class VehicleType:
     num_available: int
     start_depot: int
@@ -130,7 +114,7 @@ class VehicleType:
     profile: int
     start_late: int
     initial_load: list[int]
-    reloads: list[Reload]
+    reload_depots: list[int]
     name: str
     def __init__(
         self,
@@ -148,7 +132,7 @@ class VehicleType:
         profile: int = 0,
         start_late: int | None = None,
         initial_load: list[int] = [],
-        reloads: list[Reload] = [],
+        reload_depots: list[int] = [],
         *,
         name: str = "",
     ) -> None: ...
@@ -168,7 +152,7 @@ class VehicleType:
         profile: int | None = None,
         start_late: int | None = None,
         initial_load: list[int] | None = None,
-        reloads: list[Reload] | None = None,
+        reload_depots: list[int] | None = None,
         *,
         name: str | None = None,
     ) -> VehicleType: ...

--- a/pyvrp/cpp/ProblemData.cpp
+++ b/pyvrp/cpp/ProblemData.cpp
@@ -526,7 +526,7 @@ void ProblemData::validate() const
         if (vehicleType.profile >= dists_.size())
             throw std::out_of_range("Vehicle type has invalid profile.");
 
-        for (auto const &depot : vehicleType.reloadDepots)
+        for (auto const depot : vehicleType.reloadDepots)
             if (depot >= numDepots())
                 throw std::out_of_range("Vehicle has invalid reload depot.");
     }

--- a/pyvrp/cpp/ProblemData.h
+++ b/pyvrp/cpp/ProblemData.h
@@ -325,7 +325,7 @@ public:
      *     profile: int = 0,
      *     start_late: int | None = None,
      *     initial_load: list[int] = [],
-     *     reloads: list[Reload] = [],
+     *     reload_depots: list[int] = [],
      *     *,
      *     name: str = "",
      * )
@@ -374,10 +374,10 @@ public:
      *     This load is present irrespective of any client visits. By default
      *     this value is zero, and the vehicle only considers loads from client
      *     visits.
-     * reloads
-     *     List of reloads this vehicle may visit along it route, to empty and
-     *     reload for subsequent client visits. Defaults to an empty list, in
-     *     which case no reloads are allowed.
+     * reload_depots
+     *     List of reload depots (location indices) this vehicle may visit along
+     *     its route, to empty and reload for subsequent client visits. Defaults
+     *     to an empty list, in which case no reloads are allowed.
      * name
      *     Free-form name field for this vehicle type. Default empty.
      *
@@ -424,52 +424,6 @@ public:
      */
     struct VehicleType
     {
-        /**
-         * Reload(
-         *     depot: int = 0,
-         *     tw_early: int = 0,
-         *     tw_late: int = np.iinfo(np.int64).max,
-         *     load_duration: int = 0
-         * )
-         *
-         * Simple data object storing attributes for a reload location, where
-         * vehicles may go to reload along their routes.
-         *
-         * Parameters
-         * ----------
-         * depot
-         *     The depot location where reloading takes place. Default 0 (first
-         *     depot).
-         * tw_early
-         *     The earliest time when reloading may start, if specified. Default
-         *     0.
-         * tw_late
-         *     The latest time reloading may start, if specified. Unconstrained
-         *     if not provided.
-         * load_duration
-         *     Amount of time it takes to complete reloading. Default 0.
-         */
-        struct Reload
-        {
-            size_t const depot;           // Depot where reload takes place
-            Duration const twEarly;       // Depot opening time
-            Duration const twLate;        // Depot closing time
-            Duration const loadDuration;  // Loading duration
-
-            Reload(size_t depot = 0,
-                   Duration twEarly = 0,
-                   Duration twLate = std::numeric_limits<Duration>::max(),
-                   Duration loadDuration = 0);
-
-            Reload(Reload const &other) = default;
-            Reload(Reload &&other) = default;
-
-            bool operator==(Reload const &other) const = default;
-
-            Reload &operator=(Reload const &reload) = delete;
-            Reload &operator=(Reload &&reload) = delete;
-        };
-
         size_t const numAvailable;         // Available vehicles of this type
         size_t const startDepot;           // Departure depot location
         size_t const endDepot;             // Return depot location
@@ -483,9 +437,9 @@ public:
         Cost const unitDurationCost;  // Variable cost per unit of duration
         size_t const profile;         // Distance and duration profile
         Duration const startLate;     // Latest start of shift
-        std::vector<Load> const initialLoad;  // Initially used capacity
-        std::vector<Reload> const reloads;    // Reload locations
-        char const *name;                     // Type name (for reference)
+        std::vector<Load> const initialLoad;     // Initially used capacity
+        std::vector<size_t> const reloadDepots;  // Reload locations
+        char const *name;                        // Type name (for reference)
 
         VehicleType(size_t numAvailable = 1,
                     std::vector<Load> capacity = {},
@@ -501,7 +455,7 @@ public:
                     size_t profile = 0,
                     std::optional<Duration> startLate = std::nullopt,
                     std::vector<Load> initialLoad = {},
-                    std::vector<Reload> reloads = {},
+                    std::vector<size_t> reloadDepots = {},
                     std::string name = "");
 
         bool operator==(VehicleType const &other) const;
@@ -532,7 +486,7 @@ public:
                             std::optional<size_t> profile,
                             std::optional<Duration> startLate,
                             std::optional<std::vector<Load>> initialLoad,
-                            std::optional<std::vector<Reload>> reloads,
+                            std::optional<std::vector<size_t>> reloadDepots,
                             std::optional<std::string> name) const;
     };
 

--- a/pyvrp/cpp/ProblemData.h
+++ b/pyvrp/cpp/ProblemData.h
@@ -416,7 +416,7 @@ public:
      * initial_load
      *     Load already on the vehicle that need to be dropped off at a depot.
      *     This load is present irrespective of any client visits.
-     * reloads
+     * reload_depots
      *     List of reload locations this vehicle may visit along it route, to
      *     empty and reload.
      * name

--- a/pyvrp/cpp/bindings.cpp
+++ b/pyvrp/cpp/bindings.cpp
@@ -202,42 +202,6 @@ PYBIND11_MODULE(_pyvrp, m)
             { return py::make_iterator(group.begin(), group.end()); },
             py::return_value_policy::reference_internal);
 
-    py::class_<ProblemData::VehicleType::Reload>(
-        m, "Reload", DOC(pyvrp, ProblemData, VehicleType, Reload))
-        .def(py::init<size_t,
-                      pyvrp::Duration,
-                      pyvrp::Duration,
-                      pyvrp::Duration>(),
-             py::arg("depot") = 0,
-             py::arg("tw_early") = 0,
-             py::arg("tw_late") = std::numeric_limits<pyvrp::Duration>::max(),
-             py::arg("load_duration") = 0)
-        .def(py::self == py::self)  // this is __eq__
-        .def_readonly("depot", &ProblemData::VehicleType::Reload::depot)
-        .def_readonly("tw_early", &ProblemData::VehicleType::Reload::twEarly)
-        .def_readonly("tw_late", &ProblemData::VehicleType::Reload::twLate)
-        .def_readonly("load_duration",
-                      &ProblemData::VehicleType::Reload::loadDuration)
-        .def(py::pickle(
-            [](ProblemData::VehicleType::Reload const
-                   &reload) {  // __getstate__
-                return py::make_tuple(reload.depot,
-                                      reload.twEarly,
-                                      reload.twLate,
-                                      reload.loadDuration);
-            },
-            [](py::tuple t) {  // __setstate__
-                using Reload = ProblemData::VehicleType::Reload;
-
-                Reload reload(t[0].cast<size_t>(),           // depot
-                              t[1].cast<pyvrp::Duration>(),  // tw early
-                              t[2].cast<pyvrp::Duration>(),  // tw late
-                              t[3].cast<pyvrp::Duration>()   // load duration
-                );
-
-                return reload;
-            }));
-
     py::class_<ProblemData::VehicleType>(
         m, "VehicleType", DOC(pyvrp, ProblemData, VehicleType))
         .def(py::init<size_t,
@@ -254,7 +218,7 @@ PYBIND11_MODULE(_pyvrp, m)
                       size_t,
                       std::optional<pyvrp::Duration>,
                       std::vector<pyvrp::Load>,
-                      std::vector<ProblemData::VehicleType::Reload>,
+                      std::vector<size_t>,
                       char const *>(),
              py::arg("num_available") = 1,
              py::arg("capacity") = py::list(),
@@ -272,7 +236,7 @@ PYBIND11_MODULE(_pyvrp, m)
              py::arg("profile") = 0,
              py::arg("start_late") = py::none(),
              py::arg("initial_load") = py::list(),
-             py::arg("reloads") = py::list(),
+             py::arg("reload_depots") = py::list(),
              py::kw_only(),
              py::arg("name") = "")
         .def_readonly("num_available", &ProblemData::VehicleType::numAvailable)
@@ -291,7 +255,7 @@ PYBIND11_MODULE(_pyvrp, m)
         .def_readonly("profile", &ProblemData::VehicleType::profile)
         .def_readonly("start_late", &ProblemData::VehicleType::startLate)
         .def_readonly("initial_load", &ProblemData::VehicleType::initialLoad)
-        .def_readonly("reloads", &ProblemData::VehicleType::reloads)
+        .def_readonly("reload_depots", &ProblemData::VehicleType::reloadDepots)
         .def_readonly("name",
                       &ProblemData::VehicleType::name,
                       py::return_value_policy::reference_internal)
@@ -311,7 +275,7 @@ PYBIND11_MODULE(_pyvrp, m)
              py::arg("profile") = py::none(),
              py::arg("start_late") = py::none(),
              py::arg("initial_load") = py::none(),
-             py::arg("reloads") = py::none(),
+             py::arg("reload_depots") = py::none(),
              py::kw_only(),
              py::arg("name") = py::none(),
              DOC(pyvrp, ProblemData, VehicleType, replace))
@@ -332,12 +296,10 @@ PYBIND11_MODULE(_pyvrp, m)
                                       vehicleType.profile,
                                       vehicleType.startLate,
                                       vehicleType.initialLoad,
-                                      vehicleType.reloads,
+                                      vehicleType.reloadDepots,
                                       vehicleType.name);
             },
             [](py::tuple t) {  // __setstate__
-                using Reload = ProblemData::VehicleType::Reload;
-
                 ProblemData::VehicleType vehicleType(
                     t[0].cast<size_t>(),                    // num available
                     t[1].cast<std::vector<pyvrp::Load>>(),  // capacity
@@ -353,7 +315,7 @@ PYBIND11_MODULE(_pyvrp, m)
                     t[11].cast<size_t>(),           // profile
                     t[12].cast<pyvrp::Duration>(),  // start late
                     t[13].cast<std::vector<pyvrp::Load>>(),  // initial load
-                    t[14].cast<std::vector<Reload>>(),       // reloads
+                    t[14].cast<std::vector<size_t>>(),       // reload depots
                     t[15].cast<std::string>());              // name
 
                 return vehicleType;

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -976,31 +976,17 @@ def test_integer_vehicle_capacity_and_load_arguments_are_promoted_to_lists():
     assert_equal(veh2.initial_load, [1])
 
 
-def test_add_reloads():
+def test_add_reload_depots():
     """
     Smoke test that checks adding reloads and passing them when constructing a
     vehicle type works correctly.
     """
     m = Model()
-    depot = m.add_depot(x=0, y=0)
-    reload = m.add_reload(depot)
+    depot1 = m.add_depot(x=0, y=0)
+    depot2 = m.add_depot(x=1, y=1)
 
-    veh_type = m.add_vehicle_type(reloads=[reload])
-    assert_equal(veh_type.reloads, [reload])
-    assert_equal(veh_type.reloads[0].depot, 0)
+    veh_type1 = m.add_vehicle_type(reload_depots=[depot1])
+    assert_equal(veh_type1.reload_depots, [0])
 
-
-def test_add_reload_raises_on_unknown_depot_argument():
-    """
-    Tests that adding a reload with an unknown depot raises.
-    """
-    depot = Depot(x=0, y=0)  # created outside the model
-    m = Model()
-
-    with assert_raises(ValueError):
-        m.add_reload(depot)
-
-    # But if no depot is passed, it should default to the first, and that ought
-    # not to raise.
-    reload = m.add_reload()
-    assert_equal(reload.depot, 0)
+    veh_type2 = m.add_vehicle_type(reload_depots=[depot1, depot2])
+    assert_equal(veh_type2.reload_depots, [0, 1])

--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -976,10 +976,10 @@ def test_integer_vehicle_capacity_and_load_arguments_are_promoted_to_lists():
     assert_equal(veh2.initial_load, [1])
 
 
-def test_add_reload_depots():
+def test_adding_vehicle_reload_depots():
     """
-    Smoke test that checks adding reloads and passing them when constructing a
-    vehicle type works correctly.
+    Smoke test that checks adding reload depots to the vehicle type works
+    correctly.
     """
     m = Model()
     depot1 = m.add_depot(x=0, y=0)
@@ -990,3 +990,15 @@ def test_add_reload_depots():
 
     veh_type2 = m.add_vehicle_type(reload_depots=[depot1, depot2])
     assert_equal(veh_type2.reload_depots, [0, 1])
+
+
+def test_adding_unknown_reload_depots_raises():
+    """
+    Tests that passing an unknown reload depot when creating a new vehicle
+    type raises.
+    """
+    m = Model()
+    depot = Depot(x=0, y=0)  # not in model
+
+    with assert_raises(ValueError):
+        m.add_vehicle_type(reload_depots=[depot])

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -1102,7 +1102,7 @@ def test_validate_raises_for_invalid_reload_depot(ok_small):
     assert_equal(new_vehicle_type.reload_depots, [1])
 
     # First check if the constructor raises. There's just one depot, but the
-    # reload object references depot=1, which does not exist.
+    # reload depot references a depot at index 1, which does not exist.
     mat = np.zeros((1, 1), dtype=int)
     with assert_raises(IndexError):
         ProblemData(

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -5,7 +5,7 @@ import pytest
 from numpy.random import default_rng
 from numpy.testing import assert_, assert_allclose, assert_equal, assert_raises
 
-from pyvrp import Client, ClientGroup, Depot, ProblemData, Reload, VehicleType
+from pyvrp import Client, ClientGroup, Depot, ProblemData, VehicleType
 
 
 @pytest.mark.parametrize(
@@ -1090,38 +1090,16 @@ def test_problem_data_constructor_valid_load_dimensions():
     assert_equal(data.num_load_dimensions, 2)
 
 
-@pytest.mark.parametrize(
-    ("tw_early", "tw_late", "load_duration"),
-    [
-        (1, 0, 0),  # tw_early > tw_late
-        (-1, 1, 0),  # tw_early < 0
-        (0, 1, -1),  # load_duration < 0
-    ],
-)
-def test_reload_raises_for_invalid_arguments(
-    tw_early: int,
-    tw_late: int,
-    load_duration: int,
-):
-    """
-    Tests that the Reload constructor raises for invalid arguments.
-    """
-    depot = 0  # depot is validated by the ProblemData constructor
-    with assert_raises(ValueError):
-        Reload(depot, tw_early, tw_late, load_duration)
-
-
 def test_validate_raises_for_invalid_reload_depot(ok_small):
     """
     Tests that the ProblemData's constructor validates the reload locations
     reference existing depots, and raises if something is wrong.
     """
-    reload = Reload(depot=1)
     assert_equal(ok_small.num_depots, 1)
 
     old_vehicle_type = ok_small.vehicle_type(0)
-    new_vehicle_type = old_vehicle_type.replace(reloads=[reload])
-    assert_equal(new_vehicle_type.reloads, [reload])
+    new_vehicle_type = old_vehicle_type.replace(reload_depots=[1])
+    assert_equal(new_vehicle_type.reload_depots, [1])
 
     # First check if the constructor raises. There's just one depot, but the
     # reload object references depot=1, which does not exist.


### PR DESCRIPTION
This PR removes the `Reload` struct from #739, now that #750 expands the depots to cover the same required attributes. As such, this PR:

- [x] Is part of #739.
- [x] Adds and passes relevant tests.
- [x] Has well-formatted code and documentation.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
