### PR TITLE
Remove `StoppingCriterion.fraction_remaining()`

### DIFF
--- a/pyvrp/stop/FirstFeasible.py
+++ b/pyvrp/stop/FirstFeasible.py
@@ -8,9 +8,6 @@ class FirstFeasible:
     Terminates the search after a feasible solution has been observed.
     """
 
-    def fraction_remaining(self) -> None:
-        return None
-
     def __call__(self, best_cost: float) -> bool:
         # This function is called with the output of CostEvaluator.cost on the
         # best solution, which is INT_MAX when the best solution is infeasible.

--- a/pyvrp/stop/MaxIterations.py
+++ b/pyvrp/stop/MaxIterations.py
@@ -10,13 +10,6 @@ class MaxIterations:
         self._max_iters = max_iterations
         self._curr_iter = 0
 
-    def fraction_remaining(self) -> float:
-        if self._max_iters == 0:
-            return 0
-
-        fraction = 1 - self._curr_iter / self._max_iters
-        return max(fraction, 0.0)
-
     def __call__(self, best_cost: float) -> bool:
         self._curr_iter += 1
 

--- a/pyvrp/stop/MaxRuntime.py
+++ b/pyvrp/stop/MaxRuntime.py
@@ -13,17 +13,6 @@ class MaxRuntime:
         self._max_runtime = max_runtime
         self._start_runtime: float | None = None
 
-    def fraction_remaining(self) -> float:
-        if self._max_runtime == 0:
-            return 0
-
-        if self._start_runtime is None:
-            return 1
-
-        elapsed_time = time.perf_counter() - self._start_runtime
-        fraction = 1 - elapsed_time / self._max_runtime
-        return max(fraction, 0.0)
-
     def __call__(self, best_cost: float) -> bool:
         if self._start_runtime is None:
             self._start_runtime = time.perf_counter()

--- a/pyvrp/stop/MultipleCriteria.py
+++ b/pyvrp/stop/MultipleCriteria.py
@@ -12,9 +12,5 @@ class MultipleCriteria:
 
         self.criteria = criteria
 
-    def fraction_remaining(self) -> float | None:
-        fractions = (crit.fraction_remaining() for crit in self.criteria)
-        return min((f for f in fractions if f is not None), default=None)
-
     def __call__(self, best_cost: float) -> bool:
         return any(crit(best_cost) for crit in self.criteria)

--- a/pyvrp/stop/NoImprovement.py
+++ b/pyvrp/stop/NoImprovement.py
@@ -17,13 +17,6 @@ class NoImprovement:
         self._target: float | None = None
         self._counter = 0
 
-    def fraction_remaining(self) -> float:
-        if self._max_iterations == 0:
-            return 0
-
-        fraction = 1 - self._counter / self._max_iterations
-        return max(fraction, 0.0)
-
     def __call__(self, best_cost: float) -> bool:
         if self._target is None or best_cost < self._target:
             self._target = best_cost

--- a/pyvrp/stop/StoppingCriterion.py
+++ b/pyvrp/stop/StoppingCriterion.py
@@ -6,19 +6,6 @@ class StoppingCriterion(Protocol):  # pragma: no cover
     Protocol that stopping criteria must implement.
     """
 
