### PR TITLE
Raise when the `CostEvaluator` is constructed using negative penalties

### DIFF
--- a/pyvrp/cpp/CostEvaluator.cpp
+++ b/pyvrp/cpp/CostEvaluator.cpp
@@ -1,5 +1,7 @@
 #include "CostEvaluator.h"
 
+#include <stdexcept>
+
 using pyvrp::CostEvaluator;
 
 CostEvaluator::CostEvaluator(std::vector<double> loadPenalties,
@@ -9,4 +11,13 @@ CostEvaluator::CostEvaluator(std::vector<double> loadPenalties,
       twPenalty_(twPenalty),
       distPenalty_(distPenalty)
 {
+    for (auto const penalty : loadPenalties_)
+        if (penalty < 0)
+            throw std::invalid_argument("load_penalties must be >= 0.");
+
+    if (twPenalty_ < 0)
+        throw std::invalid_argument("tw_penalty must be >= 0.");
+
+    if (distPenalty_ < 0)
+        throw std::invalid_argument("dist_penalty must be >= 0.");
 }

--- a/pyvrp/cpp/CostEvaluator.h
+++ b/pyvrp/cpp/CostEvaluator.h
@@ -66,6 +66,11 @@ concept DeltaCostEvaluatable = requires(T arg, size_t dimension) {
  * dist_penalty
  *    The penalty for each unit of distance in excess of the vehicle's maximum
  *    distance constraint.
+ *
+ * Raises
+ * ------
+ * ValueError
+ *     When any of the given penalty terms are negative.
  */
 class CostEvaluator
 {

--- a/tests/test_CostEvaluator.py
+++ b/tests/test_CostEvaluator.py
@@ -28,7 +28,7 @@ def test_raises_negative_penalties(
     dist_penalty: float,
 ):
     """
-    Tests that passing negative penalty values to the CostEvaluator raise an
+    Tests that passing negative penalty values to the CostEvaluator raises an
     error.
     """
     with assert_raises(ValueError):

--- a/tests/test_CostEvaluator.py
+++ b/tests/test_CostEvaluator.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from numpy.testing import assert_, assert_equal
+from numpy.testing import assert_, assert_equal, assert_raises
 
 from pyvrp import (
     Client,
@@ -13,11 +13,26 @@ from pyvrp import (
 )
 
 
-def test_raises_negative_penalties():
+@pytest.mark.parametrize(
+    ("load_penalties", "tw_penalty", "dist_penalty"),
+    [
+        ([], -1, 0),
+        ([], 0, -1),
+        ([-1], 0, 0),
+        ([0, -1], 0, 0),
+    ],
+)
+def test_raises_negative_penalties(
+    load_penalties: list[float],
+    tw_penalty: float,
+    dist_penalty: float,
+):
     """
-    TODO
+    Tests that passing negative penalty values to the CostEvaluator raise an
+    error.
     """
-    pass
+    with assert_raises(ValueError):
+        CostEvaluator(load_penalties, tw_penalty, dist_penalty)
 
 
 @pytest.mark.parametrize("load_penalty", (2, 4))

--- a/tests/test_CostEvaluator.py
+++ b/tests/test_CostEvaluator.py
@@ -13,6 +13,13 @@ from pyvrp import (
 )
 
 
+def test_raises_negative_penalties():
+    """
+    TODO
+    """
+    pass
+
+
 @pytest.mark.parametrize("load_penalty", (2, 4))
 def test_load_penalty(load_penalty: float):
     """


### PR DESCRIPTION
This PR:

- [ ] Closes #xxxx.
- [ ] Adds and passes relevant tests.
- [ ] Has well-formatted code and documentation.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
