### PR TITLE
Fix bug evaluating moves involving initial vehicle load

### DIFF
--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -880,6 +880,10 @@ Route::Proposal<Segments...>::Proposal(Segments &&...segments)
     [[maybe_unused]] auto &&first = std::get<0>(segments_);
     [[maybe_unused]] auto &&last = std::get<sizeof...(Segments) - 1>(segments_);
     assert(first.route() == last.route());  // must start and end at same route
+
+    [[maybe_unused]] auto const *route = this->route();
+    assert(first.first() == route->startDepot());  // must start at route start
+    assert(last.last() == route->endDepot());      // must end at route end
 }
 
 template <Segment... Segments>

--- a/pyvrp/cpp/search/TripRelocate.cpp
+++ b/pyvrp/cpp/search/TripRelocate.cpp
@@ -28,6 +28,7 @@ public:
 
     size_t first() const { return depot_; }
     size_t last() const { return depot_; }
+    size_t size() const { return 1; }
 
     pyvrp::Distance distance([[maybe_unused]] size_t profile) const
     {

--- a/pyvrp/cpp/search/primitives.cpp
+++ b/pyvrp/cpp/search/primitives.cpp
@@ -24,6 +24,7 @@ public:
 
     size_t first() const { return client; }
     size_t last() const { return client; }
+    size_t size() const { return 1; }
 
     pyvrp::Distance distance([[maybe_unused]] size_t profile) const
     {

--- a/tests/search/test_Exchange.py
+++ b/tests/search/test_Exchange.py
@@ -554,3 +554,31 @@ def test_swap_does_not_swap_depots(ok_small_multiple_trips):
 
     # This move overlaps with reload depot at index 3, so cannot be evaluated.
     assert_equal(op.evaluate(route[2], route[4], cost_eval), 0)
+
+
+def test_bug_evaluating_move_with_initial_load():
+    """
+    Tests a bug where previously the move evaluated below would claim to result
+    in an improvement.
+    """
+    data = ProblemData(
+        clients=[
+            Client(x=0, y=0, delivery=[1]),
+            Client(x=0, y=0, delivery=[1]),
+            Client(x=0, y=0, delivery=[0]),
+        ],
+        depots=[Depot(x=0, y=0)],
+        vehicle_types=[VehicleType(2, capacity=[5], initial_load=[5])],
+        distance_matrices=[np.zeros((4, 4), dtype=int)],
+        duration_matrices=[np.zeros((4, 4), dtype=int)],
+    )
+
+    op = Exchange21(data)
+    cost_eval = CostEvaluator([1], 0, 0)
+
+    route1 = make_search_route(data, [2, 3], idx=0, vehicle_type=0)
+    route2 = make_search_route(data, [1], idx=1, vehicle_type=0)
+
+    # This move just permutes the solution, turning route1 into route2, and
+    # vice versa. Thus, the delta cost of this move should be zero.
+    assert_equal(op.evaluate(route1[1], route2[1], cost_eval), 0)

--- a/tests/search/test_Exchange.py
+++ b/tests/search/test_Exchange.py
@@ -559,7 +559,7 @@ def test_swap_does_not_swap_depots(ok_small_multiple_trips):
 def test_bug_evaluating_move_with_initial_load():
     """
     Tests a bug where previously the move evaluated below would claim to result
-    in an improvement.
+    in an improvement. See #813 for details.
     """
     data = ProblemData(
         clients=[


### PR DESCRIPTION
This PR fixes a bug where moves involving vehicle types with initial vehicle load sometimes determined a no-op move to be improving, because they incorrectly decided excess load would 'disappear' as a consequence of the move. Finally, this PR:

- [x] Adds and passes relevant tests.
- [x] Has well-formatted code and documentation.

Thanks @codyfletcher for bringing this to my attention!

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
