### PR TITLE
Ignore `stringop-overflow` diagnostic

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -26,8 +26,7 @@ if compiler.has_argument('-Wno-dangling-reference')
 endif
 
 if compiler.has_argument('-Wno-stringop-overflow')
-    # This diagnostic issues false positives for some of our code.
-    # See PyVRP#1063.
+    # This diagnostic issues false positives for some of our code (see #1063).
     add_project_link_arguments('-Wno-stringop-overflow', language: 'cpp')
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,12 @@ if compiler.has_argument('-Wno-dangling-reference')
     add_project_arguments('-Wno-dangling-reference', language: 'cpp')
 endif
 
+if compiler.has_argument('-Wno-stringop-overflow')
+    # This diagnostic issues false positives for some of our code.
+    # See PyVRP#1063.
+    add_project_link_arguments('-Wno-stringop-overflow', language: 'cpp')
+endif
+
 # Logging configuration and spdlog dependency.
 if get_option('buildtype') == 'debug'
     # Log everything in debug builds.


### PR DESCRIPTION
This PR:

- [x] Closes #1063.
- [ ] Adds and passes relevant tests.
- [ ] Has well-formatted code and documentation.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>
