### PR TITLE
Use `pytest.warns` instead of deprecated `np.testing.assert_warns`

### DIFF
--- a/tests/test_Model.py
+++ b/tests/test_Model.py
@@ -1,11 +1,6 @@
 import numpy as np
 import pytest
-from numpy.testing import (
-    assert_,
-    assert_equal,
-    assert_raises,
-    assert_warns,
-)
+from numpy.testing import assert_, assert_equal, assert_raises
 
 from pyvrp import (
     Client,
@@ -458,10 +453,10 @@ def test_data_warns_about_scaling_issues(recwarn):
 
     # But a value exceeding the maximum value is not OK. This should warn (both
     # for distance and/or duration).
-    with assert_warns(ScalingWarning):
+    with pytest.warns(ScalingWarning):
         model.add_edge(depot, client, distance=MAX_VALUE + 1)
 
-    with assert_warns(ScalingWarning):
+    with pytest.warns(ScalingWarning):
         model.add_edge(depot, client, distance=0, duration=MAX_VALUE + 1)
 
 

--- a/tests/test_PenaltyManager.py
+++ b/tests/test_PenaltyManager.py
@@ -5,7 +5,6 @@ from numpy.testing import (
     assert_allclose,
     assert_equal,
     assert_raises,
-    assert_warns,
 )
 
 from pyvrp import PenaltyManager, PenaltyParams, Solution, VehicleType
@@ -326,7 +325,7 @@ def test_warns_max_penalty_value(ok_small):
     infeas = Solution(ok_small, [[1, 2, 3, 4]])
     assert_(infeas.has_time_warp())
 
-    with assert_warns(PenaltyBoundWarning):
+    with pytest.warns(PenaltyBoundWarning):
         pm.register(infeas)
 
 

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -7,7 +7,6 @@ from numpy.testing import (
     assert_allclose,
     assert_equal,
     assert_raises,
-    assert_warns,
 )
 
 from pyvrp import CostEvaluator
@@ -172,7 +171,7 @@ def test_warns_about_scaling_issues():
     Tests that ``read()`` warns about scaling issues when a distance value is
     very large.
     """
-    with assert_warns(ScalingWarning):
+    with pytest.warns(ScalingWarning):
         # The arc from the depot to client 4 is really large (one billion), so
         # that should trigger a warning.
         read("data/ReallyLargeDistance.txt")


### PR DESCRIPTION
This PR:

- [x] Closes #985.
- [ ] Adds and passes relevant tests.
- [x] Has well-formatted code and documentation.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
