### PR TITLE
feat(build): add free-threaded Python 3.14t support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -115,34 +115,26 @@ jobs:
           uv run env PYTHONMALLOC=malloc valgrind --tool=memcheck --quiet $VALGRIND_CMD
 
   free-threaded:
-    name: Test with free-threaded Python 3.13
+    name: Test with free-threaded Python 3.14
     runs-on: ubuntu-24.04
     env:
       GCC_VERSION: "14"
-      # Point uv at the free-threaded interpreter installed by setup-python,
-      # so it does not fall back to the system /usr/bin/python3 (3.12).
-      UV_PYTHON: python3.13t
+      UV_PYTHON: python3.14t
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Set up free-threaded Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.13t"
+          python-version: "3.14t"
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.7.5"
           enable-cache: true
       - name: Install Python dependencies
-        # pytest-codspeed pulls in cffi, which does not support
-        # free-threaded CPython 3.13. Exclude it from the dev group.
-        # gcovr pulls in lxml which fails to build on 3.13t.
-        # Exclude build group and install meson and ninja manually.
-        run: |
-          uv sync --no-install-project --no-group dev --no-group build
-          uv pip install meson ninja pytest pytest-cov pytest-xdist pytest-sugar docblock
+        run: uv sync --no-install-project
       - name: Set up GCC
         run: |
           sudo apt-get install -y gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }}
@@ -154,14 +146,13 @@ jobs:
           echo "CXX=g++" >> $GITHUB_ENV
       - name: Build pyvrp
         run: |
-          uv sync --no-group dev --no-group build
-          uv pip install meson ninja pytest pytest-cov pytest-xdist pytest-sugar docblock
-          uv run --no-sync buildtools/build_extensions.py --build_type debug --clean
+          uv sync
+          uv run buildtools/build_extensions.py --build_type debug --clean
       - name: Verify GIL is disabled
         env:
           PYTHON_GIL: "0"
         run: |
-          uv run --no-sync python -c "
+          uv run python -c "
           import sys
           import pyvrp._pyvrp
           import pyvrp.search._search
@@ -171,4 +162,4 @@ jobs:
       - name: Run tests
         env:
           PYTHON_GIL: "0"
-        run: uv run --no-sync pytest --no-cov
+        run: uv run pytest --no-cov

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -113,3 +113,62 @@ jobs:
         run: |
           VALGRIND_CMD="pyvrp tests/data/RC208.vrp --round_func dimacs --max_runtime 0.5 --seed 1"
           uv run env PYTHONMALLOC=malloc valgrind --tool=memcheck --quiet $VALGRIND_CMD
+
+  free-threaded:
+    name: Test with free-threaded Python 3.13
+    runs-on: ubuntu-24.04
+    env:
+      GCC_VERSION: "14"
+      # Point uv at the free-threaded interpreter installed by setup-python,
+      # so it does not fall back to the system /usr/bin/python3 (3.12).
+      UV_PYTHON: python3.13t
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up free-threaded Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13t"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.7.5"
+          enable-cache: true
+      - name: Install Python dependencies
+        # pytest-codspeed pulls in cffi, which does not support
+        # free-threaded CPython 3.13. Exclude it from the dev group.
+        # gcovr pulls in lxml which fails to build on 3.13t.
+        # Exclude build group and install meson and ninja manually.
+        run: |
+          uv sync --no-install-project --no-group dev --no-group build
+          uv pip install meson ninja pytest pytest-cov pytest-xdist pytest-sugar docblock
+      - name: Set up GCC
+        run: |
+          sudo apt-get install -y gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }}
+
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 10
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 10
+
+          echo "CC=gcc" >> $GITHUB_ENV
+          echo "CXX=g++" >> $GITHUB_ENV
+      - name: Build pyvrp
+        run: |
+          uv sync --no-group dev --no-group build
+          uv pip install meson ninja pytest pytest-cov pytest-xdist pytest-sugar docblock
+          uv run --no-sync buildtools/build_extensions.py --build_type debug --clean
+      - name: Verify GIL is disabled
+        env:
+          PYTHON_GIL: "0"
+        run: |
+          uv run --no-sync python -c "
+          import sys
+          import pyvrp._pyvrp
+          import pyvrp.search._search
+          assert not sys._is_gil_enabled(), 'GIL should be disabled'
+          print('GIL disabled: OK')
+          "
+      - name: Run tests
+        env:
+          PYTHON_GIL: "0"
+        run: uv run --no-sync pytest --no-cov

--- a/meson.build
+++ b/meson.build
@@ -30,6 +30,14 @@ if compiler.has_argument('-Wno-stringop-overflow')
     add_project_link_arguments('-Wno-stringop-overflow', language: 'cpp')
 endif
 
+if compiler.get_id() == 'gcc'
+    # GCC 14 with LTO raises a false positive in pybind11's internals.h for
+    # the Py_GIL_DISABLED (free-threaded Python) code path. The allocation
+    # size is guarded but LTO inlining loses the proof. We use get_id()
+    # instead of has_argument() because the latter fails to detect this flag.
+    add_project_link_arguments('-Wno-alloc-size-larger-than', language: 'cpp')
+endif
+
 # Logging configuration and spdlog dependency.
 if get_option('buildtype') == 'debug'
     # Log everything in debug builds.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,7 @@ exclude_lines = [
 
 [tool.cibuildwheel]
 # We do not support old Python versions and somewhat uncommon platforms.
