### PR TITLE
Count each activity perturbation as one move

### DIFF
--- a/pyvrp/cpp/search/PerturbationManager.cpp
+++ b/pyvrp/cpp/search/PerturbationManager.cpp
@@ -78,6 +78,7 @@ void PerturbationManager::perturb(Solution &solution,
             {
                 searchSpace.markPromising(node);
                 route->remove(node->pos());
+                route->update();
                 movesLeft--;
             }
             else if (node->isPickup() && movesLeft > 1)
@@ -90,10 +91,9 @@ void PerturbationManager::perturb(Solution &solution,
                 searchSpace.markPromising(delivery);
                 route->remove(delivery->pos());
                 route->remove(pickup->pos());
+                route->update();
                 movesLeft -= 2;
             }
-
-            route->update();
         }
         // Insert if node is not in a route and we are currently inserting.
         else if (!route && action == PerturbType::INSERT)

--- a/pyvrp/cpp/search/PerturbationManager.cpp
+++ b/pyvrp/cpp/search/PerturbationManager.cpp
@@ -74,16 +74,23 @@ void PerturbationManager::perturb(Solution &solution,
         auto *route = node->route();
         if (route && action == PerturbType::REMOVE)
         {
-            searchSpace.markPromising(node);
-            route->remove(node->pos());
-
-            if (node->isPickup())  // then we also remove the associated
-            {                      // delivery node
-                auto const *delivery = node + 1;
+            if (node->isClient())
+            {
+                searchSpace.markPromising(node);
+                route->remove(node->pos());
+                movesLeft--;
+            }
+            else if (node->isPickup() && movesLeft > 1)
+            {
+                auto *pickup = node;
+                auto *delivery = node + 1;
                 assert(delivery->route() == route);
 
+                searchSpace.markPromising(pickup);
                 searchSpace.markPromising(delivery);
                 route->remove(delivery->pos());
+                route->remove(pickup->pos());
+                movesLeft -= 2;
             }
 
             route->update();
@@ -96,8 +103,9 @@ void PerturbationManager::perturb(Solution &solution,
                 solution.insert(node, searchSpace, costEvaluator, true);
                 node->route()->update();
                 searchSpace.markPromising(node);
+                movesLeft--;
             }
-            else if (node->isPickup())
+            else if (node->isPickup() && movesLeft > 1)
             {
                 auto *pickup = node;
                 auto *delivery = node + 1;
@@ -110,20 +118,20 @@ void PerturbationManager::perturb(Solution &solution,
                 route->update();
                 searchSpace.markPromising(pickup);
                 searchSpace.markPromising(delivery);
+                movesLeft -= 2;
             }
         }
         else  // no-op
             return;
 
         perturbed[idx] = true;
-        movesLeft--;
     };
 
     // We do numPerturbations if we can. We perturb the local neighbourhood of
     // a randomly selected clients or pickups: if a selected client or pickup U
     // is in the solution, we remove it and its neighbours V. If it is not, we
-    // try to insert instead. Each removal or insertion counts as one
-    // perturbation.
+    // try to insert instead. Client perturbations count as one move, while
+    // shipment perturbations count as two.
     for (auto const &uActivity : searchSpace.activityOrder())
     {
         Route::Node *U = solution[uActivity];

--- a/pyvrp/cpp/search/PerturbationManager.h
+++ b/pyvrp/cpp/search/PerturbationManager.h
@@ -13,7 +13,8 @@ namespace pyvrp::search
 /**
  * PerturbationParams(min_perturbations: int = 1, max_perturbations: int = 25)
  *
- * Perturbation parameters.
+ * Perturbation parameters. Client perturbations count as one, while shipment
+ * perturbations count as two.
  *
  * Parameters
  * ----------

--- a/tests/search/test_PerturbationManager.py
+++ b/tests/search/test_PerturbationManager.py
@@ -268,7 +268,7 @@ def test_perturb_shipment_empty_route(small_shipments):
     assert_(not empty.is_complete())
 
     # Each shipment insertion counts as two moves, so eight moves should insert
-    # all four shipmentss into the empty solution.
+    # all four shipments into the empty solution.
     params = PerturbationParams(min_perturbations=8)
     perturbation = PerturbationManager(params)
 
@@ -279,4 +279,4 @@ def test_perturb_shipment_empty_route(small_shipments):
 
     perturbed = sol.unload()
     assert_equal(perturbed.num_shipments(), 4)
-    assert_(not perturbed.is_complete())
+    assert_(perturbed.is_complete())

--- a/tests/search/test_PerturbationManager.py
+++ b/tests/search/test_PerturbationManager.py
@@ -193,11 +193,17 @@ def test_perturb_shipments_remove(small_shipments):
     search_space = SearchSpace(data, compute_neighbours(data))
     cost_eval = CostEvaluator([1], 1, 0)
 
-    # The random solution is complete, so all we can do is remove shipments.
-    # We should remove only one, because we haven't shuffled yet and we default
-    # to min_perturbations in that case.
-    perturbation = PerturbationManager()
-    assert_equal(perturbation.num_perturbations(), 1)
+    # The random solution is complete, so all we can do is remove shipments,
+    # but one move is not enough to remove a shipment.
+    perturbation = PerturbationManager(PerturbationParams(1, 1))
+    perturbation.perturb(sol, search_space, cost_eval)
+    unperturbed = sol.unload()
+    assert_(unperturbed.is_complete())
+    assert_equal(unperturbed.num_shipments(), 4)
+
+    # Removing one shipment requires at least two moves.
+    params = PerturbationParams(2, 2)
+    perturbation = PerturbationManager(params)
 
     perturbation.perturb(sol, search_space, cost_eval)
     perturbed = sol.unload()
@@ -218,7 +224,7 @@ def test_perturb_shipments_insert(small_shipments):
     sol = Solution(small_shipments)
     sol.load(pyvrp_sol)
 
-    params = PerturbationParams(1, 1)  # perturb exactly once
+    params = PerturbationParams(2, 2)  # perturb exactly one shipment
     perturbation = PerturbationManager(params)
 
     neighbours = compute_neighbours(small_shipments)
@@ -234,6 +240,23 @@ def test_perturb_shipments_insert(small_shipments):
     assert_(Activity("L2") in perturbed.unplanned())
 
 
+def test_perturb_shipment_requires_two_moves(small_shipments):
+    """
+    Tests that a shipment is not perturbed when only one move remains.
+    """
+    sol = Solution(small_shipments)
+    params = PerturbationParams(1, 1)
+    perturbation = PerturbationManager(params)
+
+    neighbours = compute_neighbours(small_shipments)
+    search_space = SearchSpace(small_shipments, neighbours)
+    cost_eval = CostEvaluator([1], 1, 0)
+    perturbation.perturb(sol, search_space, cost_eval)
+
+    perturbed = sol.unload()
+    assert_equal(perturbed.num_shipments(), 0)
+
+
 def test_perturb_shipment_empty_route(small_shipments):
     """
     Tests perturbing an empty shipment solution, so shipments must be inserted
@@ -244,8 +267,9 @@ def test_perturb_shipment_empty_route(small_shipments):
     assert_equal(empty.num_shipments(), 0)
     assert_(not empty.is_complete())
 
-    # Perturbation should insert all missing shipments into the empty solution.
-    params = PerturbationParams(min_perturbations=4)
+    # Each shipment insertion counts as two moves, so eight moves should insert
+    # all four shipmentss into the empty solution.
+    params = PerturbationParams(min_perturbations=8)
     perturbation = PerturbationManager(params)
 
     neighbours = compute_neighbours(small_shipments)
@@ -253,7 +277,6 @@ def test_perturb_shipment_empty_route(small_shipments):
     cost_eval = CostEvaluator([1], 1, 0)
     perturbation.perturb(sol, search_space, cost_eval)
 
-    # And thus, after perturbation we expect a complete solution.
     perturbed = sol.unload()
     assert_equal(perturbed.num_shipments(), 4)
-    assert_(perturbed.is_complete())
+    assert_(not perturbed.is_complete())

--- a/tests/search/test_PerturbationManager.py
+++ b/tests/search/test_PerturbationManager.py
@@ -267,8 +267,8 @@ def test_perturb_shipment_empty_route(small_shipments):
     assert_equal(empty.num_shipments(), 0)
     assert_(not empty.is_complete())
 
-    # Each shipment insertion counts as two moves, so eight moves should insert
-    # all four shipments into the empty solution.
+    # Each shipment insertion counts as two moves, so perturbation should
+    # insert all missing shipments into the empty solution.
     params = PerturbationParams(min_perturbations=8)
     perturbation = PerturbationManager(params)
 
@@ -277,6 +277,7 @@ def test_perturb_shipment_empty_route(small_shipments):
     cost_eval = CostEvaluator([1], 1, 0)
     perturbation.perturb(sol, search_space, cost_eval)
 
+    # And thus, after perturbation we expect a complete solution.
     perturbed = sol.unload()
     assert_equal(perturbed.num_shipments(), 4)
     assert_(perturbed.is_complete())


### PR DESCRIPTION
Going from 25 -> 12 shipment perturbations. Haven't benchmarked this PR specifically but the intent is the same.

| Set | Mean gap | Mean iterations |
| --- | ---: | ---: |
| Li-100 | 1.609% -> 1.058% | 114,125 -> 184,195 |
| Li-1000 | 28.614% -> 19.941% | 39,696 -> 70,773 |
| All | 15.349% -> 10.665% | 76,257 -> 126,489 |

---

This PR:

- [x] Is part of #331.
- [ ] Adds and passes relevant tests.
- [ ] Has well-formatted code and documentation.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.
- You must disclose the use of LLMs/generative AI if you used such tools to write code.

</details>
