### PR TITLE
Remove depot time window lookup when finalising at other segment 

### DIFF
--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -278,20 +278,20 @@ private:
     std::vector<size_t> visits;  // Locations in this route, incl. depots
     std::pair<double, double> centroid_;  // Center point of route's clients
 
-    std::vector<Distance> cumDist;  // Dist of depot -> client (incl.)
+    std::vector<Distance> cumDist;  // Dist of start -> node (incl.)
 
     // Load data, for each load dimension. These vectors form matrices, where
     // the rows index the load dimension, and the columns the nodes.
     std::vector<LoadSegments> loadAt;      // Load data at each node
-    std::vector<LoadSegments> loadAfter;   // Load of client -> depot (incl)
-    std::vector<LoadSegments> loadBefore;  // Load of depot -> client (incl)
+    std::vector<LoadSegments> loadAfter;   // Load of node -> end (incl)
+    std::vector<LoadSegments> loadBefore;  // Load of start -> node (incl)
 
     std::vector<Load> load_;        // Route loads (for each dimension)
     std::vector<Load> excessLoad_;  // Route excess load (for each dimension)
 
     std::vector<DurationSegment> durAt;      // Duration data at each node
-    std::vector<DurationSegment> durAfter;   // Dur of client -> depot (incl.)
-    std::vector<DurationSegment> durBefore;  // Dur of depot -> client (incl.)
+    std::vector<DurationSegment> durAfter;   // Dur of node -> end (incl.)
+    std::vector<DurationSegment> durBefore;  // Dur of start -> node (incl.)
 
 #ifndef NDEBUG
     // When debug assertions are enabled, we use this flag to check whether
@@ -969,9 +969,9 @@ std::pair<Duration, Duration> Route::Proposal<Segments...>::duration() const
             if (other.last() < data.numDepots())  // other ends at a depot
             {
                 // We can only finalise the current segment at the depot, so we
-                // first need to travel there.
-                ProblemData::Depot const &depot = data.location(other.last());
-                ds = DurationSegment::merge(edgeDur, {depot}, ds);
+                // need to travel there. The depot time windows restrictions are
+                // already handled by the other segment.
+                ds = DurationSegment::merge(edgeDur, {}, ds);
                 ds = ds.finaliseFront();
 
                 // We finalise by travelling to the depot, so the remaining
@@ -984,7 +984,7 @@ std::pair<Duration, Duration> Route::Proposal<Segments...>::duration() const
 
             if constexpr (sizeof...(args) != 0)
             {
-                if (first < data.numDepots())  // other starts at a depot
+                if (first < data.numDepots())  // segment starts at a depot
                     ds = ds.finaliseFront();
 
                 self(self, std::forward<decltype(args)>(args)...);

--- a/tests/search/test_Route.py
+++ b/tests/search/test_Route.py
@@ -1058,3 +1058,34 @@ def test_multi_trip_with_release_times():
     assert_equal(after.start_late(), 50)  # of first trip
     assert_equal(after.duration(), 100)
     assert_equal(after.time_warp(), 0)
+
+
+def test_multi_trip_caches(ok_small_multiple_trips):
+    """
+    Tests that the route duration caches correctly account for rene.
+    """
+    data = ok_small_multiple_trips
+    route = make_search_route(data, [3, 4, 0, 1, 2])
+    assert_(route.is_feasible())
+
+    # Test the prefix cache for the trip [3, 4], ending at the reload depot at
+    # index 3. We also test direct computation (``duration_between``) for good
+    # measure, and compare against a route corresponding to the first trip.
+    first_trip = make_search_route(data, [3, 4])
+    before_reload = route.duration_before(3)
+    between_start_reload = route.duration_between(0, 3)
+    assert_equal(first_trip.duration(), before_reload.duration())
+    assert_equal(between_start_reload.duration(), before_reload.duration())
+
+    # Test the postfix cache for the trip [1, 2], starting at the reload depot
+    # at index 3. We again test direct computation, and compare against a route
+    # corresponding to the second trip.
+    second_trip = make_search_route(data, [1, 2])
+    after_reload = route.duration_after(3)
+    between_reload_end = route.duration_between(3, 6)
+    assert_equal(second_trip.duration(), after_reload.duration())
+    assert_equal(between_reload_end.duration(), after_reload.duration())
+
+    # The trip durations should together sum to the route duration.
+    trips_duration = first_trip.duration() + second_trip.duration()
+    assert_equal(route.duration(), trips_duration)

--- a/tests/search/test_Route.py
+++ b/tests/search/test_Route.py
@@ -1060,18 +1060,17 @@ def test_multi_trip_with_release_times():
     assert_equal(after.time_warp(), 0)
 
 
-def test_multi_trip_caches(ok_small_multiple_trips):
+def test_multi_trip_duration_caches(ok_small_multiple_trips):
     """
-    Tests that the route duration caches correctly account for rene.
+    Tests that the route duration caches correctly account for reload depots.
     """
-    data = ok_small_multiple_trips
-    route = make_search_route(data, [3, 4, 0, 1, 2])
+    route = make_search_route(ok_small_multiple_trips, [3, 4, 0, 1, 2])
     assert_(route.is_feasible())
 
     # Test the prefix cache for the trip [3, 4], ending at the reload depot at
     # index 3. We also test direct computation (``duration_between``) for good
     # measure, and compare against a route corresponding to the first trip.
-    first_trip = make_search_route(data, [3, 4])
+    first_trip = make_search_route(ok_small_multiple_trips, [3, 4])
     before_reload = route.duration_before(3)
     between_start_reload = route.duration_between(0, 3)
     assert_equal(first_trip.duration(), before_reload.duration())
@@ -1080,7 +1079,7 @@ def test_multi_trip_caches(ok_small_multiple_trips):
     # Test the postfix cache for the trip [1, 2], starting at the reload depot
     # at index 3. We again test direct computation, and compare against a route
     # corresponding to the second trip.
-    second_trip = make_search_route(data, [1, 2])
+    second_trip = make_search_route(ok_small_multiple_trips, [1, 2])
     after_reload = route.duration_after(3)
     between_reload_end = route.duration_between(3, 6)
     assert_equal(second_trip.duration(), after_reload.duration())


### PR DESCRIPTION
The time window constraints are already handled by the other segment. There is thus no need to pull those in again.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
