### PR TITLE
Use `std::stoul` in Activity constructor

### DIFF
--- a/pyvrp/cpp/Activity.cpp
+++ b/pyvrp/cpp/Activity.cpp
@@ -37,7 +37,7 @@ Activity::Activity(ActivityType type, size_t idx) : type_(type), idx_(idx) {}
 
 Activity::Activity(std::string const &description)
     : type_(char2type(description.empty() ? ' ' : description[0])),
-      idx_(std::stol(description.empty() ? "0" : description.substr(1)))
+      idx_(description.empty() ? 0 : std::stoul(description.substr(1)))
 {
     assert(description.size() >= 2);  // sanity check; type/idx do validation
 }

--- a/pyvrp/cpp/Activity.cpp
+++ b/pyvrp/cpp/Activity.cpp
@@ -37,7 +37,7 @@ Activity::Activity(ActivityType type, size_t idx) : type_(type), idx_(idx) {}
 
 Activity::Activity(std::string const &description)
     : type_(char2type(description.empty() ? ' ' : description[0])),
-      idx_(std::stol(description.empty() ? 0 : description.substr(1)))
+      idx_(std::stol(description.empty() ? "0" : description.substr(1)))
 {
     assert(description.size() >= 2);  // sanity check; type/idx do validation
 }


### PR DESCRIPTION
Ran into this error with clang21.

```
../pyvrp/cpp/Activity.cpp:48:44: error: null passed to a callee that requires a non-null argument [-Werror,-Wnonnull]
   48 |       idx_(std::stol(description.empty() ? 0 : description.substr(1)))
      |               
```