### PR TITLE
Remove references from Measure arguments

### DIFF
--- a/pyvrp/cpp/Measure.h
+++ b/pyvrp/cpp/Measure.h
@@ -80,14 +80,14 @@ public:
     [[nodiscard]] Value get() const;
 
     // In-place unary operators.
-    Measure &operator+=(Measure const &rhs);
-    Measure &operator-=(Measure const &rhs);
-    Measure &operator*=(Measure const &rhs);
-    Measure &operator/=(Measure const &rhs);
+    Measure &operator+=(Measure const rhs);
+    Measure &operator-=(Measure const rhs);
+    Measure &operator*=(Measure const rhs);
+    Measure &operator/=(Measure const rhs);
 
     // Comparison operators.
-    [[nodiscard]] bool operator==(Measure const &other) const;
-    [[nodiscard]] std::strong_ordering operator<=>(Measure const &other) const;
+    [[nodiscard]] bool operator==(Measure const other) const;
+    [[nodiscard]] std::strong_ordering operator<=>(Measure const other) const;
 };
 
 // Retrieves the underlying value.
@@ -100,7 +100,7 @@ Value Measure<Type, Value>::get() const
 // In-place unary operators.
 template <MeasureType Type, NumberType Value>
 Measure<Type, Value> &
-Measure<Type, Value>::operator+=(Measure<Type, Value> const &rhs)
+Measure<Type, Value>::operator+=(Measure<Type, Value> const rhs)
 {
     if constexpr (std::is_integral_v<Value>)
     {
@@ -114,7 +114,7 @@ Measure<Type, Value>::operator+=(Measure<Type, Value> const &rhs)
 
 template <MeasureType Type, NumberType Value>
 Measure<Type, Value> &
-Measure<Type, Value>::operator-=(Measure<Type, Value> const &rhs)
+Measure<Type, Value>::operator-=(Measure<Type, Value> const rhs)
 {
     if constexpr (std::is_integral_v<Value>)
     {
@@ -128,7 +128,7 @@ Measure<Type, Value>::operator-=(Measure<Type, Value> const &rhs)
 
 template <MeasureType Type, NumberType Value>
 Measure<Type, Value> &
-Measure<Type, Value>::operator*=(Measure<Type, Value> const &rhs)
+Measure<Type, Value>::operator*=(Measure<Type, Value> const rhs)
 {
     if constexpr (std::is_integral_v<Value>)
     {
@@ -142,7 +142,7 @@ Measure<Type, Value>::operator*=(Measure<Type, Value> const &rhs)
 
 template <MeasureType Type, NumberType Value>
 Measure<Type, Value> &
-Measure<Type, Value>::operator/=(Measure<Type, Value> const &rhs)
+Measure<Type, Value>::operator/=(Measure<Type, Value> const rhs)
 {
     this->value /= rhs.value;
     return *this;
@@ -150,14 +150,14 @@ Measure<Type, Value>::operator/=(Measure<Type, Value> const &rhs)
 
 // Comparison operators.
 template <MeasureType Type, NumberType Value>
-bool Measure<Type, Value>::operator==(Measure<Type, Value> const &other) const
+bool Measure<Type, Value>::operator==(Measure<Type, Value> const other) const
 {
     return value == other.value;
 }
 
 template <MeasureType Type, NumberType Value>
 std::strong_ordering
-Measure<Type, Value>::operator<=>(Measure<Type, Value> const &other) const
+Measure<Type, Value>::operator<=>(Measure<Type, Value> const other) const
 {
     return value <=> other.value;
 }


### PR DESCRIPTION
We also don't do int/double references, we just copy those. The same should apply to `Measure`'s member functions.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
