### PR TITLE
Print lines missing coverage when running tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ ignore_missing_imports = true
 addopts = [
     "--cov",
     "--cov-report=xml",
-    "--cov-report=term",
+    "--cov-report=term-missing",
     "--numprocesses=auto",
 ]
 testpaths = "tests"

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,1 +1,2 @@
 */
+*.wraplock


### PR DESCRIPTION
Turns out there's also a `term-missing` option, instead of just `term`. The extra information about lines missing coverage seems useful.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
