### PR TITLE
Make start time respect release time

### DIFF
--- a/pyvrp/cpp/DurationSegment.h
+++ b/pyvrp/cpp/DurationSegment.h
@@ -282,8 +282,8 @@ Duration DurationSegment::startEarly() const
 
 Duration DurationSegment::startLate() const
 {
-    // When startLate_ < releaseTime_, we need to wait until at least
-    // releaseTime_ before we can start. This always incurs time warp.
+    // When startLate_ < releaseTime_, we need to wait until releaseTime_ before
+    // we can start. This always incurs time warp.
     return std::max(startLate_, releaseTime_);
 }
 

--- a/pyvrp/cpp/DurationSegment.h
+++ b/pyvrp/cpp/DurationSegment.h
@@ -267,6 +267,7 @@ Duration DurationSegment::timeWarp(Duration maxDuration) const
     auto const netDuration = duration() - timeWarp;
 
     return timeWarp
+           // Additional time warp from having to wait until release time.
            + std::max<Duration>(releaseTime_ - startLate_, 0)
            // Max duration constraint applies only to net route duration,
            // subtracting existing time warp. Use ternary to avoid underflow.
@@ -283,7 +284,7 @@ Duration DurationSegment::startEarly() const
 Duration DurationSegment::startLate() const
 {
     // When startLate_ < releaseTime_, we need to wait until releaseTime_ before
-    // we can start. This always incurs time warp.
+    // we can start. That wait always incurs time warp.
     return std::max(startLate_, releaseTime_);
 }
 

--- a/pyvrp/cpp/DurationSegment.h
+++ b/pyvrp/cpp/DurationSegment.h
@@ -250,11 +250,7 @@ DurationSegment DurationSegment::finaliseFront() const
     // merge with our release times, if they are binding.
     DurationSegment const curr
         = {duration_, timeWarp_, startEarly_, startLate_, 0};
-    DurationSegment const release = {0,
-                                     0,
-                                     std::max(startEarly_, releaseTime_),
-                                     std::max(startLate_, releaseTime_),
-                                     0};
+    DurationSegment const release = {0, 0, startEarly(), startLate(), 0};
 
     return merge(0, release, curr);
 }
@@ -279,18 +275,17 @@ Duration DurationSegment::timeWarp(Duration maxDuration) const
 
 Duration DurationSegment::startEarly() const
 {
-    // There are two cases:
-    // 1) When startLate_ < releaseTime_ there is time warp from release times.
-    //    As startEarly_ <= startLate_, we then return startLate_ to minimise
-    //    this time warp.
-    // 2) When startLate_ >= releaseTime_, there is a feasible start time that
-    //    does not cause time warp due to release times. Then we return either
-    //    the earliest start time, or the release time, whichever is larger.
-    assert(startEarly_ <= startLate_);
-    return std::max(startEarly_, std::min(startLate_, releaseTime_));
+    // When startEarly_ < releaseTime_, we need to wait until at least
+    // releaseTime_ before we can start.
+    return std::max(startEarly_, releaseTime_);
 }
 
