### PR TITLE
Raise IndexError in DynamicBitset bindings

### DIFF
--- a/pyvrp/cpp/bindings.cpp
+++ b/pyvrp/cpp/bindings.cpp
@@ -49,12 +49,21 @@ PYBIND11_MODULE(_pyvrp, m)
         .def("reset", &DynamicBitset::reset)
         .def(
             "__getitem__",
-            [](DynamicBitset const &bitset, size_t idx) { return bitset[idx]; },
+            [](DynamicBitset const &bitset, size_t idx)
+            {
+                if (idx >= bitset.size())
+                    throw py::index_error();
+                return bitset[idx];
+            },
             py::arg("idx"))
         .def(
             "__setitem__",
             [](DynamicBitset &bitset, size_t idx, bool value)
-            { bitset[idx] = value; },
+            {
+                if (idx >= bitset.size())
+                    throw py::index_error();
+                bitset[idx] = value;
+            },
             py::arg("idx"),
             py::arg("value"))
         .def("__or__", &DynamicBitset::operator|, py::arg("other"))

--- a/tests/test_DynamicBitset.py
+++ b/tests/test_DynamicBitset.py
@@ -1,4 +1,4 @@
-from numpy.testing import assert_, assert_equal
+from numpy.testing import assert_, assert_equal, assert_raises
 from pytest import mark
 
 from pyvrp._pyvrp import DynamicBitset
@@ -64,6 +64,22 @@ def test_get_set_item():
         assert_(not bitset[idx])
 
     assert_equal(bitset.count(), 0)  # now no bits should be set
+
+
+def test_get_set_raises_out_of_bounds():
+    """
+    Tests that setting and retrieving out of bounds raises an IndexError.
+    """
+    bitset = DynamicBitset(128)
+
+    with assert_raises(IndexError):
+        bitset[128]
+
+    with assert_raises(IndexError):
+        bitset[128] = True
+
+    # Raising out of bounds is also needed to make this assert_equal work.
+    assert_equal(bitset, bitset)
 
 
 def test_all_any_none():

--- a/tests/test_DynamicBitset.py
+++ b/tests/test_DynamicBitset.py
@@ -31,7 +31,7 @@ def test_eq():
     """
     bitset1 = DynamicBitset(64)
     bitset2 = DynamicBitset(64)
-    assert_(bitset1 == bitset2)  # both empty, equal size - should be the same
+    assert_equal(bitset1, bitset2)  # both empty, equal size
 
     bitset2[0] = True
     assert_(bitset1 != bitset2)  # 2 is no longer empty; should not be the same

--- a/tests/test_DynamicBitset.py
+++ b/tests/test_DynamicBitset.py
@@ -31,7 +31,7 @@ def test_eq():
     """
     bitset1 = DynamicBitset(64)
     bitset2 = DynamicBitset(64)
-    assert_equal(bitset1, bitset2)  # both empty, equal size
+    assert_(bitset1 == bitset2)  # both empty, equal size - should be the same
 
     bitset2[0] = True
     assert_(bitset1 != bitset2)  # 2 is no longer empty; should not be the same

--- a/tests/test_DynamicBitset.py
+++ b/tests/test_DynamicBitset.py
@@ -42,6 +42,20 @@ def test_eq():
     assert_(bitset1 != "test")
 
 
+def test_assert_equal():
+    """
+    This test exercises the issue identified in #1038, when assert_equal would
+    hang when comparing two bitsets.
+    """
+    bitset1 = DynamicBitset(128)
+    bitset2 = DynamicBitset(128)
+
+    # assert_equal iterates via __getitem__ since __iter__ isn't implemented.
+    # This requires __getitem__ to raise IndexError when out of bounds,
+    # otherwise iteration never terminates.
+    assert_equal(bitset1, bitset2)
+
+
 def test_get_set_item():
     """
     Tests that setting and retrieving an item from the bitset works correctly.
@@ -77,9 +91,6 @@ def test_get_set_raises_out_of_bounds():
 
     with assert_raises(IndexError):
         bitset[128] = True
-
-    # Raising out of bounds is also needed to make this assert_equal work.
-    assert_equal(bitset, bitset)
 
 
 def test_all_any_none():


### PR DESCRIPTION
Comparing two bitsets with `np.testing.assert_equal` hangs. [getitem](https://docs.python.org/3/reference/datamodel.html#object.__getitem__) expects to raise `IndexError` to signal the end of the sequence. Somehow `np.testing.assert_equal` relies on this protocol, so it gets stuck in an infinite loop. The fix is to add bounds checks in the `__getitem__` that throw IndexError, I also added it to `__setitem__` for convenience.

Also related: https://discuss.python.org/t/deprecate-old-style-iteration-protocol/17863

This PR:
- [ ] Closes #xxxx.
- [ ] Adds and passes relevant tests.
- [ ] Has well-formatted code and documentation.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
