### PR TITLE
Use floats in computing proximity

### DIFF
--- a/pyvrp/search/neighbourhood.py
+++ b/pyvrp/search/neighbourhood.py
@@ -139,7 +139,7 @@ def _compute_proximity(
            large class of vehicle routing problems with time-windows.
            *Computers & Operations Research*, 40(1), 475 - 489.
     """
-    early = np.zeros((data.num_locations,), dtype=int)
+    early = np.zeros((data.num_locations,), dtype=float)  # avoids overflows
     early[data.num_depots :] = np.asarray([c.tw_early for c in data.clients()])
 
     late = np.zeros_like(early)


### PR DESCRIPTION
This PR reverts the change in #737.

We have `client.tw_late = np.iinfo(np.int64).max` as default. Consequently, using `np.int64` arrays will result in overflows here:

```python
    min_wait = early[None, :] - min_duration - service[:, None] - late[:, None]
    min_tw = early[:, None] + service[:, None] + min_duration - late[None, :]
```

when `service > 0`. This results in "bad" neighbourhoods.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
