### PR TITLE
Explain that (x, y) coordinates can be scaled (lon, lat) pairs

### DIFF
--- a/pyvrp/cpp/ProblemData.h
+++ b/pyvrp/cpp/ProblemData.h
@@ -90,10 +90,12 @@ public:
      * ----------
      * x
      *     Horizontal coordinate of this client, that is, the 'x' part of the
-     *     client's (x, y) location tuple.
+     *     client's (x, y) location tuple. This can for example be a scaled
+     *     longitude value.
      * y
      *     Vertical coordinate of this client, that is, the 'y' part of the
-     *     client's (x, y) location tuple.
+     *     client's (x, y) location tuple. This can for example be a scaled
+     *     latitude value.
      * delivery
      *     The amounts this client demands from the depot.
      * pickup
@@ -276,10 +278,12 @@ public:
      * ----------
      * x
      *     Horizontal coordinate of this depot, that is, the 'x' part of the
-     *     depot's (x, y) location tuple.
+     *     depot's (x, y) location tuple. This can for example be a scaled
+     *     longitude value.
      * y
      *     Vertical coordinate of this depot, that is, the 'y' part of the
-     *     depot's (x, y) location tuple.
+     *     depot's (x, y) location tuple. This can for example be a scaled
+     *     latitude value.
      * tw_early
      *     Opening time of this depot. Default 0.
      * tw_late


### PR DESCRIPTION
This has come up two times now (mostly about why, see e.g. #650), and I've seen someone ask a question on LinkedIn about what to put here. Just scaled (lon, lat) data is perfectly fine, so I'm adding that to the docstring.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
