### PR TITLE
Replace black-jupyter with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,11 +12,6 @@ repos:
     hooks:
       - id: nbstripout
 
-  - repo: https://github.com/psf/black
-    rev: 22.12.0
-    hooks:
-      - id: black-jupyter
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.10
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,10 +85,6 @@ default-groups = ["build", "dev"]
 package = true
 
 
-[tool.black]
-line-length = 79
-
-
 [tool.ruff]
 line-length = 79
 


### PR DESCRIPTION
This PR replaces black-jupyter with ruff. Black-jupyter was formatting Python code because we didn't set the `types_or` field in pre-commit, and it clashed with ruff. But we can just completely remove it and replace with ruff, because ruff now formats and lints notebooks since v0.6.0 [by default](https://docs.astral.sh/ruff/configuration/#jupyter-notebook-discovery).

- [ ] Closes #xxxx.
- [ ] Adds and passes relevant tests.
- [ ] Has well-formatted code and documentation.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
