### PR TITLE
Relax shipment guard in Exchange operators

### DIFF
--- a/pyvrp/cpp/search/Exchange.h
+++ b/pyvrp/cpp/search/Exchange.h
@@ -77,24 +77,25 @@ bool Exchange<N, M>::containsDepot(Route::Node *node, size_t segLength) const
 template <size_t N, size_t M>
 bool Exchange<N, M>::overlap(Route::Node *U, Route::Node *V) const
 {
-    return U->route() == V->route()
-           // We need max(M, 1) here because when V is the depot and M == 0,
-           // this would turn negative and wrap around to a large number.
-           && U->pos() <= V->pos() + std::max<size_t>(M, 1) - 1
+    assert(U->route() == V->route());
+
+    // We need max(M, 1) here because when V is the depot and M == 0, this
+    // would turn negative and wrap around to a large number.
+    return U->pos() <= V->pos() + std::max<size_t>(M, 1) - 1
            && V->pos() <= U->pos() + N - 1;
 }
 
 template <size_t N, size_t M>
 bool Exchange<N, M>::adjacent(Route::Node *U, Route::Node *V) const
 {
-    return U->route() == V->route()
-           && (U->pos() + N == V->pos() || V->pos() + M == U->pos());
+    assert(U->route() == V->route());
+    return U->pos() + N == V->pos() || V->pos() + M == U->pos();
 }
 
 template <size_t N, size_t M>
 bool Exchange<N, M>::splitsShipment(Route::Node *U, Route::Node *V) const
 {
-    auto const fn = [](Route::Node *node, size_t segLength)
+    auto const splits = [](Route::Node *node, size_t segLength)
     {
         auto const &route = *node->route();
         auto const last = node->pos() + segLength - 1;
@@ -109,9 +110,9 @@ bool Exchange<N, M>::splitsShipment(Route::Node *U, Route::Node *V) const
     };
 
     if constexpr (M > 0)
-        return fn(U, N) || fn(V, M);
+        return splits(U, N) || splits(V, M);
     else
-        return fn(U, N);
+        return splits(U, N);
 }
 
 template <size_t N, size_t M>