-Duration DurationSegment::startLate() const { return startLate_; }
+Duration DurationSegment::startLate() const
+{
+    // When startLate_ < releaseTime_, we need to wait until at least
+    // releaseTime_ before we can start. This always incurs time warp.
+    return std::max(startLate_, releaseTime_);
+}
 
 Duration DurationSegment::endEarly() const
 {

--- a/pyvrp/cpp/Route.cpp
+++ b/pyvrp/cpp/Route.cpp
@@ -158,14 +158,13 @@ void Route::makeSchedule(ProblemData const &data)
 
         auto const earliestStart = std::max(
             start.twEarly, std::min(trip.releaseTime(), start.twLate));
-        auto const wait = std::max<Duration>(earliestStart - now, 0);
+        auto const latestStart = tripIdx == 0  // first trip also accounts for
+                                               // the latest start constraint
+                                     ? std::min(start.twLate, vehData.startLate)
+                                     : start.twLate;
 
-        auto tw = std::max<Duration>(now - start.twLate, 0);
-        if (tripIdx == 0)  // then we also need to account for the vehicle's
-        {                  // latest start constraint, if binding.
-            auto const latestStart = std::min(start.twLate, vehData.startLate);
-            tw = std::max<Duration>(now - latestStart, 0);
-        }
+        auto const wait = std::max<Duration>(earliestStart - now, 0);
+        auto const tw = std::max<Duration>(now - latestStart, 0);
 
         now += wait;
         now -= tw;

--- a/pyvrp/cpp/Route.cpp
+++ b/pyvrp/cpp/Route.cpp
@@ -136,8 +136,6 @@ void Route::makeSchedule(ProblemData const &data)
     auto const &vehData = data.vehicleType(vehicleType_);
     auto const &durations = data.durationMatrix(vehData.profile);
 
-    // TODO rethink the following
-
     auto now = startTime_;
     auto const handle
         = [&](auto const &where, size_t location, size_t trip, Duration service)
@@ -158,15 +156,16 @@ void Route::makeSchedule(ProblemData const &data)
         auto const &trip = trips_[tripIdx];
         ProblemData::Depot const &start = data.location(trip.startDepot());
 
-        DurationSegment ds
-            = {0, 0, start.twEarly, start.twLate, trip.releaseTime()};
-        if (tripIdx == 0)
-            ds = DurationSegment::merge(0, {vehData, vehData.startLate}, ds);
+        auto const earliestStart = std::max(
+            start.twEarly, std::min(trip.releaseTime(), start.twLate));
+        auto const wait = std::max<Duration>(earliestStart - now, 0);
 
-        auto const wait = std::max<Duration>(ds.startEarly() - now, 0);
-        auto const tw = tripIdx == 0
-                            ? ds.timeWarp()
-                            : std::max<Duration>(now - ds.startLate(), 0);
+        auto tw = std::max<Duration>(now - start.twLate, 0);
+        if (tripIdx == 0)  // then we also need to account for the vehicle's
+        {                  // latest start constraint, if binding.
+            auto const latestStart = std::min(start.twLate, vehData.startLate);
+            tw = std::max<Duration>(now - latestStart, 0);
+        }
 
         now += wait;
         now -= tw;

--- a/pyvrp/cpp/Route.cpp
+++ b/pyvrp/cpp/Route.cpp
@@ -136,6 +136,8 @@ void Route::makeSchedule(ProblemData const &data)
     auto const &vehData = data.vehicleType(vehicleType_);
     auto const &durations = data.durationMatrix(vehData.profile);
 
+    // TODO rethink the following
+
     auto now = startTime_;
     auto const handle
         = [&](auto const &where, size_t location, size_t trip, Duration service)
@@ -248,6 +250,9 @@ Route::Route(ProblemData const &data, Trips trips, size_t vehType)
     DurationSegment ds = {vehData, vehData.twLate};
     for (auto trip = trips_.rbegin(); trip != trips_.rend(); ++trip)
     {
+        if (trip != trips_.rbegin())  // need to finalise before next trip,
+            ds = ds.finaliseFront();  // unless this is the first one
+
         ProblemData::Depot const &end = data.location(trip->endDepot());
         ds = DurationSegment::merge(0, {end}, ds);
 
@@ -267,7 +272,6 @@ Route::Route(ProblemData const &data, Trips trips, size_t vehType)
         DurationSegment const depotDS = {start};
 
         ds = DurationSegment::merge(edgeDuration, depotDS, ds);
-        ds = ds.finaliseFront();
     }
 
     ds = DurationSegment::merge(0, {vehData, vehData.startLate}, ds);

--- a/tests/test_DurationSegment.py
+++ b/tests/test_DurationSegment.py
@@ -189,11 +189,9 @@ def test_finalise_back_with_time_warp_from_release_time():
     """
     Tests finalise_back() when there's time warp due to the release time.
     """
-    # Release time is 75, which is after start_late of 70. So we have 5 time
-    # warp from this.
     segment = DurationSegment(5, 0, 50, 70, 75)
-    assert_equal(segment.start_early(), 70)
-    assert_equal(segment.start_late(), 70)
+    assert_equal(segment.start_early(), 75)  # = max(early, release_time)
+    assert_equal(segment.start_late(), 75)  # = max(late, release_time)
     assert_equal(segment.release_time(), 75)
     assert_equal(segment.duration(), 5)
     assert_equal(segment.time_warp(), 5)  # due to release time
@@ -259,7 +257,7 @@ def test_time_warp_from_release_time(release_time: int, exp_time_warp: int):
     in the expected amount of time warp.
     """
     segment = DurationSegment(0, 0, 0, 100, release_time)
-    assert_equal(segment.start_late(), 100)
+    assert_equal(segment.start_late(), max(100, release_time))
     assert_equal(segment.time_warp(), exp_time_warp)
 
 

--- a/tests/test_Route.py
+++ b/tests/test_Route.py
@@ -870,7 +870,7 @@ def test_bug_iterating_with_empty_last_trip(ok_small_multiple_trips):
 def test_route_release_time_after_vehicle_start_late():
     """
     Tests that a route time warps back to the vehicle's latest start if that
-    latest start occurs before the first trip's release time.
+    latest start is before the first trip's release time.
     """
     data = read("data/OkSmallReleaseTimes.txt")
 
@@ -885,3 +885,6 @@ def test_route_release_time_after_vehicle_start_late():
     assert_equal(route.release_time(), 20_000)
     assert_equal(route.time_warp(), 10_000)
     assert_equal(route.duration(), 7_686)
+
+    # Sanity check that all time warp is also accounted for in the schedule.
+    assert_equal(sum(v.time_warp for v in route.schedule()), route.time_warp())

--- a/tests/test_Route.py
+++ b/tests/test_Route.py
@@ -865,3 +865,23 @@ def test_bug_iterating_with_empty_last_trip(ok_small_multiple_trips):
     route = Route(ok_small_multiple_trips, [trip1, trip2], 0)
     assert_equal([client for client in route], [1, 2])
     assert_equal(route.visits(), [1, 2])
+
+
+def test_route_release_time_after_vehicle_start_late():
+    """
+    Tests that a route time warps back to the vehicle's latest start if that
+    latest start occurs before the first trip's release time.
+    """
+    data = read("data/OkSmallReleaseTimes.txt")
+
+    new_type = data.vehicle_type(0).replace(start_late=10_000)
+    data = data.replace(vehicle_types=[new_type])
+    route = Route(data, [3, 1], 0)
+
+    # Route starts at 20_000 due to release time. We immediately time warp back
+    # to 10_000 for the vehicle's latest start constraint. From there, we visit
+    # 3 and 1 as regular, without accruing any additional time warp.
+    assert_equal(route.start_time(), 20_000)
+    assert_equal(route.release_time(), 20_000)
+    assert_equal(route.time_warp(), 10_000)
+    assert_equal(route.duration(), 7_686)


### PR DESCRIPTION
This PR fixes an issue where `pyvrp::Route` incorrectly missed time warp due to a latest start constraint on the vehicle, and a release time later than that constraint. This has been corrected by moving the start time of the route to at least the release time, and time warping back to the time of the latest start constraint, if needed.

This PR:
- [ ] Closes #xxxx.
- [x] Adds and passes relevant tests.
- [x] Has well-formatted code and documentation.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
