### PR TITLE
Improve shipment neighbourhood insert

### DIFF
--- a/pyvrp/cpp/search/Solution.cpp
+++ b/pyvrp/cpp/search/Solution.cpp
@@ -236,7 +236,6 @@ bool Solution::insert(Route::Node *pickup,
     Route::Node *pickupAfter = routes[0][0];  // fallback option
     size_t deliveryPos = 1;
     Cost bestCost = std::numeric_limits<Cost>::max();
-    std::unordered_set<Route::Node *> evaluated;
 
     // First we search the shipment's neighbourhood to insert the pickup and
     // delivery in a route that's already in use.
@@ -249,11 +248,8 @@ bool Solution::insert(Route::Node *pickup,
         if (!route)
             continue;
 
-        for (auto *V : {neighbour, p(neighbour)})  // after or before neighbour
+        for (auto *V : {p(neighbour), neighbour})  // before or after neighbour
         {
-            if (!evaluated.insert(V).second)
-                continue;
-
             Cost deltaCost = -shipment.prize;
             costEvaluator.deltaCost<true>(
                 deltaCost,  // delivery directly after pickup

--- a/pyvrp/cpp/search/Solution.cpp
+++ b/pyvrp/cpp/search/Solution.cpp
@@ -245,16 +245,14 @@ bool Solution::insert(Route::Node *pickup,
         Route::Node *neighbour = this->operator[](vActivity);
         assert(neighbour);
 
-        if (!neighbour->route())
+        auto const *route = neighbour->route();
+        if (!route)
             continue;
 
-        for (auto *V : {neighbour, p(neighbour)})
+        for (auto *V : {neighbour, p(neighbour)})  // after or before neighbour
         {
             if (!evaluated.insert(V).second)
                 continue;
-
-            auto const *route = V->route();
-            assert(route);
 
             Cost deltaCost = -shipment.prize;
             costEvaluator.deltaCost<true>(

--- a/pyvrp/cpp/search/Solution.cpp
+++ b/pyvrp/cpp/search/Solution.cpp
@@ -8,7 +8,6 @@
 #include <cassert>
 #include <limits>
 #include <ostream>
-#include <unordered_set>
 
 using pyvrp::Cost;
 using pyvrp::Distance;

--- a/pyvrp/cpp/search/Solution.cpp
+++ b/pyvrp/cpp/search/Solution.cpp
@@ -6,7 +6,9 @@
 
 #include <algorithm>
 #include <cassert>
+#include <limits>
 #include <ostream>
+#include <unordered_set>
 
 using pyvrp::Cost;
 using pyvrp::Distance;
@@ -234,49 +236,58 @@ bool Solution::insert(Route::Node *pickup,
     Route::Node *pickupAfter = routes[0][0];  // fallback option
     size_t deliveryPos = 1;
     Cost bestCost = std::numeric_limits<Cost>::max();
+    std::unordered_set<Route::Node *> evaluated;
 
     // First we search the shipment's neighbourhood to insert the pickup and
     // delivery in a route that's already in use.
     for (auto const &vActivity : searchSpace.neighboursOf(pickup->activity()))
     {
-        Route::Node *V = this->operator[](vActivity);
-        assert(V);
+        Route::Node *neighbour = this->operator[](vActivity);
+        assert(neighbour);
 
-        auto const *route = V->route();
-        if (!route)
+        if (!neighbour->route())
             continue;
 
-        Cost deltaCost = -shipment.prize;
-        costEvaluator.deltaCost<true>(
-            deltaCost,  // delivery directly after pickup
-            Route::Proposal(route->before(V->pos()),
-                            PickupSegment(data_, pickup->idx()),
-                            DeliverySegment(data_, delivery->idx()),
-                            route->after(V->pos() + 1)));
-
-        if (deltaCost < bestCost)
+        for (auto *V : {neighbour, p(neighbour)})
         {
-            pickupAfter = V;
-            deliveryPos = V->pos() + 1;
-            bestCost = deltaCost;
-        }
+            if (!evaluated.insert(V).second)
+                continue;
 
-        for (auto const *node = n(V); !node->isDepot(); node = n(node))
-        {
+            auto const *route = V->route();
+            assert(route);
+
             Cost deltaCost = -shipment.prize;
             costEvaluator.deltaCost<true>(
-                deltaCost,
+                deltaCost,  // delivery directly after pickup
                 Route::Proposal(route->before(V->pos()),
                                 PickupSegment(data_, pickup->idx()),
-                                route->between(V->pos() + 1, node->pos()),
                                 DeliverySegment(data_, delivery->idx()),
-                                route->after(node->pos() + 1)));
+                                route->after(V->pos() + 1)));
 
             if (deltaCost < bestCost)
             {
                 pickupAfter = V;
-                deliveryPos = node->pos() + 1;
+                deliveryPos = V->pos() + 1;
                 bestCost = deltaCost;
+            }
+
+            for (auto const *node = n(V); !node->isDepot(); node = n(node))
+            {
+                Cost deltaCost = -shipment.prize;
+                costEvaluator.deltaCost<true>(
+                    deltaCost,
+                    Route::Proposal(route->before(V->pos()),
+                                    PickupSegment(data_, pickup->idx()),
+                                    route->between(V->pos() + 1, node->pos()),
+                                    DeliverySegment(data_, delivery->idx()),
+                                    route->after(node->pos() + 1)));
+
+                if (deltaCost < bestCost)
+                {
+                    pickupAfter = V;
+                    deliveryPos = node->pos() + 1;
+                    bestCost = deltaCost;
+                }
             }
         }
     }

--- a/pyvrp/cpp/search/Solution.h
+++ b/pyvrp/cpp/search/Solution.h
@@ -63,7 +63,7 @@ public:
     // Inserts the given pickup and delivery pair into the solution - either in
     // its neighbourhood, or in an empty route, if improving or required.
     // Returns true if the shipment was successfully inserted, false otherwise.
-    // Updating the search space an inserted route is left to the calling code.
+    // Updating the search space and inserted route is left to the calling code.
     bool insert(Route::Node *pickup,
                 Route::Node *delivery,
                 SearchSpace const &searchSpace,

--- a/pyvrp/cpp/search/neighbourhood.cpp
+++ b/pyvrp/cpp/search/neighbourhood.cpp
@@ -87,6 +87,10 @@ Matrix<double> computeProximity(ProblemData const &data,
                 auto const idx = client;
                 auto const &to = data.client(client);
                 prox(frm, idx) = std::min(cost(frmData, to), prox(frm, idx));
+
+                if (params.symmetricProximity)
+                    prox(frm, idx)
+                        = std::min(cost(to, frmData), prox(frm, idx));
             }
 
             // To shipment pickups.
@@ -95,6 +99,10 @@ Matrix<double> computeProximity(ProblemData const &data,
                 auto const idx = data.numClients() + pick;
                 auto const &to = data.shipment(pick).pickup;
                 prox(frm, idx) = std::min(cost(frmData, to), prox(frm, idx));
+
+                if (params.symmetricProximity)
+                    prox(frm, idx)
+                        = std::min(cost(to, frmData), prox(frm, idx));
             }
 
             // To shipment deliveries.
@@ -103,6 +111,10 @@ Matrix<double> computeProximity(ProblemData const &data,
                 auto const idx = data.numClients() + data.numShipments() + del;
                 auto const &to = data.shipment(del).delivery;
                 prox(frm, idx) = std::min(cost(frmData, to), prox(frm, idx));
+
+                if (params.symmetricProximity)
+                    prox(frm, idx)
+                        = std::min(cost(to, frmData), prox(frm, idx));
             }
         }
 
@@ -120,6 +132,11 @@ Matrix<double> computeProximity(ProblemData const &data,
                 prox(frm, idx) = std::min({cost(shipment.pickup, to),
                                            cost(shipment.delivery, to),
                                            prox(frm, idx)});
+
+                if (params.symmetricProximity)
+                    prox(frm, idx) = std::min({cost(to, shipment.pickup),
+                                               cost(to, shipment.delivery),
+                                               prox(frm, idx)});
             }
 
             // To shipment pickups.
@@ -130,6 +147,11 @@ Matrix<double> computeProximity(ProblemData const &data,
                 prox(frm, idx) = std::min({cost(shipment.pickup, to),
                                            cost(shipment.delivery, to),
                                            prox(frm, idx)});
+
+                if (params.symmetricProximity)
+                    prox(frm, idx) = std::min({cost(to, shipment.pickup),
+                                               cost(to, shipment.delivery),
+                                               prox(frm, idx)});
             }
 
             // To shipment deliveries.
@@ -140,6 +162,11 @@ Matrix<double> computeProximity(ProblemData const &data,
                 prox(frm, idx) = std::min({cost(shipment.pickup, to),
                                            cost(shipment.delivery, to),
                                            prox(frm, idx)});
+
+                if (params.symmetricProximity)
+                    prox(frm, idx) = std::min({cost(to, shipment.pickup),
+                                               cost(to, shipment.delivery),
+                                               prox(frm, idx)});
             }
         }
     }
@@ -164,12 +191,6 @@ pyvrp::search::computeNeighbours(ProblemData const &data,
                                  NeighbourhoodParams const &params)
 {
     auto prox = computeProximity(data, params);
-
-    if (params.symmetricProximity)  // then we symmetrise the proximity matrix
-        for (size_t frm = 0; frm != prox.numRows(); ++frm)
-            for (size_t to = frm; to != prox.numRows(); ++to)
-                prox(frm, to) = prox(to, frm)
-                    = std::min(prox(frm, to), prox(to, frm));
 
     for (auto const &group : data.groups())
         for (auto const frmClient : group)

--- a/pyvrp/cpp/search/neighbourhood.cpp
+++ b/pyvrp/cpp/search/neighbourhood.cpp
@@ -118,7 +118,7 @@ Matrix<double> computeProximity(ProblemData const &data,
         }
 
         // From shipment pickups. Their neighbourhood considers proximity cost
-        // from both pickup and delivery endpoints to other activities.
+        // from both pickup and delivery steps to other activities.
         for (size_t frm = data.numClients(); frm != prox.numRows(); ++frm)
         {
             auto const &shipment = data.shipment(frm - data.numClients());

--- a/pyvrp/cpp/search/neighbourhood.cpp
+++ b/pyvrp/cpp/search/neighbourhood.cpp
@@ -87,10 +87,6 @@ Matrix<double> computeProximity(ProblemData const &data,
                 auto const idx = client;
                 auto const &to = data.client(client);
                 prox(frm, idx) = std::min(cost(frmData, to), prox(frm, idx));
-
-                if (params.symmetricProximity)
-                    prox(frm, idx)
-                        = std::min(cost(to, frmData), prox(frm, idx));
             }
 
             // To shipment pickups.
@@ -99,10 +95,6 @@ Matrix<double> computeProximity(ProblemData const &data,
                 auto const idx = data.numClients() + pick;
                 auto const &to = data.shipment(pick).pickup;
                 prox(frm, idx) = std::min(cost(frmData, to), prox(frm, idx));
-
-                if (params.symmetricProximity)
-                    prox(frm, idx)
-                        = std::min(cost(to, frmData), prox(frm, idx));
             }
 
             // To shipment deliveries.
@@ -111,10 +103,6 @@ Matrix<double> computeProximity(ProblemData const &data,
                 auto const idx = data.numClients() + data.numShipments() + del;
                 auto const &to = data.shipment(del).delivery;
                 prox(frm, idx) = std::min(cost(frmData, to), prox(frm, idx));
-
-                if (params.symmetricProximity)
-                    prox(frm, idx)
-                        = std::min(cost(to, frmData), prox(frm, idx));
             }
         }
 
@@ -132,11 +120,6 @@ Matrix<double> computeProximity(ProblemData const &data,
                 prox(frm, idx) = std::min({cost(shipment.pickup, to),
                                            cost(shipment.delivery, to),
                                            prox(frm, idx)});
-
-                if (params.symmetricProximity)
-                    prox(frm, idx) = std::min({cost(to, shipment.pickup),
-                                               cost(to, shipment.delivery),
-                                               prox(frm, idx)});
             }
 
             // To shipment pickups.
@@ -147,11 +130,6 @@ Matrix<double> computeProximity(ProblemData const &data,
                 prox(frm, idx) = std::min({cost(shipment.pickup, to),
                                            cost(shipment.delivery, to),
                                            prox(frm, idx)});
-
-                if (params.symmetricProximity)
-                    prox(frm, idx) = std::min({cost(to, shipment.pickup),
-                                               cost(to, shipment.delivery),
-                                               prox(frm, idx)});
             }
 
             // To shipment deliveries.
@@ -162,14 +140,15 @@ Matrix<double> computeProximity(ProblemData const &data,
                 prox(frm, idx) = std::min({cost(shipment.pickup, to),
                                            cost(shipment.delivery, to),
                                            prox(frm, idx)});
-
-                if (params.symmetricProximity)
-                    prox(frm, idx) = std::min({cost(to, shipment.pickup),
-                                               cost(to, shipment.delivery),
-                                               prox(frm, idx)});
             }
         }
     }
+
+    if (params.symmetricProximity)  // then we symmetrise the proximity matrix
+        for (size_t frm = 0; frm != prox.numRows(); ++frm)
+            for (size_t to = frm; to != prox.numRows(); ++to)
+                prox(frm, to) = prox(to, frm)
+                    = std::min(prox(frm, to), prox(to, frm));
 
     return prox;
 }

--- a/pyvrp/cpp/search/neighbourhood.cpp
+++ b/pyvrp/cpp/search/neighbourhood.cpp
@@ -50,7 +50,7 @@ Matrix<double> computeProximity(ProblemData const &data,
         auto const &dists = data.distanceMatrix(vehType.profile);
         auto const &durs = data.durationMatrix(vehType.profile);
 
-        auto const cost = [&](auto const &from, auto const &to)
+        auto const arcCost = [&](auto const &from, auto const &to)
         {
             auto const frmServ = static_cast<double>(from.serviceDuration);
             auto const frmEarly = static_cast<double>(from.twEarly);
@@ -76,6 +76,17 @@ Matrix<double> computeProximity(ProblemData const &data,
                    + params.weightWaitTime * std::max(minWait, 0.0);
         };
 
+        // Proximity between two activities. If proximity is symmetric, we
+        // evaluate the arc in both directions, and take the best of the two.
+        auto const cost = [&](auto const &from, auto const &to)
+        {
+            auto value = arcCost(from, to);
+            if (params.symmetricProximity)
+                value = std::min(value, arcCost(to, from));
+
+            return value;
+        };
+
         // From clients.
         for (size_t frm = 0; frm != data.numClients(); ++frm)
         {
@@ -87,10 +98,6 @@ Matrix<double> computeProximity(ProblemData const &data,
                 auto const idx = client;
                 auto const &to = data.client(client);
                 prox(frm, idx) = std::min(cost(frmData, to), prox(frm, idx));
-
-                if (params.symmetricProximity)
-                    prox(frm, idx)
-                        = std::min(cost(to, frmData), prox(frm, idx));
             }
 
             // To shipment pickups.
@@ -99,10 +106,6 @@ Matrix<double> computeProximity(ProblemData const &data,
                 auto const idx = data.numClients() + pick;
                 auto const &to = data.shipment(pick).pickup;
                 prox(frm, idx) = std::min(cost(frmData, to), prox(frm, idx));
-
-                if (params.symmetricProximity)
-                    prox(frm, idx)
-                        = std::min(cost(to, frmData), prox(frm, idx));
             }
 
             // To shipment deliveries.
@@ -111,10 +114,6 @@ Matrix<double> computeProximity(ProblemData const &data,
                 auto const idx = data.numClients() + data.numShipments() + del;
                 auto const &to = data.shipment(del).delivery;
                 prox(frm, idx) = std::min(cost(frmData, to), prox(frm, idx));
-
-                if (params.symmetricProximity)
-                    prox(frm, idx)
-                        = std::min(cost(to, frmData), prox(frm, idx));
             }
         }
 
@@ -132,11 +131,6 @@ Matrix<double> computeProximity(ProblemData const &data,
                 prox(frm, idx) = std::min({cost(shipment.pickup, to),
                                            cost(shipment.delivery, to),
                                            prox(frm, idx)});
-
-                if (params.symmetricProximity)
-                    prox(frm, idx) = std::min({cost(to, shipment.pickup),
-                                               cost(to, shipment.delivery),
-                                               prox(frm, idx)});
             }
 
             // To shipment pickups.
@@ -147,11 +141,6 @@ Matrix<double> computeProximity(ProblemData const &data,
                 prox(frm, idx) = std::min({cost(shipment.pickup, to),
                                            cost(shipment.delivery, to),
                                            prox(frm, idx)});
-
-                if (params.symmetricProximity)
-                    prox(frm, idx) = std::min({cost(to, shipment.pickup),
-                                               cost(to, shipment.delivery),
-                                               prox(frm, idx)});
             }
 
             // To shipment deliveries.
@@ -162,11 +151,6 @@ Matrix<double> computeProximity(ProblemData const &data,
                 prox(frm, idx) = std::min({cost(shipment.pickup, to),
                                            cost(shipment.delivery, to),
                                            prox(frm, idx)});
-
-                if (params.symmetricProximity)
-                    prox(frm, idx) = std::min({cost(to, shipment.pickup),
-                                               cost(to, shipment.delivery),
-                                               prox(frm, idx)});
             }
         }
     }

--- a/pyvrp/cpp/search/neighbourhood.cpp
+++ b/pyvrp/cpp/search/neighbourhood.cpp
@@ -76,7 +76,7 @@ Matrix<double> computeProximity(ProblemData const &data,
                    + params.weightWaitTime * std::max(minWait, 0.0);
         };
 
-        // Symmetrise each pair before combining shipment endpoints below.
+        // Symmetrise the cost, if required.
         auto const cost = [&](auto const &from, auto const &to)
         {
             auto value = directedCost(from, to);

--- a/pyvrp/cpp/search/neighbourhood.cpp
+++ b/pyvrp/cpp/search/neighbourhood.cpp
@@ -50,7 +50,7 @@ Matrix<double> computeProximity(ProblemData const &data,
         auto const &dists = data.distanceMatrix(vehType.profile);
         auto const &durs = data.durationMatrix(vehType.profile);
 
-        auto const directedCost = [&](auto const &from, auto const &to)
+        auto const cost = [&](auto const &from, auto const &to)
         {
             auto const frmServ = static_cast<double>(from.serviceDuration);
             auto const frmEarly = static_cast<double>(from.twEarly);
@@ -76,23 +76,6 @@ Matrix<double> computeProximity(ProblemData const &data,
                    + params.weightWaitTime * std::max(minWait, 0.0);
         };
 
-        // Symmetrise the cost, if required.
-        auto const cost = [&](auto const &from, auto const &to)
-        {
-            auto value = directedCost(from, to);
-            if (params.symmetricProximity)
-                value = std::min(value, directedCost(to, from));
-
-            return value;
-        };
-
-        // A shipment's pickup neighbourhood considers proximity cost from both
-        // pickup and delivery endpoints.
-        auto const shipmentCost = [&](auto const &shipment, auto const &to) {
-            return std::min(cost(shipment.pickup, to),
-                            cost(shipment.delivery, to));
-        };
-
         // From clients.
         for (size_t frm = 0; frm != data.numClients(); ++frm)
         {
@@ -104,6 +87,10 @@ Matrix<double> computeProximity(ProblemData const &data,
                 auto const idx = client;
                 auto const &to = data.client(client);
                 prox(frm, idx) = std::min(cost(frmData, to), prox(frm, idx));
+
+                if (params.symmetricProximity)
+                    prox(frm, idx)
+                        = std::min(cost(to, frmData), prox(frm, idx));
             }
 
             // To shipment pickups.
@@ -112,6 +99,10 @@ Matrix<double> computeProximity(ProblemData const &data,
                 auto const idx = data.numClients() + pick;
                 auto const &to = data.shipment(pick).pickup;
                 prox(frm, idx) = std::min(cost(frmData, to), prox(frm, idx));
+
+                if (params.symmetricProximity)
+                    prox(frm, idx)
+                        = std::min(cost(to, frmData), prox(frm, idx));
             }
 
             // To shipment deliveries.
@@ -120,10 +111,15 @@ Matrix<double> computeProximity(ProblemData const &data,
                 auto const idx = data.numClients() + data.numShipments() + del;
                 auto const &to = data.shipment(del).delivery;
                 prox(frm, idx) = std::min(cost(frmData, to), prox(frm, idx));
+
+                if (params.symmetricProximity)
+                    prox(frm, idx)
+                        = std::min(cost(to, frmData), prox(frm, idx));
             }
         }
 
-        // From shipment pickups.
+        // From shipment pickups. Their neighbourhood considers proximity cost
+        // from both pickup and delivery endpoints to other activities.
         for (size_t frm = data.numClients(); frm != prox.numRows(); ++frm)
         {
             auto const &shipment = data.shipment(frm - data.numClients());
@@ -133,8 +129,14 @@ Matrix<double> computeProximity(ProblemData const &data,
             {
                 auto const idx = client;
                 auto const &to = data.client(client);
-                prox(frm, idx)
-                    = std::min(shipmentCost(shipment, to), prox(frm, idx));
+                prox(frm, idx) = std::min({cost(shipment.pickup, to),
+                                           cost(shipment.delivery, to),
+                                           prox(frm, idx)});
+
+                if (params.symmetricProximity)
+                    prox(frm, idx) = std::min({cost(to, shipment.pickup),
+                                               cost(to, shipment.delivery),
+                                               prox(frm, idx)});
             }
 
             // To shipment pickups.
@@ -142,8 +144,14 @@ Matrix<double> computeProximity(ProblemData const &data,
             {
                 auto const idx = data.numClients() + pick;
                 auto const &to = data.shipment(pick).pickup;
-                prox(frm, idx)
-                    = std::min(shipmentCost(shipment, to), prox(frm, idx));
+                prox(frm, idx) = std::min({cost(shipment.pickup, to),
+                                           cost(shipment.delivery, to),
+                                           prox(frm, idx)});
+
+                if (params.symmetricProximity)
+                    prox(frm, idx) = std::min({cost(to, shipment.pickup),
+                                               cost(to, shipment.delivery),
+                                               prox(frm, idx)});
             }
 
             // To shipment deliveries.
@@ -151,8 +159,14 @@ Matrix<double> computeProximity(ProblemData const &data,
             {
                 auto const idx = data.numClients() + data.numShipments() + del;
                 auto const &to = data.shipment(del).delivery;
-                prox(frm, idx)
-                    = std::min(shipmentCost(shipment, to), prox(frm, idx));
+                prox(frm, idx) = std::min({cost(shipment.pickup, to),
+                                           cost(shipment.delivery, to),
+                                           prox(frm, idx)});
+
+                if (params.symmetricProximity)
+                    prox(frm, idx) = std::min({cost(to, shipment.pickup),
+                                               cost(to, shipment.delivery),
+                                               prox(frm, idx)});
             }
         }
     }

--- a/pyvrp/cpp/search/neighbourhood.cpp
+++ b/pyvrp/cpp/search/neighbourhood.cpp
@@ -50,7 +50,7 @@ Matrix<double> computeProximity(ProblemData const &data,
         auto const &dists = data.distanceMatrix(vehType.profile);
         auto const &durs = data.durationMatrix(vehType.profile);
 
-        auto const cost = [&](auto const &from, auto const &to)
+        auto const directedCost = [&](auto const &from, auto const &to)
         {
             auto const frmServ = static_cast<double>(from.serviceDuration);
             auto const frmEarly = static_cast<double>(from.twEarly);
@@ -77,22 +77,20 @@ Matrix<double> computeProximity(ProblemData const &data,
         };
 
         // Symmetrise each pair before combining shipment endpoints below.
-        auto const proximity = [&](auto const &from, auto const &to)
+        auto const cost = [&](auto const &from, auto const &to)
         {
-            auto value = cost(from, to);
+            auto value = directedCost(from, to);
             if (params.symmetricProximity)
-                value = std::min(value, cost(to, from));
+                value = std::min(value, directedCost(to, from));
 
             return value;
         };
 
-        // A shipment is close to an activity when either endpoint is close.
-        // Its neighbourhood can therefore contain activities near the pickup
-        // or the delivery.
-        auto const shipmentProximity = [&](auto const &shipment, auto const &to)
-        {
-            return std::min(proximity(shipment.pickup, to),
-                            proximity(shipment.delivery, to));
+        // A shipment's pickup neighbourhood considers proximity cost from both
+        // pickup and delivery endpoints.
+        auto const shipmentCost = [&](auto const &shipment, auto const &to) {
+            return std::min(cost(shipment.pickup, to),
+                            cost(shipment.delivery, to));
         };
 
         // From clients.
@@ -105,8 +103,7 @@ Matrix<double> computeProximity(ProblemData const &data,
             {
                 auto const idx = client;
                 auto const &to = data.client(client);
-                prox(frm, idx)
-                    = std::min(proximity(frmData, to), prox(frm, idx));
+                prox(frm, idx) = std::min(cost(frmData, to), prox(frm, idx));
             }
 
             // To shipment pickups.
@@ -114,8 +111,7 @@ Matrix<double> computeProximity(ProblemData const &data,
             {
                 auto const idx = data.numClients() + pick;
                 auto const &to = data.shipment(pick).pickup;
-                prox(frm, idx)
-                    = std::min(proximity(frmData, to), prox(frm, idx));
+                prox(frm, idx) = std::min(cost(frmData, to), prox(frm, idx));
             }
 
             // To shipment deliveries.
@@ -123,12 +119,11 @@ Matrix<double> computeProximity(ProblemData const &data,
             {
                 auto const idx = data.numClients() + data.numShipments() + del;
                 auto const &to = data.shipment(del).delivery;
-                prox(frm, idx)
-                    = std::min(proximity(frmData, to), prox(frm, idx));
+                prox(frm, idx) = std::min(cost(frmData, to), prox(frm, idx));
             }
         }
 
-        // From shipments.
+        // From shipment pickups.
         for (size_t frm = data.numClients(); frm != prox.numRows(); ++frm)
         {
             auto const &shipment = data.shipment(frm - data.numClients());
@@ -139,7 +134,7 @@ Matrix<double> computeProximity(ProblemData const &data,
                 auto const idx = client;
                 auto const &to = data.client(client);
                 prox(frm, idx)
-                    = std::min(shipmentProximity(shipment, to), prox(frm, idx));
+                    = std::min(shipmentCost(shipment, to), prox(frm, idx));
             }
 
             // To shipment pickups.
@@ -148,7 +143,7 @@ Matrix<double> computeProximity(ProblemData const &data,
                 auto const idx = data.numClients() + pick;
                 auto const &to = data.shipment(pick).pickup;
                 prox(frm, idx)
-                    = std::min(shipmentProximity(shipment, to), prox(frm, idx));
+                    = std::min(shipmentCost(shipment, to), prox(frm, idx));
             }
 
             // To shipment deliveries.
@@ -157,7 +152,7 @@ Matrix<double> computeProximity(ProblemData const &data,
                 auto const idx = data.numClients() + data.numShipments() + del;
                 auto const &to = data.shipment(del).delivery;
                 prox(frm, idx)
-                    = std::min(shipmentProximity(shipment, to), prox(frm, idx));
+                    = std::min(shipmentCost(shipment, to), prox(frm, idx));
             }
         }
     }

--- a/pyvrp/cpp/search/neighbourhood.cpp
+++ b/pyvrp/cpp/search/neighbourhood.cpp
@@ -76,6 +76,25 @@ Matrix<double> computeProximity(ProblemData const &data,
                    + params.weightWaitTime * std::max(minWait, 0.0);
         };
 
+        // Symmetrise each pair before combining shipment endpoints below.
+        auto const proximity = [&](auto const &from, auto const &to)
+        {
+            auto value = cost(from, to);
+            if (params.symmetricProximity)
+                value = std::min(value, cost(to, from));
+
+            return value;
+        };
+
+        // A shipment is close to an activity when either endpoint is close.
+        // Its neighbourhood can therefore contain activities near the pickup
+        // or the delivery.
+        auto const shipmentProximity = [&](auto const &shipment, auto const &to)
+        {
+            return std::min(proximity(shipment.pickup, to),
+                            proximity(shipment.delivery, to));
+        };
+
         // From clients.
         for (size_t frm = 0; frm != data.numClients(); ++frm)
         {
@@ -86,7 +105,8 @@ Matrix<double> computeProximity(ProblemData const &data,
             {
                 auto const idx = client;
                 auto const &to = data.client(client);
-                prox(frm, idx) = std::min(cost(frmData, to), prox(frm, idx));
+                prox(frm, idx)
+                    = std::min(proximity(frmData, to), prox(frm, idx));
             }
 
             // To shipment pickups.
@@ -94,7 +114,8 @@ Matrix<double> computeProximity(ProblemData const &data,
             {
                 auto const idx = data.numClients() + pick;
                 auto const &to = data.shipment(pick).pickup;
-                prox(frm, idx) = std::min(cost(frmData, to), prox(frm, idx));
+                prox(frm, idx)
+                    = std::min(proximity(frmData, to), prox(frm, idx));
             }
 
             // To shipment deliveries.
@@ -102,21 +123,23 @@ Matrix<double> computeProximity(ProblemData const &data,
             {
                 auto const idx = data.numClients() + data.numShipments() + del;
                 auto const &to = data.shipment(del).delivery;
-                prox(frm, idx) = std::min(cost(frmData, to), prox(frm, idx));
+                prox(frm, idx)
+                    = std::min(proximity(frmData, to), prox(frm, idx));
             }
         }
 
-        // From shipment pickups.
+        // From shipments.
         for (size_t frm = data.numClients(); frm != prox.numRows(); ++frm)
         {
-            auto const &frmData = data.shipment(frm - data.numClients()).pickup;
+            auto const &shipment = data.shipment(frm - data.numClients());
 
             // To clients.
             for (size_t client = 0; client != data.numClients(); ++client)
             {
                 auto const idx = client;
                 auto const &to = data.client(client);
-                prox(frm, idx) = std::min(cost(frmData, to), prox(frm, idx));
+                prox(frm, idx)
+                    = std::min(shipmentProximity(shipment, to), prox(frm, idx));
             }
 
             // To shipment pickups.
@@ -124,7 +147,8 @@ Matrix<double> computeProximity(ProblemData const &data,
             {
                 auto const idx = data.numClients() + pick;
                 auto const &to = data.shipment(pick).pickup;
-                prox(frm, idx) = std::min(cost(frmData, to), prox(frm, idx));
+                prox(frm, idx)
+                    = std::min(shipmentProximity(shipment, to), prox(frm, idx));
             }
 
             // To shipment deliveries.
@@ -132,7 +156,8 @@ Matrix<double> computeProximity(ProblemData const &data,
             {
                 auto const idx = data.numClients() + data.numShipments() + del;
                 auto const &to = data.shipment(del).delivery;
-                prox(frm, idx) = std::min(cost(frmData, to), prox(frm, idx));
+                prox(frm, idx)
+                    = std::min(shipmentProximity(shipment, to), prox(frm, idx));
             }
         }
     }
@@ -157,12 +182,6 @@ pyvrp::search::computeNeighbours(ProblemData const &data,
                                  NeighbourhoodParams const &params)
 {
     auto prox = computeProximity(data, params);
-
-    if (params.symmetricProximity)  // then we symmetrise the proximity matrix
-        for (size_t frm = 0; frm != prox.numRows(); ++frm)
-            for (size_t to = frm; to != prox.numRows(); ++to)
-                prox(frm, to) = prox(to, frm)
-                    = std::min(prox(frm, to), prox(to, frm));
 
     for (auto const &group : data.groups())
         for (auto const frmClient : group)

--- a/pyvrp/cpp/search/neighbourhood.cpp
+++ b/pyvrp/cpp/search/neighbourhood.cpp
@@ -144,12 +144,6 @@ Matrix<double> computeProximity(ProblemData const &data,
         }
     }
 
-    if (params.symmetricProximity)  // then we symmetrise the proximity matrix
-        for (size_t frm = 0; frm != prox.numRows(); ++frm)
-            for (size_t to = frm; to != prox.numRows(); ++to)
-                prox(frm, to) = prox(to, frm)
-                    = std::min(prox(frm, to), prox(to, frm));
-
     return prox;
 }
 }  // namespace
@@ -170,6 +164,12 @@ pyvrp::search::computeNeighbours(ProblemData const &data,
                                  NeighbourhoodParams const &params)
 {
     auto prox = computeProximity(data, params);
+
+    if (params.symmetricProximity)  // then we symmetrise the proximity matrix
+        for (size_t frm = 0; frm != prox.numRows(); ++frm)
+            for (size_t to = frm; to != prox.numRows(); ++to)
+                prox(frm, to) = prox(to, frm)
+                    = std::min(prox(frm, to), prox(to, frm));
 
     for (auto const &group : data.groups())
         for (auto const frmClient : group)

--- a/pyvrp/cpp/search/neighbourhood.h
+++ b/pyvrp/cpp/search/neighbourhood.h
@@ -25,9 +25,8 @@ namespace pyvrp::search
  *     calculation. A large wait time indicates the clients are far apart
  *     in duration/time.
  * num_neighbours
- *     Number of other clients that are in each client's granular
- *     neighbourhood. This parameter determines the size of the overall
- *     neighbourhood.
+ *     Number of activities in each granular neighbourhood. This parameter
+ *     determines the size of the overall neighbourhood.
  * symmetric_proximity
  *     Whether to calculate a symmetric proximity matrix. This ensures edge
  *     :math:`(i, j)` is given the same weight as :math:`(j, i)`.

--- a/tests/search/test_Solution.py
+++ b/tests/search/test_Solution.py
@@ -196,3 +196,37 @@ def test_insert_pickup_delivery_non_adjacent(small_shipments):
 
     # The solution should have inserted L2 and U2, but not next to each other.
     assert_equal(str(route), "L0 L1 L3 U0 L2 U1 U3 U2")
+
+
+def test_insert_shipment_at_neighbour_predecessor(small_shipments):
+    """
+    Tests inserting a shipment at the predecessor of a neighbour.
+    """
+    sol = Solution(small_shipments)
+
+    # Start with shipment 1 in the route. Shipment 0 remains unplanned.
+    route = sol.routes[0]
+    for descr in ["L1", "U1"]:
+        route.append(sol[Activity(descr)])
+    route.update()
+    assert_equal(route.distance(), 27_732)
+
+    # L1 is the only neighbour of shipment 0. Inserting shipment 0 should
+    # therefore consider positions after L1 and after its predecessor, which
+    # is the start depot.
+    neighbours = {
+        Activity(f"L{idx}"): [] for idx in range(small_shipments.num_shipments)
+    }
+    neighbours[Activity("L0")] = [Activity("L1")]
+    search_space = SearchSpace(small_shipments, neighbours)
+
+    pickup, delivery = sol.shipments[0]
+    cost_eval = CostEvaluator([0], 0, 0)
+    assert_(sol.insert(pickup, delivery, search_space, cost_eval, True))
+    route.update()
+
+    # Inserting after the start depot adds 3_125 distance, compared to 9_571
+    # for opening the empty second route. Considering only positions after L1
+    # would instead produce L1 L0 U1 U0.
+    assert_equal(route.distance(), 30_857)
+    assert_equal(str(route), "L0 U0 L1 U1")

--- a/tests/search/test_Solution.py
+++ b/tests/search/test_Solution.py
@@ -225,8 +225,7 @@ def test_insert_shipment_at_neighbour_predecessor(small_shipments):
     assert_(sol.insert(pickup, delivery, search_space, cost_eval, True))
     route.update()
 
-    # Inserting after the start depot adds 3_125 distance, compared to 9_571
-    # for opening the empty second route. Considering only positions after L1
-    # would instead produce L1 L0 U1 U0.
+    # Inserting after the start depot adds 3_125 distance. Considering only
+    # positions after L1 would instead produce L1 L0 U1 U0, adding 6_637.
     assert_equal(route.distance(), 30_857)
     assert_equal(str(route), "L0 U0 L1 U1")

--- a/tests/search/test_neighbourhood.py
+++ b/tests/search/test_neighbourhood.py
@@ -238,7 +238,7 @@ def test_shipments_exclude_either_activity_in_neighbourhood(small_shipments):
         assert_(pickup not in neighbourhood)  # cannot be in own neighbourhood
         assert_(delivery not in neighbourhood)  # nor can delivery
 
-        # The neighbourhood contains pickup and delivery activities for each 
+        # The neighbourhood contains pickup and delivery activities for each
         # shipment, but excludes its own.
         assert_equal(len(neighbourhood), 2 * small_shipments.num_shipments - 2)
 
@@ -249,8 +249,8 @@ def test_shipment_proximity_uses_pickup_and_delivery():
     """
     distances = np.full((5, 5), 100, dtype=int)
     np.fill_diagonal(distances, 0)
-    distances[3, 1] = distances[1, 3] = 10 # pickup closest to C0
-    distances[4, 2] = distances[2, 4] = 1 # delivery closest to C1
+    distances[3, 1] = distances[1, 3] = 10  # pickup closest to C0
+    distances[4, 2] = distances[2, 4] = 1  # delivery closest to C1
 
     data = ProblemData(
         locations=[Location(idx, 0) for idx in range(5)],

--- a/tests/search/test_neighbourhood.py
+++ b/tests/search/test_neighbourhood.py
@@ -2,7 +2,15 @@ import numpy as np
 from numpy.testing import assert_, assert_equal, assert_raises
 from pytest import mark
 
-from pyvrp import Activity, Client, Depot, Location, ProblemData, VehicleType
+from pyvrp import (
+    Activity,
+    Client,
+    Depot,
+    Location,
+    ProblemData,
+    Shipment,
+    VehicleType,
+)
 from pyvrp.search import NeighbourhoodParams, compute_neighbours
 
 
@@ -233,6 +241,33 @@ def test_shipments_exclude_either_activity_in_neighbourhood(small_shipments):
         # The neighbourhood contains pickup and delivery activities for each 
         # shipment, but excludes its own.
         assert_equal(len(neighbourhood), 2 * small_shipments.num_shipments - 2)
+
+
+def test_shipment_proximity_uses_pickup_and_delivery():
+    """
+    Tests that shipment proximity considers both pickup and delivery.
+    """
+    distances = np.full((5, 5), 100, dtype=int)
+    np.fill_diagonal(distances, 0)
+    distances[3, 1] = distances[1, 3] = 10 # pickup closest to C0
+    distances[4, 2] = distances[2, 4] = 1 # delivery closest to C1
+
+    data = ProblemData(
+        locations=[Location(idx, 0) for idx in range(5)],
+        clients=[Client(1), Client(2)],
+        depots=[Depot(0)],
+        vehicle_types=[VehicleType()],
+        distance_matrices=[distances],
+        duration_matrices=[distances],
+        shipments=[Shipment(3, 4)],
+    )
+
+    # Shipment 0's pickup is closest to C0, but its delivery is even closer to
+    # C1. With one neighbour, the neighbour is therefore C1 rather than C0.
+    params = NeighbourhoodParams(0, num_neighbours=1)
+    neighbours = compute_neighbours(data, params)
+
+    assert_equal(neighbours[Activity("L0")], [Activity("C1")])
 
 
 def test_mixed_client_shipments(small_shipments):


### PR DESCRIPTION

This PR:
- [x] Our granular insert now only tries pickup after a neighbour V. Checking insert pickup before that neighbour, `p(V)`, helps. This can be explained by having symmetric proximity: if (U, V) are neighbours, then U -> V and V -> U could either be good positions.
	- I also added checking inserting `p(V)` on client neighbour insert, but that didn't consistently improve performance across variants. It did help quite a bit for MTVRPTW (because we can also insert after reload depots?). In general, I think insertion after depots (or breaks/recharges in the future) are a bit overlooked (see the Schneider paper in #215).
- [x] I also changed the neighbourhood definition. Instead of calculating shipment proximity using only the pickup -> client/pickup/delivery, we use the full shipment: pickup/delivery -> client/pickup/delivery. I do not fully understand why this works as well as it does, other than that it gives the granular neighbourhood a much broader view of promising insertion positions (and our operators don't strictly benefit only from good insertion positions).
	- [x] Before this PR, symmetric proximity was not considered for delivery. This was also an important change (cf. https://github.com/PyVRP/PyVRP/pull/1153#issuecomment-5164732956)
- [x] See benchmarks below for a feature-by-feature benchmark on PDPTW.

Furthermore:
- [x] Is part of #331.
- [ ] Adds and passes relevant tests.
- [ ] Has well-formatted code and documentation.


<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.
- You must disclose the use of LLMs/generative AI if you used such tools to write code.

</details>

--


### 1 minute

| Li set (# inst) | Pickup-and-delivery (f1dd61e62) | Only predecessor insert (131e0c3f8) | Only changed neighbourhood (4bc0a4bc5) | Combined (65593f3d8) |
|---|---:|---:|---:|---:|
| Li100 (56) | 0.35% | 0.10% | 0.02% | 0.02% |
| Li200 (60) | 1.02% | 0.35% | 0.28% | 0.16% |
| Li400 (60) | 3.00% | 1.22% | 1.40% | 0.89% |
| Li600 (60) | 7.23% | 3.04% | 3.27% | 1.51% |
| Li800 (60) | 11.04% | 4.47% | 5.98% | 2.61% |
| Li1000 (58) | 15.54% | 7.28% | 8.52% | 4.23% |

### 10 minutes

| Li set (# inst) | Pickup-and-delivery (f1dd61e62) | Only predecessor insert (131e0c3f8) | Only changed neighbourhood (4bc0a4bc5) | Combined (65593f3d8) |
|---|---:|---:|---:|---:|
| Li100 (56) | 0.02% | 0.00% | 0.01% | 0.00% |
| Li200 (60) | 0.19% | 0.09% | 0.10% | 0.05% |
| Li400 (60) | 0.88% | 0.59% | 0.38% | 0.44% |
| Li600 (60) | 1.91% | 1.33% | 0.79% | 0.70% |
| Li800 (60) | 2.68% | 1.41% | 1.42% | 0.96% |
| Li1000 (58) | 4.68% | 2.56% | 1.87% | 1.36% |
