### PR TITLE
Fix prize bug in ReplaceGroup

### DIFF
--- a/pyvrp/cpp/search/ReplaceGroup.cpp
+++ b/pyvrp/cpp/search/ReplaceGroup.cpp
@@ -27,8 +27,8 @@ ReplaceGroup::evaluate(Route::Node *U, CostEvaluator const &costEvaluator)
             assert(client != U->idx());
             V_ = &solution_->nodes[client];
             auto *route = V_->route();
-            deltaCost = data.client(client).prize - uData.prize;
 
+            deltaCost = data.client(client).prize - uData.prize;
             costEvaluator.deltaCost(  // evaluate replacing V with U
                 deltaCost,
                 Route::Proposal(route->before(V_->pos() - 1),

--- a/pyvrp/cpp/search/ReplaceGroup.cpp
+++ b/pyvrp/cpp/search/ReplaceGroup.cpp
@@ -27,6 +27,7 @@ ReplaceGroup::evaluate(Route::Node *U, CostEvaluator const &costEvaluator)
             assert(client != U->idx());
             V_ = &solution_->nodes[client];
             auto *route = V_->route();
+            deltaCost = data.client(client).prize - uData.prize;
 
             costEvaluator.deltaCost(  // evaluate replacing V with U
                 deltaCost,

--- a/tests/search/test_ReplaceGroup.py
+++ b/tests/search/test_ReplaceGroup.py
@@ -1,6 +1,15 @@
+import numpy as np
 from numpy.testing import assert_, assert_equal
 
-from pyvrp import CostEvaluator
+from pyvrp import (
+    Client,
+    ClientGroup,
+    CostEvaluator,
+    Depot,
+    Location,
+    ProblemData,
+    VehicleType,
+)
 from pyvrp import Solution as PyVRPSolution
 from pyvrp.search import ReplaceGroup
 from pyvrp.search._search import Node, Solution
@@ -29,6 +38,34 @@ def test_replace(ok_small_mutually_exclusive_groups):
 
     op.apply(node)
     assert_equal(str(sol.routes[0]), "C1 C3")
+
+
+def test_replace_accounts_for_prizes():
+    """
+    Tests that prizes are included in the replacement cost.
+    """
+    matrix = np.zeros((1, 1), dtype=int)
+    data = ProblemData(
+        locations=[Location(0, 0)],
+        clients=[
+            Client(0, prize=1, required=False, group=0),
+            Client(0, prize=5, required=False, group=0),
+        ],
+        depots=[Depot(0)],
+        vehicle_types=[VehicleType(1)],
+        distance_matrices=[matrix],
+        duration_matrices=[matrix],
+        groups=[ClientGroup([0, 1])],
+    )
+    sol = Solution(data)
+    sol.load(PyVRPSolution(data, [[0]]))
+
+    op = ReplaceGroup(data)
+    op.init(sol)
+
+    # Replacing C0 with C1 collects four more units of prize.
+    move = op.evaluate(sol.nodes[1], CostEvaluator([], 0, 0))
+    assert_equal(move, (-4, True))
 
 
 def test_supports(


### PR DESCRIPTION
This PR fixes a bug in ReplaceGroup, which didn't account for client prizes. Found this while reviewing #1131.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.
- You must disclose the use of LLMs/generative AI if you used such tools to write code.

</details>
