### PR TITLE
chore(deps): unrestrict Python upper constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ classifiers = [
 
 
 [tool.poetry.dependencies]
-python = ">=3.10,<4"  # NOTE: Cannot write without the upper bound because 'docblock' defines it.
+python = ">=3.10,<4.0"
 numpy = [
     # Numpy 1.26 is the first version of numpy that supports Python 3.12+.
     { version = ">=1.15.2", python = "<3.12" },
@@ -95,7 +95,7 @@ codecov = "*"
 meson = "^1.0.0"
 ninja = "^1.11.1"
 gcovr = "^7.2"
-docblock = "^0.1.5"
+docblock = ">=0.1.6"
 
 
 [tool.poetry.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ classifiers = [
 
 
 [tool.poetry.dependencies]
-python = "^3.10,<3.14"
+python = ">=3.10,<4"  # NOTE: Cannot write without the upper bound because 'docblock' defines it.
 numpy = [
     # Numpy 1.26 is the first version of numpy that supports Python 3.12+.
     { version = ">=1.15.2", python = "<3.12" },


### PR DESCRIPTION
Libraries must not restrict the upper bound unless there is a known incompatibility. See the related PR:
https://github.com/PyVRP/PyVRP/pull/663#discussion_r2059892131

---

Running `poetry lock` did not change the lock. 

Also, I believe that adding 3.14 to the CI workflow is a bit too soon and out of scope of this PR.