@@ -226,15 +227,20 @@ std::pair<Cost, bool> Exchange<N, M>::evaluate(
 {
     stats_.numEvaluations++;
 
-    if (!U->route() || !V->route())
+    if (!U->route() || !V->route() || containsDepot(U, N))
         return std::make_pair(0, false);
 
-    if (containsDepot(U, N) || overlap(U, V))
-        return std::make_pair(0, false);
+    if (U->route() == V->route())
+    {
+        // We cannot easily evaluate across trips, and if U and V overlap the
+        // move is not well-defined.
+        if (U->trip() != V->trip() || overlap(U, V))
+            return std::make_pair(0, false);
 
-    // We cannot easily evaluate across trips, so we cannot determine this move.
-    if (U->route() == V->route() && U->trip() != V->trip())
-        return std::make_pair(0, false);
+        if constexpr (M != 0)    // is equivalent to relocate; no need to
+            if (adjacent(U, V))  // evaluate as a swap
+                return std::make_pair(0, false);
+    }
 
     if constexpr (M == 0)  // special case where nothing in V is moved
     {
@@ -249,7 +255,7 @@ std::pair<Cost, bool> Exchange<N, M>::evaluate(
             if (U->idx() >= V->idx())
                 return std::make_pair(0, false);
 
-        if (containsDepot(V, M) || splitsShipment(U, V) || adjacent(U, V))
+        if (containsDepot(V, M) || splitsShipment(U, V))
             return std::make_pair(0, false);
 
         return evalSwapMove(U, V, costEvaluator);

--- a/pyvrp/cpp/search/Exchange.h
+++ b/pyvrp/cpp/search/Exchange.h
@@ -26,11 +26,11 @@ template <size_t N, size_t M> class Exchange : public BinaryOperator
     static_assert(N >= M && N > 0, "N < M or N == 0 does not make sense");
 
     // Tests if the segment starting at node of given length contains the depot.
-    bool containsDepot(Route::Node *node, size_t segLength) const;
+    bool hasDepot(Route::Node *node, size_t segLength) const;
 
-    // Tests if exchanging the segments starting at U and V would result in a
-    // split shipment.
-    bool splitsShipment(Route::Node *U, Route::Node *V) const;
+    // Tests if the segment starting at node of given length would split a
+    // shipment if exchanged.
+    bool splitsShipment(Route::Node *node, size_t segLength) const;
 
     // Tests if the segments of U and V overlap in the same route.
     bool overlap(Route::Node *U, Route::Node *V) const;
@@ -63,7 +63,7 @@ public:
 };
 
 template <size_t N, size_t M>
-bool Exchange<N, M>::containsDepot(Route::Node *node, size_t segLength) const
+bool Exchange<N, M>::hasDepot(Route::Node *node, size_t segLength) const
 {
     auto const first = node->pos();
     auto const last = first + segLength - 1;
@@ -93,26 +93,18 @@ bool Exchange<N, M>::adjacent(Route::Node *U, Route::Node *V) const
 }
 
 template <size_t N, size_t M>
-bool Exchange<N, M>::splitsShipment(Route::Node *U, Route::Node *V) const
+bool Exchange<N, M>::splitsShipment(Route::Node *node, size_t segLength) const
 {
-    auto const splits = [](Route::Node *node, size_t segLength)
-    {
-        auto const &route = *node->route();
-        auto const last = node->pos() + segLength - 1;
+    auto const &route = *node->route();
+    auto const last = node->pos() + segLength - 1;
 
-        // Moving this segment certainly does not split a shipment if there is
-        // not currently a shipment on the vehicle (at node), or if one is
-        // loaded, it is delivered within this segment.
-        return node->isDelivery()
-               || route.numPickups(node->pos())
-                      != route.numDeliveries(node->pos()) + node->isPickup()
-               || route.numPickups(last) != route.numDeliveries(last);
-    };
-
-    if constexpr (M > 0)
-        return splits(U, N) || splits(V, M);
-    else
-        return splits(U, N);
+    // Moving this segment certainly does not split a shipment if there is not
+    // currently a shipment on the vehicle (at node), or if one is loaded, it
+    // is delivered within this segment.
+    return node->isDelivery()
+           || route.numPickups(node->pos())
+                  != route.numDeliveries(node->pos()) + node->isPickup()
+           || route.numPickups(last) != route.numDeliveries(last);
 }
 
 template <size_t N, size_t M>
@@ -227,7 +219,7 @@ std::pair<Cost, bool> Exchange<N, M>::evaluate(
 {
     stats_.numEvaluations++;
 
-    if (!U->route() || !V->route() || containsDepot(U, N))
+    if (!U->route() || !V->route() || hasDepot(U, N) || splitsShipment(U, N))
         return std::make_pair(0, false);
 
     if (U->route() == V->route())
@@ -237,29 +229,26 @@ std::pair<Cost, bool> Exchange<N, M>::evaluate(
         if (U->trip() != V->trip() || overlap(U, V))
             return std::make_pair(0, false);
 
-        if constexpr (M != 0)    // is equivalent to relocate; no need to
-            if (adjacent(U, V))  // evaluate as a swap
+        if constexpr (M != 0)  // is equivalent to relocate; no need to
+        {                      // evaluate as a swap
+            if (adjacent(U, V))
                 return std::make_pair(0, false);
+        }
+        else if (U == n(V))  // already the situation after relocate; no-op
+            return std::make_pair(0, false);
     }
 
     if constexpr (M == 0)  // special case where nothing in V is moved
-    {
-        if (U == n(V) || splitsShipment(U, V))
-            return std::make_pair(0, false);
-
         return evalRelocateMove(U, V, costEvaluator);
-    }
-    else
-    {
-        if constexpr (N == M)  // symmetric, so only have to evaluate this once
-            if (U->idx() >= V->idx())
-                return std::make_pair(0, false);
 
-        if (containsDepot(V, M) || splitsShipment(U, V))
+    if constexpr (N == M)  // symmetric, so only have to evaluate this once
+        if (U->idx() >= V->idx())
             return std::make_pair(0, false);
 
-        return evalSwapMove(U, V, costEvaluator);
-    }
+    if (hasDepot(V, M) || splitsShipment(V, M))
+        return std::make_pair(0, false);
+
+    return evalSwapMove(U, V, costEvaluator);
 }
 
 template <size_t N, size_t M>

--- a/pyvrp/cpp/search/Exchange.h
+++ b/pyvrp/cpp/search/Exchange.h
@@ -28,9 +28,9 @@ template <size_t N, size_t M> class Exchange : public BinaryOperator
     // Tests if the segment starting at node of given length contains the depot.
     bool containsDepot(Route::Node *node, size_t segLength) const;
 
-    // Tests if the segment starting at node of given length would split a
-    // shipment if exchanged.
-    bool splitsShipment(Route::Node *node, size_t segLength) const;
+    // Tests if exchanging the segments starting at U and V would result in a
+    // split shipment.
+    bool splitsShipment(Route::Node *U, Route::Node *V) const;
 
     // Tests if the segments of U and V overlap in the same route.
     bool overlap(Route::Node *U, Route::Node *V) const;
@@ -92,18 +92,26 @@ bool Exchange<N, M>::adjacent(Route::Node *U, Route::Node *V) const
 }
 
 template <size_t N, size_t M>
-bool Exchange<N, M>::splitsShipment(Route::Node *node, size_t segLength) const
+bool Exchange<N, M>::splitsShipment(Route::Node *U, Route::Node *V) const
 {
-    auto const &route = *node->route();
-    auto const last = node->pos() + segLength - 1;
+    auto const fn = [](Route::Node *node, size_t segLength)
+    {
+        auto const &route = *node->route();
+        auto const last = node->pos() + segLength - 1;
 
-    // Moving this segment certainly does not split a shipment if there is not
-    // currently a shipment on the vehicle (at node), or if one is loaded, it
-    // is delivered within this segment.
-    return node->isDelivery()
-           || route.numPickups(node->pos())
-                  != route.numDeliveries(node->pos()) + node->isPickup()
-           || route.numPickups(last) != route.numDeliveries(last);
+        // Moving this segment certainly does not split a shipment if there is
+        // not currently a shipment on the vehicle (at node), or if one is
+        // loaded, it is delivered within this segment.
+        return node->isDelivery()
+               || route.numPickups(node->pos())
+                      != route.numDeliveries(node->pos()) + node->isPickup()
+               || route.numPickups(last) != route.numDeliveries(last);
+    };
+
+    if constexpr (M > 0)
+        return fn(U, N) || fn(V, M);
+    else
+        return fn(U, N);
 }
 
 template <size_t N, size_t M>
@@ -221,7 +229,7 @@ std::pair<Cost, bool> Exchange<N, M>::evaluate(
     if (!U->route() || !V->route())
         return std::make_pair(0, false);
 
-    if (containsDepot(U, N) || splitsShipment(U, N) || overlap(U, V))
+    if (containsDepot(U, N) || overlap(U, V))
         return std::make_pair(0, false);
 
     // We cannot easily evaluate across trips, so we cannot determine this move.
@@ -230,7 +238,7 @@ std::pair<Cost, bool> Exchange<N, M>::evaluate(
 
     if constexpr (M == 0)  // special case where nothing in V is moved
     {
-        if (U == n(V))
+        if (U == n(V) || splitsShipment(U, V))
             return std::make_pair(0, false);
 
         return evalRelocateMove(U, V, costEvaluator);
@@ -238,12 +246,10 @@ std::pair<Cost, bool> Exchange<N, M>::evaluate(
     else
     {
         if constexpr (N == M)  // symmetric, so only have to evaluate this once
-        {
             if (U->idx() >= V->idx())
                 return std::make_pair(0, false);
-        }
 
-        if (containsDepot(V, M) || splitsShipment(V, M) || adjacent(U, V))
+        if (containsDepot(V, M) || splitsShipment(U, V) || adjacent(U, V))
             return std::make_pair(0, false);
 
         return evalSwapMove(U, V, costEvaluator);


### PR DESCRIPTION
This PR is part of #1098.

Attempt:
<details>

```
template <size_t N, size_t M>
bool Exchange<N, M>::splitsShipment(Route::Node *U, Route::Node *V) const
{
    auto const fn = [](Route::Node *node, size_t segLength)
    {
        auto const &route = *node->route();
        auto const last = node->pos() + segLength - 1;

        // Moving this segment certainly does not split a shipment if there is
        // not currently a shipment on the vehicle (at node), or if one is
        // loaded, it is delivered within this segment.
        return node->isDelivery()
               || route.numPickups(node->pos())
                      != route.numDeliveries(node->pos()) + node->isPickup()
               || route.numPickups(last) != route.numDeliveries(last);
    };

    if constexpr (M > 0)
    {
        if (!fn(U, N) && !fn(V, M))
            return false;
    }
    else
    {
        if (!fn(U, N))
            return false;
    }

    auto const hasDeliveries = [](Route::Node *node, size_t segLength)
    {
        auto const &route = *node->route();
        auto const last = node->pos() + segLength - 1;
        return node->isDelivery()
               || route.numDeliveries(node->pos()) != route.numDeliveries(last);
    };

    auto const hasPickups = [](Route::Node *node, size_t segLength)
    {
        auto const &route = *node->route();
        auto const last = node->pos() + segLength - 1;
        return node->isPickup()
               || route.numPickups(node->pos()) != route.numPickups(last);
    };

    if (U->route() == V->route())
    {
        // Then we move U to the back of the route, and V to the front (when
        // M > 0). The shipment precedence constraints are maintained if U
        // does not contain pickups, and V no deliveries.
        if constexpr (M == 0)
            return U->pos() < V->pos() ? hasPickups(U, N) : hasDeliveries(U, N);
        else
        {
            if (U->pos() < V->pos())
                return hasPickups(U, N) || hasDeliveries(V, M);
            else  // then U must not contain deliveries, and V not any pickups
                return hasDeliveries(U, N) || hasPickups(V, M);
        }
    }

    return true;
}
```

</details>


<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.
- You must disclose the use of LLMs/generative AI if you used such tools to write code.

</details>
