### PR TITLE
Remove depot service duration

### DIFF
--- a/docs/source/setup/faq.rst
+++ b/docs/source/setup/faq.rst
@@ -4,16 +4,27 @@ FAQ
 This is a list of frequently asked questions about PyVRP.
 Feel free to suggest new entries!
 
-How do I...
------------
+Installation
+------------
 
 .. glossary::
 
-   ... install the latest PyVRP from ``main`` without having to compile things myself?
+   How do I install the latest PyVRP from ``main`` without having to compile things myself?
 
       The latest prebuilt binaries can be found `here <https://github.com/PyVRP/PyVRP/actions/workflows/CD.yml>`_.
 
-   ... compile PyVRP from source on Windows machines?
+   How do I compile PyVRP from source on Windows machines?
 
       None of the PyVRP developers have a functioning Windows development enviroment available, so we cannot help you troubleshoot this.
       If you have difficulty figuring out how to build PyVRP on Windows, consider using the `Windows Subsystem for Linux (WSL) <https://learn.microsoft.com/en-us/windows/wsl/>`_ instead.
+
+Modelling
+---------
+
+.. glossary::
+
+   How do I model vehicle load or service duration at the depots?
+
+      PyVRP's :class:`~pyvrp._pyvrp.Depot` object indeed does not have a load or service duration attribute.
+      Instead, this can be modelled by adding the time for loading or servicing the vehicle at the depot to the duration of all the edges leaving the depot.
+      This is an equivalent way of modelling depot service duration.

--- a/pyvrp/Model.py
+++ b/pyvrp/Model.py
@@ -254,7 +254,6 @@ class Model:
         self,
         x: int,
         y: int,
-        service_duration: int = 0,
         tw_early: int = 0,
         tw_late: int = np.iinfo(np.int64).max,
         *,
