### PR TITLE
Fix route unpacking in quickstart example

### DIFF
--- a/examples/quick_tutorial.ipynb
+++ b/examples/quick_tutorial.ipynb
@@ -875,7 +875,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "route = res.best.routes()[0]\n",
+    "route, *_ = res.best.routes()\n",
     "\n",
     "for idx, trip in enumerate(route.trips()):\n",
     "    start_depot = trip.start_depot()\n",


### PR DESCRIPTION
I changed the rng a bit in #827 and this led to a different optimal solution with 3 routes.

![image](https://github.com/user-attachments/assets/985d6368-a2a4-4cde-ab03-49024d51e425)

This PR does two things:
- It reduces the number of vehicle types to 2, so that a 3-route optimal solution is not possible. 
- It accesses the first route by index and not by unpacking. If a 1-route optimal solution exists, then this at least won't result in an error. (Edit: Actually, a 1-route solution is not possible because we set `max_reloads=2`, but taking the first route by index is clearer.)

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
