### PR TITLE
Bump pybind11 to v3.0.0

### DIFF
--- a/subprojects/pybind11.wrap
+++ b/subprojects/pybind11.wrap
@@ -1,13 +1,13 @@
 [wrap-file]
-directory = pybind11-2.13.5
-source_url = https://github.com/pybind/pybind11/archive/refs/tags/v2.13.5.tar.gz
-source_filename = pybind11-2.13.5.tar.gz
-source_hash = b1e209c42b3a9ed74da3e0b25a4f4cd478d89d5efbb48f04b277df427faf6252
-patch_filename = pybind11_2.13.5-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/pybind11_2.13.5-1/get_patch
-patch_hash = ecb031b830481560b3d8487ed63ba4f5509a074be42f5d19af64d844c795e15b
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/pybind11_2.13.5-1/pybind11-2.13.5.tar.gz
-wrapdb_version = 2.13.5-1
+directory = pybind11-3.0.0
+source_url = https://github.com/pybind/pybind11/archive/refs/tags/v3.0.0.tar.gz
+source_filename = pybind11-3.0.0.tar.gz
+source_hash = 453b1a3e2b266c3ae9da872411cadb6d693ac18063bd73226d96cfb7015a200c
+patch_filename = pybind11_3.0.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/pybind11_3.0.0-1/get_patch
+patch_hash = 51ef27fd76207c530fb54017aaa166ff02bb49f12308d497635fefbc1bc6a560
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/pybind11_3.0.0-1/pybind11-3.0.0.tar.gz
+wrapdb_version = 3.0.0-1
 
 [provide]
 pybind11 = pybind11_dep


### PR DESCRIPTION
pybind11 v3 is finally out! That's been a blocker for #599 since forever. Very nice to have.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
