### PR TITLE
Use trusted publishing

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -62,4 +62,4 @@ jobs:
         run: ls -la dist/
       - name: Deploy to PyPI
         run: |
-          uv publish --token ${{ secrets.PYPI_TOKEN }}
+          uv publish


### PR DESCRIPTION
I just read https://blog.pypi.org/posts/2025-11-26-pypi-and-shai-hulud/ and think we should probably start using trusted publishing. This PR sets that up on GH (I've already done PyPI), but I don't know if there's more I need to do. Guess we'll see when next we push to PyPI.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
