### PR TITLE
Revert single shipment activity change in neighbourhood

### DIFF
--- a/pyvrp/cpp/search/neighbourhood.cpp
+++ b/pyvrp/cpp/search/neighbourhood.cpp
@@ -173,23 +173,6 @@ pyvrp::search::computeNeighbours(ProblemData const &data,
                 // not too problematic if we need to have them.
                 prox(frmClient, toClient) = std::numeric_limits<double>::max();
 
-    for (size_t frm = 0; frm != prox.numRows(); ++frm)
-        for (size_t to = data.numClients(); to != prox.numRows(); ++to)
-        {
-            auto const toDeliv = data.numShipments() + to;
-            auto const pick = prox(frm, to);
-            auto const deliv = prox(frm, toDeliv);
-
-            // Only one of {pickup, delivery} enters the neighbourhood lists of
-            // other activities, to ensure a wide diversity of activities. Here
-            // we select the activity that is nearest, and set the other to max
-            // float (see reasoning above for groups about infty).
-            if (pick < deliv)
-                prox(frm, toDeliv) = std::numeric_limits<double>::max();
-            else
-                prox(frm, to) = std::numeric_limits<double>::max();
-        }
-
     for (size_t idx = 0; idx != prox.numRows(); ++idx)  // excl. self
         prox(idx, idx) = std::numeric_limits<double>::infinity();
 

--- a/tests/search/test_neighbourhood.py
+++ b/tests/search/test_neighbourhood.py
@@ -263,29 +263,3 @@ def test_mixed_client_shipments(small_shipments):
     # case, there is always one other client, and three other shipments. Thus,
     # a total of seven activities can be in the neighbourhood.
     assert_equal(len(neighbours[Activity("C0")]), 7)
-
-
-def test_shipments_enter_neighbourhood_with_only_one_activity(small_shipments):
-    """
-    Tests that shipments enter the neighbourhood of other activities with
-    either their pickup or their delivery activity, but not both if it can
-    be avoided.
-    """
-    # There are four shipments, so with num_neighbours == 3, each shipment can
-    # have fully unique neighbours (all different indices). Here we check
-    # that's indeed the case.
-    params = NeighbourhoodParams(num_neighbours=3)
-    neighbourhoud = compute_neighbours(small_shipments, params)
-    for _, neighbours in neighbourhoud.items():
-        idcs = {activity.idx for activity in neighbours}
-        assert_equal(len(idcs), len(neighbours))
-
-    # But from num_neighbours > 3 onward we need to have some duplication in
-    # shipments: some enter the neighbourhood list with both a pickup and a
-    # delivery activity, instead of just one of both. Thus, the indices are
-    # no longer unique.
-    params = NeighbourhoodParams(num_neighbours=4)
-    neighbourhoud = compute_neighbours(small_shipments, params)
-    for _, neighbours in neighbourhoud.items():
-        idcs = {activity.idx for activity in neighbours}
-        assert_(len(idcs) < len(neighbours))


### PR DESCRIPTION
Ran with RelocateShipment at https://github.com/PyVRP/PyVRP/pull/1143#issuecomment-5096417768.

Before -> after revert

| Set | Mean gap | Mean iterations |
| --- | ---: | ---: |
| Li-100 | 0.319% -> 0.255% | 88,967 -> 95,471 |
| Li-1000 | 10.917% -> 9.814% | 38,874 -> 44,240 |
| All | 5.711% -> 5.118% | 63,481 -> 69,406 |



This PR:

- [x] Is part of #1098. Reverts a change from #1138.
- [ ] Adds and passes relevant tests.
- [ ] Has well-formatted code and documentation.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.
- You must disclose the use of LLMs/generative AI if you used such tools to write code.

</details>