-build = "cp311-* cp312-* cp313-* cp313t-* cp314-*"
+build = "cp311-* cp312-* cp313-* cp314-* cp314t-*"
 skip = "*_ppc64le *_i686 *_s390x *-win32"
 build-frontend = "build"
 test-groups = ["dev"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,12 +138,13 @@ exclude_lines = [
 
 [tool.cibuildwheel]
 # We do not support old Python versions and somewhat uncommon platforms.
-build = "cp311-* cp312-* cp313-* cp314-*"
+build = "cp311-* cp312-* cp313-* cp313t-* cp314-*"
 skip = "*_ppc64le *_i686 *_s390x *-win32"
 build-frontend = "build"
 test-groups = ["dev"]
 test-sources = ["tests"]
 test-command = "pytest ./tests -v"
+enable = ["cpython-freethreading"]
 
 
 [tool.cibuildwheel.windows]

--- a/pyvrp/PenaltyManager.py
+++ b/pyvrp/PenaltyManager.py
@@ -89,10 +89,10 @@ class PenaltyParams:
     max_penalty: float = 100_000.0
 
     def __post_init__(self):
-        if not self.solutions_between_updates >= 1:
+        if self.solutions_between_updates < 1:
             raise ValueError("Expected solutions_between_updates >= 1.")
 
-        if not self.penalty_increase >= 1.0:
+        if self.penalty_increase < 1.0:
             raise ValueError("Expected penalty_increase >= 1.")
 
         if not (0.0 <= self.penalty_decrease <= 1.0):
@@ -149,6 +149,12 @@ class PenaltyManager:
         :attr:`~pyvrp.PenaltyManager.PenaltyParams.max_penalty`].
     params
         PenaltyManager parameters. If not provided, a default will be used.
+
+    .. warning::
+
+       This class is **not** thread-safe. Do not share a single
+       ``PenaltyManager`` instance across multiple threads without
+       external synchronization. Each thread should use its own instance.
     """
 
     def __init__(
@@ -222,7 +228,7 @@ class PenaltyManager:
         Registers the feasibility dimensions of the given solution.
         """
         is_feasible = [
-            *[excess == 0 for excess in sol.excess_load()],
+            *(excess == 0 for excess in sol.excess_load()),
             not sol.has_time_warp(),
             not sol.has_excess_distance(),
         ]

--- a/pyvrp/cpp/RandomNumberGenerator.h
+++ b/pyvrp/cpp/RandomNumberGenerator.h
@@ -21,6 +21,11 @@ namespace pyvrp
  * ----------
  * seed
  *     Seed used to set the initial RNG state.
+ *
+ * .. warning::
+ *
+ *    This class is **not** thread-safe. Each thread must use its own
+ *    ``RandomNumberGenerator`` instance.
  */
 class RandomNumberGenerator
 {
@@ -77,7 +82,6 @@ public:
     /**
      * Returns the internal RNG state.
      */
-    // Could be useful for debugging.
     std::array<uint32_t, 4> const &state() const;
 };
 
@@ -94,7 +98,7 @@ constexpr size_t RandomNumberGenerator::max()
 template <typename T>
 RandomNumberGenerator::result_type RandomNumberGenerator::randint(T high)
 {
-    static_assert(std::is_integral<T>::value);
+    static_assert(std::is_integral_v<T>);
     return operator()() % high;
 }
 

--- a/pyvrp/cpp/bindings.cpp
+++ b/pyvrp/cpp/bindings.cpp
@@ -39,7 +39,7 @@ using pyvrp::Solution;
 using PiecewiseLinearFunction
     = pyvrp::PiecewiseLinearFunction<int64_t, int64_t>;
 
-PYBIND11_MODULE(_pyvrp, m)
+PYBIND11_MODULE(_pyvrp, m, py::mod_gil_not_used())
 {
     py::options options;
     options.disable_enum_members_docstring();

--- a/pyvrp/cpp/search/bindings.cpp
+++ b/pyvrp/cpp/search/bindings.cpp
@@ -44,7 +44,7 @@ using pyvrp::search::supports;
 using pyvrp::search::SwapTails;
 using pyvrp::search::UnaryOperator;
 
-PYBIND11_MODULE(_search, m)
+PYBIND11_MODULE(_search, m, py::mod_gil_not_used())
 {
     pyvrp::registerLogger("pyvrp.search");
 


### PR DESCRIPTION
This PR:

- [x] Closes #1053.

## Summary

Add free-threaded Python (3.14t) support:

- Mark pybind11 extension modules (`_pyvrp`, `_search`) as GIL-free via `py::mod_gil_not_used()`
- Add CI job running full test suite with `PYTHON_GIL=0` on Python 3.14t
- Enable `cpython-freethreading` in cibuildwheel and build `cp314t-*` wheels
- Add thread-safety warnings to `PenaltyManager` and `RandomNumberGenerator`
- Minor code cleanups: simplify comparisons, use `std::is_integral_v`

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.

</details>