### PR TITLE
Exponential moving average acceptance

### DIFF
--- a/pyvrp/IteratedLocalSearch.py
+++ b/pyvrp/IteratedLocalSearch.py
@@ -144,12 +144,13 @@ class IteratedLocalSearch:
             cand_cost = cost_eval.penalised_cost(candidate)
             curr_cost = cost_eval.penalised_cost(current)
 
-            if cand_cost < max(curr_cost, threshold):  # accept candidate
+            if cand_cost < curr_cost:  # accept if better
                 current = candidate
+                weight = self._params.smoothing_factor
+                threshold = weight * cand_cost + (1 - weight) * threshold
 
-                if cand_cost < curr_cost:  # only update if better
-                    weight = self._params.smoothing_factor
-                    threshold = weight * cand_cost + (1 - weight) * threshold
+            if cand_cost < threshold:  # accept worse if below threshold
+                current = candidate
 
             stats.collect(current, candidate, best, cost_eval)
             print_progress.iteration(stats)


### PR DESCRIPTION
This PR:

- [x] Closes #946.
- [ ] Adds and passes relevant tests.
- [ ] Has well-formatted code and documentation.



| Commit  | Time     | CVRP-XXL | MDVRPTW | HFVRP | VRPB | MTVRPTWR | CVRP | PCVRPTW | VRPTW |
|---------|----------|----------|---------|-------|------|----------|------|---------|-------|
| bbdc29b (main)  | 1 min    | 4.37%    | 1.87%   | 1.61%  | 1.20%  | 1.00%    | 0.63%  | 0.93%   | 1.77%  |
|          | 2 min    | 3.50%    | 1.40%   | 1.10%  | 0.91%  | 0.73%    | 0.49%  | 0.73%   | 1.50%  |
|          | 10 min   | 1.91%    | 0.81%   | 0.58%  | 0.57%  | 0.32%    | 0.30%  | 0.43%   | 0.97%  |
| | academic | 0.99% | 0.48% | 0.49% | 0.43% | 0.31% | 0.26% | 0.22% | 0.63% |
| 925be68 | 1min     |    5.25% |   2.15% | 1.57% | 1.23% |    0.91% | 0.69% |   0.97% | 2.02% |
| 925be68 | 2min     |    4.26% |   1.51% | 1.20% | 0.93% |    0.63% | 0.53% |   0.71% | 1.58% |
| 925be68 | 10min    |    2.37% |   1.02% | 0.77% | 0.69% |    0.35% | 0.39% |   0.49% | 1.09% |
| 925be68 | academic |    1.54% |   0.91% | 0.72% | 0.64% |    0.35% | 0.37% |   0.38% | 0.88% |
| 5da51a4 | 1min     |    5.67% |   2.74% | 2.53% | 1.51% |    1.35% | 0.90% |   1.13% | 3.05% |
| 5da51a4 | 2min     |    4.79% |   1.73% | 1.27% | 1.04% |    0.78% | 0.60% |   0.73% | 1.88% |
| 5da51a4 | 10min    |    2.87% |   0.75% | 0.65% | 0.58% |    0.30% | 0.30% |   0.41% | 0.98% |
| 5da51a4 | academic |    1.24% |   0.62% | 0.51% | 0.50% |    0.30% | 0.26% |   0.31% | 0.73% |



<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
