### PR TITLE
Return duration and time warp from proposal's duration segment evaluation

### DIFF
--- a/pyvrp/cpp/Route.h
+++ b/pyvrp/cpp/Route.h
@@ -321,7 +321,13 @@ public:
 
     bool operator==(Route const &other) const;
 
+    Route &operator=(Route const &other) = default;
+    Route &operator=(Route &&other) = default;
+
     Route() = delete;
+
+    Route(Route const &other) = default;
+    Route(Route &&other) = default;
 
     Route(ProblemData const &data, Trips trips, VehicleType vehicleType);
 

--- a/pyvrp/cpp/Trip.h
+++ b/pyvrp/cpp/Trip.h
@@ -145,7 +145,13 @@ public:
 
     bool operator==(Trip const &other) const;
 
+    Trip &operator=(Trip const &other) = default;
+    Trip &operator=(Trip &&other) = default;
+
     Trip() = delete;
+
+    Trip(Trip const &other) = default;
+    Trip(Trip &&other) = default;
 
     Trip(ProblemData const &data,
          Visits visits,

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -77,8 +77,20 @@ public:
          */
         Route const *route() const;
 
+        /**
+         * Returns the travel distance of the proposed route.
+         */
         Distance distance() const;
-        DurationSegment durationSegment() const;
+
+        /**
+         * Returns a pair of (duration, time warp) attributes of the proposed
+         * route.
+         */
+        std::pair<Duration, Duration> duration() const;
+
+        /**
+         * Returns the excess load of the proposed route.
+         */
         Load excessLoad(size_t dimension) const;
     };
 
@@ -908,7 +920,7 @@ Distance Route::Proposal<Segments...>::distance() const
 }
 
 template <Segment... Segments>
-DurationSegment Route::Proposal<Segments...>::durationSegment() const
+std::pair<Duration, Duration> Route::Proposal<Segments...>::duration() const
 {
     auto const &data = route()->data;
     auto const profile = route()->profile();
@@ -958,7 +970,8 @@ DurationSegment Route::Proposal<Segments...>::durationSegment() const
         return ds;
     };
 
-    return std::apply(fn, detail::reverse(segments_));
+    auto const ds = std::apply(fn, detail::reverse(segments_));
+    return std::make_pair(ds.duration(), ds.timeWarp(route()->maxDuration()));
 }
 
 template <Segment... Segments>


### PR DESCRIPTION
This keeps the concatenation schemes out of the cost evaluator, and makes it a bit clearer what's actually necessary to evaluate a proposal.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
