### PR TITLE
Add delta cost shortcuts based on proposal size and duration

### DIFF
--- a/pyvrp/cpp/CostEvaluator.h
+++ b/pyvrp/cpp/CostEvaluator.h
@@ -279,16 +279,14 @@ bool CostEvaluator::deltaCost(Cost &out, T<Args...> const &proposal) const
                 proposal.loadSegment(dim).load(), capacity[dim], dim);
     }
 
-    auto const hasDurationCost = route->unitDurationCost() != 0;
-    auto const hasTimeWarp = route->hasTimeWarp();
-
-    if (proposal.isHomogeneous() && proposal.size() < route->size()
-        && !hasDurationCost && !hasTimeWarp)
-        return true;
-
-    auto const duration = proposal.durationSegment();
-    out += route->unitDurationCost() * static_cast<Cost>(duration.duration());
-    out += twPenalty(duration.timeWarp(route->maxDuration()));
+    if (route->unitDurationCost() != 0 || route->hasTimeWarp()
+        || !proposal.isHomogeneous() || proposal.size() >= route->size())
+    {
+        auto const duration = proposal.durationSegment();
+        out += route->unitDurationCost()
+               * static_cast<Cost>(duration.duration());
+        out += twPenalty(duration.timeWarp(route->maxDuration()));
+    }
 
     return true;
 }
@@ -355,7 +353,7 @@ bool CostEvaluator::deltaCost(Cost &out,
         if (out >= 0)
             return false;
 
-    if (uRoute->unitDurationCost() > 0 || uRoute->hasTimeWarp()
+    if (uRoute->unitDurationCost() != 0 || uRoute->hasTimeWarp()
         || !uProposal.isHomogeneous() || uProposal.size() >= uRoute->size())
     {
         auto const uDuration = uProposal.durationSegment();
@@ -364,7 +362,7 @@ bool CostEvaluator::deltaCost(Cost &out,
         out += twPenalty(uDuration.timeWarp(uRoute->maxDuration()));
     }
 
-    if (vRoute->unitDurationCost() > 0 || vRoute->hasTimeWarp()
+    if (vRoute->unitDurationCost() != 0 || vRoute->hasTimeWarp()
         || !vProposal.isHomogeneous() || vProposal.size() >= vRoute->size())
     {
         auto const vDuration = vProposal.durationSegment();

--- a/pyvrp/cpp/CostEvaluator.h
+++ b/pyvrp/cpp/CostEvaluator.h
@@ -279,6 +279,13 @@ bool CostEvaluator::deltaCost(Cost &out, T<Args...> const &proposal) const
                 proposal.loadSegment(dim).load(), capacity[dim], dim);
     }
 
+    auto const hasDurationCost = route->unitDurationCost() != 0;
+    auto const hasTimeWarp = route->hasTimeWarp();
+
+    if (proposal.isHomogeneous() && proposal.size() < route->size()
+        && !hasDurationCost && !hasTimeWarp)
+        return true;
+
     auto const duration = proposal.durationSegment();
     out += route->unitDurationCost() * static_cast<Cost>(duration.duration());
     out += twPenalty(duration.timeWarp(route->maxDuration()));

--- a/pyvrp/cpp/CostEvaluator.h
+++ b/pyvrp/cpp/CostEvaluator.h
@@ -279,14 +279,9 @@ bool CostEvaluator::deltaCost(Cost &out, T<Args...> const &proposal) const
                 proposal.loadSegment(dim).load(), capacity[dim], dim);
     }
 
-    if (route->unitDurationCost() != 0 || route->hasTimeWarp()
-        || !proposal.isHomogeneous() || proposal.size() >= route->size())
-    {
-        auto const duration = proposal.durationSegment();
-        out += route->unitDurationCost()
-               * static_cast<Cost>(duration.duration());
-        out += twPenalty(duration.timeWarp(route->maxDuration()));
-    }
+    auto const duration = proposal.durationSegment();
+    out += route->unitDurationCost() * static_cast<Cost>(duration.duration());
+    out += twPenalty(duration.timeWarp(route->maxDuration()));
 
     return true;
 }
