### PR TITLE
Make CodSpeed solve benchmark run for more iterations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,7 +169,8 @@ dmypy.json
 debug/
 release/
 
-# Profiler results
+# Profiler and benchmark results
+*.codspeed/
 *.prof
 perf.data*
 heaptrack.*.gz

--- a/benchmarks/test_solve.py
+++ b/benchmarks/test_solve.py
@@ -10,4 +10,4 @@ def test_solve(instance, benchmark, request):
     Tests performance of solving various instances.
     """
     data = request.getfixturevalue(instance)
-    benchmark(solve, data, stop=MaxIterations(25), seed=0)
+    benchmark(solve, data, stop=MaxIterations(100), seed=0)

--- a/benchmarks/test_solve.py
+++ b/benchmarks/test_solve.py
@@ -10,4 +10,4 @@ def test_solve(instance, benchmark, request):
     Tests performance of solving various instances.
     """
     data = request.getfixturevalue(instance)
-    benchmark(solve, data, stop=MaxIterations(1), seed=0)
+    benchmark(solve, data, stop=MaxIterations(25), seed=0)


### PR DESCRIPTION
This PR makes our call to `solve()` run for 25 iterations, instead of 1, in the benchmarks. I noticed very little work was being done in the local search, while I think that's one of the main reasons to have this benchmark in the first place.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
