### PR TITLE
Skip finalise when we just merged with a singleton segment

### DIFF
--- a/pyvrp/cpp/search/Route.h
+++ b/pyvrp/cpp/search/Route.h
@@ -968,7 +968,10 @@ std::pair<Duration, Duration> Route::Proposal<Segments...>::duration() const
 
             if constexpr (sizeof...(args) != 0)
             {
-                if (first < data.numDepots())  // segment starts at a depot
+                if (first < data.numDepots() && other.size() != 1)
+                    // Other starts at a depot and contains more than one node,
+                    // so there might be a release time component we need to
+                    // take into account. So we need to finalise again.
                     ds = ds.finaliseFront();
 
                 self(self, std::forward<decltype(args)>(args)...);
@@ -1007,7 +1010,10 @@ Load Route::Proposal<Segments...>::excessLoad(size_t dimension) const
 
             if constexpr (sizeof...(args) != 0)
             {
-                if (other.last() < data.numDepots())  // other ends at a depot
+                if (other.last() < data.numDepots() && other.size() != 1)
+                    // Other ends at a depot and contains more than one node,
+                    // so there might be meaningful load on it. This means we
+                    // need to finalise again.
                     ls = ls.finalise(capacity);
 
                 self(self, std::forward<decltype(args)>(args)...);


### PR DESCRIPTION
We do not need to finalise again if the segment we just merged with contains only a single (reload) depot. This PR adds checks that let us skip finalising in those cases.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