@@ -353,23 +348,13 @@ bool CostEvaluator::deltaCost(Cost &out,
         if (out >= 0)
             return false;
 
-    if (uRoute->unitDurationCost() != 0 || uRoute->hasTimeWarp()
-        || !uProposal.isHomogeneous() || uProposal.size() >= uRoute->size())
-    {
-        auto const uDuration = uProposal.durationSegment();
-        out += uRoute->unitDurationCost()
-               * static_cast<Cost>(uDuration.duration());
-        out += twPenalty(uDuration.timeWarp(uRoute->maxDuration()));
-    }
+    auto const uDuration = uProposal.durationSegment();
+    out += uRoute->unitDurationCost() * static_cast<Cost>(uDuration.duration());
+    out += twPenalty(uDuration.timeWarp(uRoute->maxDuration()));
 
-    if (vRoute->unitDurationCost() != 0 || vRoute->hasTimeWarp()
-        || !vProposal.isHomogeneous() || vProposal.size() >= vRoute->size())
-    {
-        auto const vDuration = vProposal.durationSegment();
-        out += vRoute->unitDurationCost()
-               * static_cast<Cost>(vDuration.duration());
-        out += twPenalty(vDuration.timeWarp(vRoute->maxDuration()));
-    }
+    auto const vDuration = vProposal.durationSegment();
+    out += vRoute->unitDurationCost() * static_cast<Cost>(vDuration.duration());
+    out += twPenalty(vDuration.timeWarp(vRoute->maxDuration()));
 
     return true;
 }

--- a/pyvrp/cpp/CostEvaluator.h
+++ b/pyvrp/cpp/CostEvaluator.h
@@ -355,13 +355,23 @@ bool CostEvaluator::deltaCost(Cost &out,
         if (out >= 0)
             return false;
 
-    auto const uDuration = uProposal.durationSegment();
-    out += uRoute->unitDurationCost() * static_cast<Cost>(uDuration.duration());
-    out += twPenalty(uDuration.timeWarp(uRoute->maxDuration()));
+    if (uRoute->unitDurationCost() > 0 || uRoute->hasTimeWarp()
+        || !uProposal.isHomogeneous() || uProposal.size() >= uRoute->size())
+    {
+        auto const uDuration = uProposal.durationSegment();
+        out += uRoute->unitDurationCost()
+               * static_cast<Cost>(uDuration.duration());
+        out += twPenalty(uDuration.timeWarp(uRoute->maxDuration()));
+    }
 
-    auto const vDuration = vProposal.durationSegment();
-    out += vRoute->unitDurationCost() * static_cast<Cost>(vDuration.duration());
-    out += twPenalty(vDuration.timeWarp(vRoute->maxDuration()));
+    if (vRoute->unitDurationCost() > 0 || vRoute->hasTimeWarp()
+        || !vProposal.isHomogeneous() || vProposal.size() >= vRoute->size())
+    {
+        auto const vDuration = vProposal.durationSegment();
+        out += vRoute->unitDurationCost()
+               * static_cast<Cost>(vDuration.duration());
+        out += twPenalty(vDuration.timeWarp(vRoute->maxDuration()));
+    }
 
     return true;
 }

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -45,11 +45,22 @@ public:
         Proposal(Segments &&...segments);
 
         /**
+         * Size (number of locations) of the newly proposed route.
+         */
+        size_t size() const;
+
+        /**
          * The proposal's route. This is the route associated with the first
          * segment, and determines i.a. the vehicle type and route profile used
          * in the proposal.
          */
         Route const *route() const;
+
+        /**
+         * Whether this proposal consists of route segments that all belong to
+         * the same route.
+         */
+        bool isHomogeneous() const;
 
         DistanceSegment distanceSegment() const;
         DurationSegment durationSegment() const;
@@ -749,9 +760,25 @@ Route::Proposal<Segments...>::Proposal(Segments &&...segments)
 }
 
 template <typename... Segments>