-    def fraction_remaining(self) -> float | None:
-        """
-        Returns the fraction of the stopping criterion's budget that remains.
-
-        Returns
-        -------
-        float | None
-            A value between 0 and 1, where 0 means the stopping criterion is
-            met and 1 means it is not. If the stopping criterion does not
-            have a meaningful interpretation of remaining fraction, it should
-            return None.
-        """
-
     def __call__(self, best_cost: float) -> bool:
         """
         When called, this stopping criterion should return True if the

--- a/tests/stop/test_FirstFeasible.py
+++ b/tests/stop/test_FirstFeasible.py
@@ -18,11 +18,3 @@ def test_stops_on_first_feasible_solution(ok_small):
     cost_eval = CostEvaluator([0], 0, 0)
     assert_(not stop(cost_eval.cost(infeas)))
     assert_(stop(cost_eval.cost(feas)))
-
-
-def test_fraction_remaining():
-    """
-    Tests that calling ``fraction_remaining()`` returns None.
-    """
-    stop = FirstFeasible()
-    assert_(stop.fraction_remaining() is None)

--- a/tests/stop/test_MaxIterations.py
+++ b/tests/stop/test_MaxIterations.py
@@ -1,4 +1,4 @@
-from numpy.testing import assert_, assert_equal, assert_raises
+from numpy.testing import assert_, assert_raises
 from pytest import mark
 
 from pyvrp.stop import MaxIterations
@@ -44,29 +44,3 @@ def test_after_max_iterations():
 
     for _ in range(100):
         assert_(stop(1))
-
-
-def test_fraction_remaining():
-    """
-    Tests that calling ``fraction_remaining()`` returns the correct values.
-    """
-    stop = MaxIterations(100)
-    assert_equal(stop.fraction_remaining(), 1)
-
-    stop(0)
-    assert_equal(stop.fraction_remaining(), 0.99)
-
-
-def test_fraction_remaining_zero_budget():
-    """
-    Tests that ``fraction_remaining()`` works correctly when max iterations is
-    set to zero.
-    """
-    # Zero max iterations should result in zero fraction remaining from the
-    # start.
-    stop = MaxIterations(0)
-    assert_equal(stop.fraction_remaining(), 0)
-
-    # Fraction remaining should also not go below zero.
-    stop(0)
-    assert_equal(stop.fraction_remaining(), 0)

--- a/tests/stop/test_MaxRuntime.py
+++ b/tests/stop/test_MaxRuntime.py
@@ -1,4 +1,4 @@
-from numpy.testing import assert_, assert_equal, assert_raises
+from numpy.testing import assert_, assert_raises
 from pytest import mark
 
 from pyvrp.stop import MaxRuntime
@@ -46,40 +46,3 @@ def test_after_max_runtime(max_runtime):
 
     for _ in range(100):
         assert_(stop(1))
-
-
-def test_fraction_remaining():
-    """
-    Tests that calling ``fraction_remaining()`` returns the correct values.
-    """
-    stop = MaxRuntime(1)
-    assert_equal(stop.fraction_remaining(), 1)
-
-    stop(0)
-    assert_(0 < stop.fraction_remaining() < 1)
-
-
-def test_fraction_remaining_zero_budget():
-    """
-    Tests that ``fraction_remaining()`` works correctly when max runtime is
-    set to zero.
-    """
-    # Zero max runtime should result in zero fraction remaining from the start.
-    stop = MaxRuntime(0)
-    assert_equal(stop.fraction_remaining(), 0)
-
-    # Fraction remaining should not go below zero.
-    stop(0)
-    assert_equal(stop.fraction_remaining(), 0)
-
-
-def test_fraction_remaining_infinite_budget():
-    """
-    Tests that ``fraction_remaining()`` works correctly when max iterations is
-    set to infinity, which is used in PyVRP's CLI.
-    """
-    stop = MaxRuntime(float("inf"))
-    assert_equal(stop.fraction_remaining(), 1)
-
-    stop(0)
-    assert_equal(stop.fraction_remaining(), 1)

--- a/tests/stop/test_MultipleCriteria.py
+++ b/tests/stop/test_MultipleCriteria.py
@@ -1,8 +1,7 @@
-from numpy.testing import assert_, assert_equal, assert_raises
+from numpy.testing import assert_, assert_raises
 from pytest import mark
 
 from pyvrp.stop import (
-    FirstFeasible,
     MaxIterations,
     MaxRuntime,
     MultipleCriteria,
@@ -52,20 +51,3 @@ def test_after_max_runtime(max_runtime):
 
     for _ in range(100):
         assert_(stop(1))
-
-
-def test_fraction_remaining():
-    """
-    Tests that calling ``fraction_remaining()`` returns the minimum value among
-    its underlying criteria.
-    """
-    # MaxIterations is the most restrictive stopping criterion.
-    stop = MultipleCriteria([MaxIterations(1), MaxRuntime(1), FirstFeasible()])
-    assert_equal(stop.fraction_remaining(), 1)
-
-    stop(0)
-    assert_equal(stop.fraction_remaining(), 0)
-
-    # Return None when no criteria have a meaningful fraction remaining.
-    stop = MultipleCriteria([FirstFeasible()])
-    assert_equal(stop.fraction_remaining(), None)

--- a/tests/stop/test_NoImprovement.py
+++ b/tests/stop/test_NoImprovement.py
@@ -1,4 +1,4 @@
-from numpy.testing import assert_, assert_equal, assert_raises
+from numpy.testing import assert_, assert_raises
 from pytest import mark
 
 from pyvrp.stop import NoImprovement
@@ -69,39 +69,3 @@ def test_n_max_iterations_with_single_improvement(n, k):
 
     for _ in range(n):
         assert_(stop(1))
-
-
-def test_fraction_remaining():
-    """
-    Tests that calling ``fraction_remaining()`` returns the correct values.
-    """
-    stop = NoImprovement(100)
-    assert_equal(stop.fraction_remaining(), 1)
-
-    # First call registers initial best solution and resets internal counter.
-    stop(1)
-    assert_equal(stop.fraction_remaining(), 1)
-
-    # New solution is not improving, so fraction remaining should decrease.
-    stop(2)
-    assert_equal(stop.fraction_remaining(), 0.99)
-
-    # Found a new best solution, so the iteration counter resets and so does
-    # the fraction remaining.
-    stop(0)
-    assert_equal(stop.fraction_remaining(), 1)
-
-
-def test_fraction_remaining_zero_budget():
-    """
-    Tests that ``fraction_remaining()`` works correctly when max iterations is
-    set to zero.
-    """
-    # Zero max iterations should result in zero fraction remaining from the
-    # start.
-    stop = NoImprovement(0)
-    assert_equal(stop.fraction_remaining(), 0)
-
-    # Fraction remaining should also not go below zero.
-    stop(0)
-    assert_equal(stop.fraction_remaining(), 0)


### PR DESCRIPTION
This PR is kind of a leftover from #946, and reverts the stopping criteria to what they were before ILS's initial acceptance criterion based on remaining budget.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