@@ -264,14 +263,7 @@ class Model:
         Adds a depot with the given attributes to the model. Returns the
         created :class:`~pyvrp._pyvrp.Depot` instance.
         """
-        depot = Depot(
-            x=x,
-            y=y,
-            service_duration=service_duration,
-            tw_early=tw_early,
-            tw_late=tw_late,
-            name=name,
-        )
+        depot = Depot(x=x, y=y, tw_early=tw_early, tw_late=tw_late, name=name)
 
         self._depots.append(depot)
 

--- a/pyvrp/_pyvrp.pyi
+++ b/pyvrp/_pyvrp.pyi
@@ -87,7 +87,6 @@ class ClientGroup:
 class Depot:
     x: int
     y: int
-    service_duration: int
     tw_early: int
     tw_late: int
     name: str
@@ -95,7 +94,6 @@ class Depot:
         self,
         x: int,
         y: int,
-        service_duration: int = 0,
         tw_early: int = 0,
         tw_late: int = ...,
         *,

--- a/pyvrp/cpp/DurationSegment.cpp
+++ b/pyvrp/cpp/DurationSegment.cpp
@@ -31,7 +31,8 @@ DurationSegment::DurationSegment(ProblemData::Client const &client)
 }
 
 DurationSegment::DurationSegment(ProblemData::Depot const &depot)
-    : timeWarp_(0),
+    : duration_(0),
+      timeWarp_(0),
       twEarly_(depot.twEarly),
       twLate_(depot.twLate),
       releaseTime_(0)

--- a/pyvrp/cpp/DurationSegment.cpp
+++ b/pyvrp/cpp/DurationSegment.cpp
@@ -30,10 +30,8 @@ DurationSegment::DurationSegment(ProblemData::Client const &client)
 {
 }
 
-DurationSegment::DurationSegment(ProblemData::Depot const &depot,
-                                 Duration const serviceDuration)
-    : duration_(serviceDuration),
-      timeWarp_(0),
+DurationSegment::DurationSegment(ProblemData::Depot const &depot)
+    : timeWarp_(0),
       twEarly_(depot.twEarly),
       twLate_(depot.twLate),
       releaseTime_(0)

--- a/pyvrp/cpp/DurationSegment.h
+++ b/pyvrp/cpp/DurationSegment.h
@@ -97,10 +97,9 @@ public:
     DurationSegment(ProblemData::Client const &client);
 
     /**
-     * Construct from attributes of the given depot and depot service duration.
+     * Construct from attributes of the given depot.
      */
-    DurationSegment(ProblemData::Depot const &depot,
-                    Duration const serviceDuration);
+    DurationSegment(ProblemData::Depot const &depot);
 
     /**
      * Construct from attributes of the given vehicle type and latest finish.

--- a/pyvrp/cpp/ProblemData.cpp
+++ b/pyvrp/cpp/ProblemData.cpp
@@ -186,20 +186,11 @@ void ProblemData::ClientGroup::clear() { clients_.clear(); }
 
 ProblemData::Depot::Depot(Coordinate x,
                           Coordinate y,
-                          Duration serviceDuration,
                           Duration twEarly,
                           Duration twLate,
                           std::string name)
-    : x(x),
-      y(y),
-      serviceDuration(serviceDuration),
-      twEarly(twEarly),
-      twLate(twLate),
-      name(duplicate(name.data()))
+    : x(x), y(y), twEarly(twEarly), twLate(twLate), name(duplicate(name.data()))
 {
-    if (serviceDuration < 0)
-        throw std::invalid_argument("service_duration must be >= 0.");
-
     if (twEarly > twLate)
         throw std::invalid_argument("tw_early must be <= tw_late.");
 
@@ -210,7 +201,6 @@ ProblemData::Depot::Depot(Coordinate x,
 ProblemData::Depot::Depot(Depot const &depot)
     : x(depot.x),
       y(depot.y),
-      serviceDuration(depot.serviceDuration),
       twEarly(depot.twEarly),
       twLate(depot.twLate),
       name(duplicate(depot.name))
@@ -220,7 +210,6 @@ ProblemData::Depot::Depot(Depot const &depot)
 ProblemData::Depot::Depot(Depot &&depot)
     : x(depot.x),
       y(depot.y),
-      serviceDuration(depot.serviceDuration),
       twEarly(depot.twEarly),
       twLate(depot.twLate),
       name(depot.name)  // we can steal
@@ -235,7 +224,6 @@ bool ProblemData::Depot::operator==(Depot const &other) const
     // clang-format off
     return x == other.x 
         && y == other.y
-        && serviceDuration == other.serviceDuration
         && twEarly == other.twEarly
         && twLate == other.twLate
         && std::strcmp(name, other.name) == 0;

--- a/pyvrp/cpp/ProblemData.h
+++ b/pyvrp/cpp/ProblemData.h
@@ -264,7 +264,6 @@ public:
      * Depot(
      *    x: int,
      *    y: int,
-     *    service_duration: int = 0,
      *    tw_early: int = 0,
      *    tw_late: int = np.iinfo(np.int64).max,
      *    *,
@@ -281,8 +280,6 @@ public:
      * y
      *     Vertical coordinate of this depot, that is, the 'y' part of the
      *     depot's (x, y) location tuple.
-     * service_duration
-     *     Time it takes to e.g. load a vehicle at this depot. Default 0.
      * tw_early
      *     Opening time of this depot. Default 0.
      * tw_late
@@ -296,8 +293,6 @@ public:
      *     Horizontal coordinate of this depot.
      * y
      *     Vertical coordinate of this depot.
-     * service_duration
-     *     Time it takes to e.g. load a vehicle at this depot.
      * tw_early
      *     Opening time of this depot.
      * tw_late
@@ -309,14 +304,12 @@ public:
     {
         Coordinate const x;
         Coordinate const y;
-        Duration const serviceDuration;
         Duration const twEarly;  // Depot opening time
         Duration const twLate;   // Depot closing time
         char const *name;        // Depot name (for reference)
 
         Depot(Coordinate x,
               Coordinate y,
-              Duration serviceDuration = 0,
               Duration twEarly = 0,
               Duration twLate = std::numeric_limits<Duration>::max(),
               std::string name = "");

--- a/pyvrp/cpp/Route.cpp
+++ b/pyvrp/cpp/Route.cpp
@@ -39,11 +39,9 @@ Route::Route(ProblemData const &data, Visits visits, size_t const vehicleType)
     startDepot_ = vehType.startDepot;
     endDepot_ = vehType.endDepot;
 
-    ProblemData::Depot const &start = data.location(startDepot_);
-    service_ += start.serviceDuration;
-
     DurationSegment const vehStart(vehType, vehType.startLate);
-    DurationSegment const depotStart(start, start.serviceDuration);
+    ProblemData::Depot const &start = data.location(startDepot_);
+    DurationSegment const depotStart(start);
     DurationSegment ds = DurationSegment::merge(0, vehStart, depotStart);
 
     std::vector<LoadSegment> loadSegments(data.numLoadDimensions());
@@ -95,8 +93,9 @@ Route::Route(ProblemData const &data, Visits visits, size_t const vehicleType)
             loadSegments[dim].load() - vehType.capacity[dim], 0));
     }
 
-    DurationSegment const depotEnd(vehType, vehType.twLate);
-    DurationSegment const vehEnd(data.location(endDepot_), 0);
+    ProblemData::Depot const &end = data.location(endDepot_);
+    DurationSegment const depotEnd(end);
+    DurationSegment const vehEnd(vehType, vehType.twLate);
     DurationSegment const endDS = DurationSegment::merge(0, depotEnd, vehEnd);
     ds = DurationSegment::merge(durations(last, endDepot_), ds, endDS);
 

--- a/pyvrp/cpp/Route.h
+++ b/pyvrp/cpp/Route.h
@@ -152,7 +152,7 @@ public:
     [[nodiscard]] Cost durationCost() const;
 
     /**
-     * Total duration of service on this route, at depots and clients.
+     * Total duration of client service on this route.
      */
     [[nodiscard]] Duration serviceDuration() const;
 

--- a/pyvrp/cpp/bindings.cpp
+++ b/pyvrp/cpp/bindings.cpp
@@ -147,18 +147,15 @@ PYBIND11_MODULE(_pyvrp, m)
                       pyvrp::Coordinate,
                       pyvrp::Duration,
                       pyvrp::Duration,
-                      pyvrp::Duration,
                       char const *>(),
              py::arg("x"),
              py::arg("y"),
-             py::arg("service_duration") = 0,
              py::arg("tw_early") = 0,
              py::arg("tw_late") = std::numeric_limits<pyvrp::Duration>::max(),
              py::kw_only(),
              py::arg("name") = "")
         .def_readonly("x", &ProblemData::Depot::x)
         .def_readonly("y", &ProblemData::Depot::y)
-        .def_readonly("service_duration", &ProblemData::Depot::serviceDuration)
         .def_readonly("tw_early", &ProblemData::Depot::twEarly)
         .def_readonly("tw_late", &ProblemData::Depot::twLate)
         .def_readonly("name",
@@ -167,21 +164,16 @@ PYBIND11_MODULE(_pyvrp, m)
         .def(py::self == py::self)  // this is __eq__
         .def(py::pickle(
             [](ProblemData::Depot const &depot) {  // __getstate__
-                return py::make_tuple(depot.x,
-                                      depot.y,
-                                      depot.serviceDuration,
-                                      depot.twEarly,
-                                      depot.twLate,
-                                      depot.name);
+                return py::make_tuple(
+                    depot.x, depot.y, depot.twEarly, depot.twLate, depot.name);
             },
             [](py::tuple t) {  // __setstate__
                 ProblemData::Depot depot(
                     t[0].cast<pyvrp::Coordinate>(),  // x
                     t[1].cast<pyvrp::Coordinate>(),  // y
-                    t[2].cast<pyvrp::Duration>(),    // service duration
-                    t[3].cast<pyvrp::Duration>(),    // tw early
-                    t[4].cast<pyvrp::Duration>(),    // tw late
-                    t[5].cast<std::string>());       // name
+                    t[2].cast<pyvrp::Duration>(),    // tw early
+                    t[3].cast<pyvrp::Duration>(),    // tw late
+                    t[4].cast<std::string>());       // name
 
                 return depot;
             }))

--- a/pyvrp/cpp/search/Route.cpp
+++ b/pyvrp/cpp/search/Route.cpp
@@ -189,15 +189,19 @@ void Route::update()
 
     ProblemData::Depot const &start = data.location(startDepot());
     DurationSegment const vehStart(vehicleType_, vehicleType_.startLate);
-    DurationSegment const depotStart(start, start.serviceDuration);
+    DurationSegment const depotStart(start);
     durAt[0] = DurationSegment::merge(0, vehStart, depotStart);
 
-    DurationSegment const depotEnd(vehicleType_, vehicleType_.twLate);
-    DurationSegment const vehEnd(data.location(endDepot()), 0);
+    ProblemData::Depot const &end = data.location(endDepot());
+    DurationSegment const depotEnd(end);
+    DurationSegment const vehEnd(vehicleType_, vehicleType_.twLate);
     durAt[nodes.size() - 1] = DurationSegment::merge(0, depotEnd, vehEnd);
 
     for (size_t idx = 1; idx != nodes.size() - 1; ++idx)
-        durAt[idx] = {data.location(visits[idx])};
+    {
+        ProblemData::Client const &client = data.location(visits[idx]);
+        durAt[idx] = {client};
+    }
 
     auto const &durMat = data.durationMatrix(profile());
 

--- a/pyvrp/cpp/search/primitives.cpp
+++ b/pyvrp/cpp/search/primitives.cpp
@@ -27,7 +27,8 @@ public:
 
     pyvrp::DurationSegment duration([[maybe_unused]] size_t profile) const
     {
-        return {data.location(client)};
+        pyvrp::ProblemData::Client const &clientData = data.location(client);
+        return {clientData};
     }
 
     pyvrp::LoadSegment load(size_t dimension) const

--- a/tests/test_ProblemData.py
+++ b/tests/test_ProblemData.py
@@ -135,12 +135,11 @@ def test_raises_for_invalid_client_data(
 
 
 @pytest.mark.parametrize(
-    ("x", "y", "tw_early", "tw_late", "service_duration"),
+    ("x", "y", "tw_early", "tw_late"),
     [
-        (0, 0, 1, 0, 0),  # tw_early > tw_late
-        (0, 0, -1, 0, 0),  # tw_early < 0
-        (0, 0, 0, -1, 0),  # tw_late < 0
-        (0, 0, 0, 0, -1),  # service_duration < 0
+        (0, 0, 1, 0),  # tw_early > tw_late
+        (0, 0, -1, 0),  # tw_early < 0
+        (0, 0, 0, -1),  # tw_late < 0
     ],
 )
 def test_raises_for_invalid_depot_data(
@@ -148,13 +147,12 @@ def test_raises_for_invalid_depot_data(
     y: int,
     tw_early: int,
     tw_late: int,
-    service_duration: int,
 ):
     """
     Tests that an invalid depot configuration is not accepted.
     """
     with assert_raises(ValueError):
-        Depot(x, y, service_duration, tw_early, tw_late)
+        Depot(x, y, tw_early, tw_late)
 
 
 def test_depot_initialises_data_correctly():
@@ -165,7 +163,6 @@ def test_depot_initialises_data_correctly():
     depot = Depot(
         x=1,
         y=2,
-        service_duration=3,
         tw_early=5,
         tw_late=7,
         name="test",
@@ -173,7 +170,6 @@ def test_depot_initialises_data_correctly():
 
     assert_equal(depot.x, 1)
     assert_equal(depot.y, 2)
-    assert_equal(depot.service_duration, 3)
     assert_equal(depot.tw_early, 5)
     assert_equal(depot.tw_late, 7)
     assert_equal(depot.name, "test")

--- a/tests/test_Route.py
+++ b/tests/test_Route.py
@@ -248,28 +248,6 @@ def test_release_time_and_max_duration():
     assert_equal(route.time_warp(), 998)
 
 
-def test_release_time_and_service_duration_duration():
-    """
-    Tests the interaction between release times and depot service duration, and
-    checks that service at the depot happens after the tasks are released. See
-    also the ``test_release_time_and_max_duration`` test.
-    """
-    ok_small = read("data/OkSmallReleaseTimes.txt")
-    depot = Depot(x=2334, y=726, service_duration=6_000)
-    data = ok_small.replace(depots=[depot])
-
-    # This route has a release time of 5000, but we want to start much later
-    # anyway because of the time windows. That's not possible, however, because
-    # of the depot service duration of 6000. The overall route duration is 5998
-    # plus the 6000, and there is no time warp.
-    route = Route(data, [2, 3, 4], 0)
-    assert_equal(route.release_time(), 5_000)
-    assert_equal(route.start_time(), 5_000)
-    assert_equal(route.duration(), 6_000 + 5_998)
-    assert_equal(route.service_duration(), 6_000 + 1_140)
-    assert_equal(route.time_warp(), 0)
-
-
 def test_route_centroid(ok_small):
     """
     Tests that each route's center point is the center point of all clients


### PR DESCRIPTION
This PR is helpful in light of #773 (see https://github.com/PyVRP/PyVRP/pull/773#discussion_r2071760946). It reverts part of #750 and explains in the FAQ how depot services may be modelled instead.

- [ ] Closes #xxxx.
- [ ] Adds and passes relevant tests.
- [ ] Has well-formatted code and documentation.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