+size_t Route::Proposal<Segments...>::size() const
+{
+    return std::apply([](auto &&...args) { return (args.size() + ...); },
+                      segments_);
+}
+
+template <typename... Segments>
 Route const *Route::Proposal<Segments...>::route() const
 {
     return std::get<0>(segments_).route();
+}
+
+template <typename... Segments>
+bool Route::Proposal<Segments...>::isHomogeneous() const
+{
+    auto const *target = route();
+    return std::apply([&target](auto &&...args)
+                      { return ((args.route() == target) && ...); },
+                      segments_);
 }
 
 template <typename... Segments>

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -123,6 +123,7 @@ private:
 
         inline size_t first() const;  // client at start
         inline size_t last() const;   // end depot
+        inline size_t size() const;
 
         inline SegmentAfter(Route const &route, size_t start);
         inline DistanceSegment distance(size_t profile) const;
@@ -144,6 +145,7 @@ private:
 
         inline size_t first() const;  // start depot
         inline size_t last() const;   // client at end
+        inline size_t size() const;
 
         inline SegmentBefore(Route const &route, size_t end);
         inline DistanceSegment distance(size_t profile) const;
@@ -166,6 +168,7 @@ private:
 
         inline size_t first() const;  // client at start
         inline size_t last() const;   // client at end
+        inline size_t size() const;
 
         inline SegmentBetween(Route const &route, size_t start, size_t end);
         inline DistanceSegment distance(size_t profile) const;
@@ -531,14 +534,17 @@ LoadSegment const &Route::SegmentBefore::load(size_t dimension) const
 Route const *Route::SegmentBefore::route() const { return &route_; }
 size_t Route::SegmentBefore::first() const { return route_.visits.front(); }
 size_t Route::SegmentBefore::last() const { return route_.visits[end]; }
+size_t Route::SegmentBefore::size() const { return end + 1; }
 
 Route const *Route::SegmentAfter::route() const { return &route_; }
 size_t Route::SegmentAfter::first() const { return route_.visits[start]; }
 size_t Route::SegmentAfter::last() const { return route_.visits.back(); }
+size_t Route::SegmentAfter::size() const { return route_.size() + 2 - start; }
 
 Route const *Route::SegmentBetween::route() const { return &route_; }
 size_t Route::SegmentBetween::first() const { return route_.visits[start]; }
 size_t Route::SegmentBetween::last() const { return route_.visits[end]; }
+size_t Route::SegmentBetween::size() const { return end - start + 1; }
 
 DistanceSegment Route::SegmentBetween::distance(size_t profile) const
 {

--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -825,6 +825,10 @@ DistanceSegment Route::Proposal<Segments...>::distanceSegment() const
 template <Segment... Segments>
 DurationSegment Route::Proposal<Segments...>::durationSegment() const
 {
+    if (!route()->hasTimeWarp() && route()->unitDurationCost() == 0
+        && isHomogeneous() && size() < route()->size())
+        return {};
+
     auto const &data = route()->data;
     auto const profile = route()->profile();
     auto const &matrix = data.durationMatrix(profile);

--- a/pyvrp/cpp/search/primitives.cpp
+++ b/pyvrp/cpp/search/primitives.cpp
@@ -17,8 +17,11 @@ public:
     {
     }
 
+    pyvrp::search::Route const *route() const { return nullptr; }
+
     size_t first() const { return client; }
     size_t last() const { return client; }
+    size_t size() const { return 1; }
 
     pyvrp::DistanceSegment distance([[maybe_unused]] size_t profile) const
     {


### PR DESCRIPTION
This PR:

- [x] Closes #49 (see there for details).
- [ ] Adds and passes relevant tests.
- [ ] Has well-formatted code and documentation.

TODO:
- [x] Segments need to track their size
- [x] We then need to determine if the proposal consists of segments all from the same route, and if the proposed size is smaller than that of the current route
- [x] If that's the case it's a pure remove. We can then shortcut time or distance calculations if the objective allows it.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
