### PR TITLE
Change stopping criterion best cost to int

### DIFF
--- a/pyvrp/minimise_fleet.py
+++ b/pyvrp/minimise_fleet.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from pyvrp._pyvrp import ProblemData, VehicleType
+from pyvrp._pyvrp import CostEvaluator, ProblemData, VehicleType
 from pyvrp.solve import SolveParams, solve
 from pyvrp.stop import FirstFeasible, MultipleCriteria, StoppingCriterion
 
@@ -72,15 +72,17 @@ def minimise_fleet(
             display=False,
             params=params,
         )
+        best = res.best
+        cost_eval = CostEvaluator([0] * data.num_load_dimensions, 0, 0)
 
-        if stop(res.cost()) or not res.is_feasible():
+        if stop(cost_eval.cost(best)) or not best.is_feasible():
             return feas_fleet
 
         feas_fleet = fleet
-        if res.best.num_routes() < data.num_vehicles:
+        if best.num_routes() < data.num_vehicles:
             # Then we can make a bigger jump because more than one vehicle of
             # the feasible fleet was unused.
-            feas_fleet = fleet.replace(num_available=res.best.num_routes())
+            feas_fleet = fleet.replace(num_available=best.num_routes())
 
     return feas_fleet
 

--- a/pyvrp/stop/FirstFeasible.py
+++ b/pyvrp/stop/FirstFeasible.py
@@ -8,7 +8,7 @@ class FirstFeasible:
     Terminates the search after a feasible solution has been observed.
     """
 
-    def __call__(self, best_cost: float) -> bool:
+    def __call__(self, best_cost: int) -> bool:
         # This function is called with the output of CostEvaluator.cost on the
         # best solution, which is INT_MAX when the best solution is infeasible.
         # Thus, when the cost is below INT_MAX, we have at least one feasible

--- a/pyvrp/stop/MaxIterations.py
+++ b/pyvrp/stop/MaxIterations.py
@@ -10,7 +10,7 @@ class MaxIterations:
         self._max_iters = max_iterations
         self._curr_iter = 0
 
-    def __call__(self, best_cost: float) -> bool:
+    def __call__(self, best_cost: int) -> bool:
         self._curr_iter += 1
 
         return self._curr_iter > self._max_iters

--- a/pyvrp/stop/MaxRuntime.py
+++ b/pyvrp/stop/MaxRuntime.py
@@ -13,7 +13,7 @@ class MaxRuntime:
         self._max_runtime = max_runtime
         self._start_runtime: float | None = None
 
-    def __call__(self, best_cost: float) -> bool:
+    def __call__(self, best_cost: int) -> bool:
         if self._start_runtime is None:
             self._start_runtime = time.perf_counter()
 

--- a/pyvrp/stop/MultipleCriteria.py
+++ b/pyvrp/stop/MultipleCriteria.py
@@ -12,5 +12,5 @@ class MultipleCriteria:
 
         self.criteria = criteria
 
-    def __call__(self, best_cost: float) -> bool:
+    def __call__(self, best_cost: int) -> bool:
         return any(crit(best_cost) for crit in self.criteria)

--- a/pyvrp/stop/NoImprovement.py
+++ b/pyvrp/stop/NoImprovement.py
@@ -14,10 +14,10 @@ class NoImprovement:
             raise ValueError("max_iterations < 0 not understood.")
 
         self._max_iterations = max_iterations
-        self._target: float | None = None
+        self._target: int | None = None
         self._counter = 0
 
-    def __call__(self, best_cost: float) -> bool:
+    def __call__(self, best_cost: int) -> bool:
         if self._target is None or best_cost < self._target:
             self._target = best_cost
             self._counter = 0

--- a/pyvrp/stop/StoppingCriterion.py
+++ b/pyvrp/stop/StoppingCriterion.py
@@ -6,7 +6,7 @@ class StoppingCriterion(Protocol):  # pragma: no cover
     Protocol that stopping criteria must implement.
     """
 
-    def __call__(self, best_cost: float) -> bool:
+    def __call__(self, best_cost: int) -> bool:
         """
         When called, this stopping criterion should return True if the
         algorithm should stop, and False otherwise.


### PR DESCRIPTION
This PR changes the type of the `best_cost` argument from `float` to `int`. The reason for `best_cost` being typed as `float` was probably due to our historical support for double precision (#491, #518, #623). Since that's no longer the case, it's better to change this for better interoperability with the C++ side.

- [ ] Closes #xxxx.
- [ ] Adds and passes relevant tests.
- [ ] Has well-formatted code and documentation.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
