### PR TITLE
Remove meson_options.txt from package includes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,6 @@ include = [
     { path = "tests/", format = "sdist" },
 
     { path = "meson.build", format = "sdist" },
-    { path = "meson_options.txt", format = "sdist" },
     { path = "buildtools/*.py", format = "sdist" },
     { path = "subprojects/*.wrap", format = "sdist" },
 


### PR DESCRIPTION
We no longer use meson options, having removed the last option in #807 and deleting the `meson_options.txt` file. So this include is now superfluous.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
