### PR TITLE
Add Google Colab badges to tutorial notebooks

### DIFF
--- a/notebooks/duration_constraints.ipynb
+++ b/notebooks/duration_constraints.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PyVRP/PyVRP/blob/main/notebooks/duration_constraints.ipynb)\n"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},

--- a/notebooks/load.ipynb
+++ b/notebooks/load.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PyVRP/PyVRP/blob/main/notebooks/load.ipynb)\n"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},

--- a/notebooks/mutually_exclusive_groups.ipynb
+++ b/notebooks/mutually_exclusive_groups.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PyVRP/PyVRP/blob/main/notebooks/mutually_exclusive_groups.ipynb)\n"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},

--- a/notebooks/optional_clients.ipynb
+++ b/notebooks/optional_clients.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PyVRP/PyVRP/blob/main/notebooks/optional_clients.ipynb)\n"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},

--- a/notebooks/profiles.ipynb
+++ b/notebooks/profiles.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PyVRP/PyVRP/blob/main/notebooks/profiles.ipynb)\n"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},

--- a/notebooks/pyvrp_implementation.ipynb
+++ b/notebooks/pyvrp_implementation.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PyVRP/PyVRP/blob/main/notebooks/pyvrp_implementation.ipynb)\n"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},

--- a/notebooks/quick_start.ipynb
+++ b/notebooks/quick_start.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PyVRP/PyVRP/blob/main/notebooks/quick_start.ipynb)\n"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},

--- a/notebooks/reloading.ipynb
+++ b/notebooks/reloading.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/PyVRP/PyVRP/blob/main/notebooks/reloading.ipynb)\n"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},


### PR DESCRIPTION
This PR adds 'Open in Colab' badges to all tutorial notebooks, making it easy for users to run the examples directly in Google Colab without local setup.

Closes #1110.

Each notebook now has a Colab badge as the first markdown cell, linking to:
`https://colab.research.google.com/github/PyVRP/PyVRP/blob/main/notebooks/{filename}`

Changes made to 8 notebooks:
- quick_start.ipynb
- pyvrp_implementation.ipynb
- duration_constraints.ipynb
- load.ipynb
- profiles.ipynb
- optional_clients.ipynb
- reloading.ipynb
- mutually_exclusive_groups.ipynb

The Colab badge is added as the first cell so users see it immediately when opening the notebook.