### PR TITLE
Cycle through colors when plotting solution

### DIFF
--- a/pyvrp/plotting/plot_solution.py
+++ b/pyvrp/plotting/plot_solution.py
@@ -43,7 +43,7 @@ def plot_solution(
     colors = plt.get_cmap("tab10")
     in_solution = np.zeros(data.num_locations, dtype=bool)
     for idx, route in enumerate(solution.routes()):
-        color = colors(idx)
+        color = colors(idx % colors.N)
         in_solution[route] = True
 
         if len(route) == 1 or plot_clients:  # explicit client coordinate plot


### PR DESCRIPTION
We use the `tab10` colormap to plot routes, but we don't cycle through the colors. This PR fixes that.

<details>
<summary>Before</summary>
<img width="1280" height="825" alt="image" src="https://github.com/user-attachments/assets/e54e6992-ba7a-4822-82cd-c63099a0eda7" />

</details>

<details>
<summary>After</summary>

<img width="1275" height="794" alt="image" src="https://github.com/user-attachments/assets/8b3f64ec-addf-4156-9747-166e5f4b0350" />

</details>

----

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
