### PR TITLE
Allow negative fixed vehicle cost

### DIFF
--- a/docs/source/setup/faq.rst
+++ b/docs/source/setup/faq.rst
@@ -40,6 +40,11 @@ Modelling
       Set zero distance and duration on edges leaving (for start depots) or entering (for end depots) the dummy depots.
       You can then drop these dummy depots from PyVRP's solution in a post-processing step. 
 
+   How can I make sure PyVRP uses all my vehicles?
+
+      By specifying a negative fixed cost for each vehicle.
+      This incentivises PyVRP to use more vehicles than it normally would.
+
 Debugging
 ---------
 

--- a/pyvrp/cpp/VehicleType.cpp
+++ b/pyvrp/cpp/VehicleType.cpp
@@ -96,9 +96,6 @@ VehicleType::VehicleType(size_t numAvailable,
     if (maxDistance < 0)
         throw std::invalid_argument("max_distance must be >= 0.");
 
-    if (fixedCost < 0)
-        throw std::invalid_argument("fixed_cost must be >= 0.");
-
     if (unitDistanceCost < 0)
         throw std::invalid_argument("unit_distance_cost must be >= 0.");
 

--- a/tests/test_VehicleType.py
+++ b/tests/test_VehicleType.py
@@ -34,7 +34,6 @@ _MAX_SIZE = np.iinfo(np.uint64).max
         (0, 1, 0, -1, 0, 0, 0, 0, 0, 0, 0),  # negative late
         (0, 1, 0, 0, -1, 0, 0, 0, 0, 0, 0),  # negative shift_duration
         (0, 1, 0, 0, 0, -1, 0, 0, 0, 0, 0),  # negative max_distance
-        (0, 1, 0, 0, 0, 0, -1, 0, 0, 0, 0),  # negative fixed_cost
         (0, 1, 0, 0, 0, 0, 0, -1, 0, 0, 0),  # negative unit_distance_cost
         (0, 1, 0, 0, 0, 0, 0, 0, -1, 0, 0),  # negative unit_duration_cost
         (0, 1, 0, 0, 0, 0, 0, 0, 0, -1, 0),  # negative start late
@@ -329,3 +328,12 @@ def test_max_trips_is_one_if_no_reload_depots(ok_small):
     assert_equal(veh_type.reload_depots, [])
     assert_equal(veh_type.max_reloads, _MAX_SIZE)
     assert_equal(veh_type.max_trips, 1)
+
+
+def test_allows_negative_fixed_cost():
+    """
+    Tests that the vehicle type allows negative fixed costs. This was initially
+    not allowed.
+    """
+    veh_type = VehicleType(fixed_cost=-100)
+    assert_equal(veh_type.fixed_cost, -100)

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -99,3 +99,21 @@ def test_solve_custom_params(rc208):
     # is skipped because it's an empty initial solution with penalised cost 0.
     costs = [datum.current_cost for datum in res.stats.data[1:]]
     assert_(monotonically_decreasing(costs))
+
+
+def test_negative_fixed_cost_uses_all_vehicles(ok_small):
+    """
+    Tests that setting a large, negative fixed cost incentivises the solver to
+    use more vehicles than it otherwise would.
+    """
+    # The regular instance has zero fixed cost, and normally uses only two
+    # vehicles.
+    res = solve(ok_small, stop=MaxIterations(10))
+    assert_equal(res.best.num_routes(), 2)
+
+    # Let's not set a large, negative fixed cost. This should result in all
+    # vehicles being used.
+    veh_type = ok_small.vehicle_type(0).replace(fixed_cost=-10_000)
+    data = ok_small.replace(vehicle_types=[veh_type])
+    res = solve(data, stop=MaxIterations(10))
+    assert_equal(res.best.num_routes(), 3)

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -111,7 +111,7 @@ def test_negative_fixed_cost_uses_all_vehicles(ok_small):
     res = solve(ok_small, stop=MaxIterations(10))
     assert_equal(res.best.num_routes(), 2)
 
-    # Let's not set a large, negative fixed cost. This should result in all
+    # Let's now set a large, negative fixed cost. This should result in all
     # vehicles being used.
     veh_type = ok_small.vehicle_type(0).replace(fixed_cost=-10_000)
     data = ok_small.replace(vehicle_types=[veh_type])


### PR DESCRIPTION
This PR:

- [ ] Closes #xxxx.
- [x] Adds and passes relevant tests.
- [x] Has well-formatted code and documentation.

Main motivation for this is to allow use cases where users want to utilise *all* their vehicles. A negative reduce cost incentivises PyVRP to use those.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.
- You must disclose the use of LLMs/generative AI if you used such tools to write code.

</details>
