### PR TITLE
docs: enable version dropdown and add code copy feature

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,11 @@
+# --- BEGIN: helper block to enable Sphinx-Immaterial version dropdown ---
+try:
+    html_theme_options
+except NameError:
+    html_theme_options = {}
+features = set(html_theme_options.get("features", []))
+features.add("content.code.copy")
+html_theme_options["features"] = sorted(features)
+html_theme_options["version_dropdown"] = True
+html_theme_options["version_json"] = "/versions.json"
+# --- END helper block ---

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,0 +1,4 @@
+[
+  { "version": "/",         "title": "latest",  "aliases": ["latest","stable"] },
+  { "version": "/v0.11.3/", "title": "v0.11.3", "aliases": [] }
+]


### PR DESCRIPTION
**Summary**  
This PR improves the developer documentation by enabling version switching and making code blocks easier to copy:
- Adds `versions.json` to support Sphinx-Immaterial’s version dropdown  
- Enables a copy-to-clipboard “copy” button on code blocks  
- Maintains backward-compatibility with existing Sphinx configuration  

Improves ease of use when navigating multiple versions of the docs, and reduce friction for copying example commands.  

**Details / Testing**  
- Built locally with `sphinx-immaterial >= 0.13`  
- Dropdown now shows “latest” and “v0.11.3” and resolves links correctly  
- No changes to library code or tests — docs-only update  

**Checklist**  
- [x] Builds successfully via `sphinx-build docs _build/html`  
- [x] No modifications to core library or test suite  
- [x] Follows PyVRP’s contributing guidelines (per reference contr. page)