### PR TITLE
Remove support for shipments in Exchange

### DIFF
--- a/pyvrp/cpp/search/Exchange.h
+++ b/pyvrp/cpp/search/Exchange.h
@@ -28,10 +28,6 @@ template <size_t N, size_t M> class Exchange : public BinaryOperator
     // Tests if the segment starting at node of given length contains the depot.
     bool hasDepot(Route::Node *node, size_t segLength) const;
 
-    // Tests if the segment starting at node of given length would split a
-    // shipment if exchanged.
-    bool splitsShipment(Route::Node *node, size_t segLength) const;
-
     // Tests if the segments of U and V overlap in the same route.
     bool overlap(Route::Node *U, Route::Node *V) const;
 
@@ -93,21 +89,6 @@ bool Exchange<N, M>::adjacent(Route::Node *U, Route::Node *V) const
 }
 
 template <size_t N, size_t M>
-bool Exchange<N, M>::splitsShipment(Route::Node *node, size_t segLength) const
-{
-    auto const &route = *node->route();
-    auto const last = node->pos() + segLength - 1;
-
-    // Moving this segment certainly does not split a shipment if there is not
-    // currently a shipment on the vehicle (at node), or if one is loaded, it
-    // is delivered within this segment.
-    return node->isDelivery()
-           || route.numPickups(node->pos())
-                  != route.numDeliveries(node->pos()) + node->isPickup()
-           || route.numPickups(last) != route.numDeliveries(last);
-}
-
-template <size_t N, size_t M>
 std::pair<Cost, bool> Exchange<N, M>::evalRelocateMove(
     Route::Node *U, Route::Node *V, CostEvaluator const &costEvaluator) const
 {
@@ -127,7 +108,7 @@ std::pair<Cost, bool> Exchange<N, M>::evalRelocateMove(
 
         // Then U's route is empty after this move, so we can subtract the
         // current route's cost and only evaluate V's proposal.
-        if (uRoute->numClients() + 2 * uRoute->numShipments() == N)
+        if (uRoute->numClients() == N)
         {
             deltaCost -= costEvaluator.penalisedCost(*uRoute);
             costEvaluator.deltaCost(deltaCost, vProposal);
@@ -220,7 +201,7 @@ std::pair<Cost, bool> Exchange<N, M>::evaluate(
 {
     stats_.numEvaluations++;
 
-    if (!U->route() || !V->route() || hasDepot(U, N) || splitsShipment(U, N))
+    if (!U->route() || !V->route() || hasDepot(U, N))
         return std::make_pair(0, false);
 
     if (U->route() == V->route())
@@ -246,7 +227,7 @@ std::pair<Cost, bool> Exchange<N, M>::evaluate(
         if (U->idx() >= V->idx())
             return std::make_pair(0, false);
 
-    if (hasDepot(V, M) || splitsShipment(V, M))
+    if (hasDepot(V, M))
         return std::make_pair(0, false);
 
     return evalSwapMove(U, V, costEvaluator);
@@ -288,11 +269,7 @@ template <size_t N, size_t M> std::string Exchange<N, M>::name() const
 template <size_t N, size_t M>
 bool Exchange<N, M>::supports(ProblemData const &data)
 {
-    if (data.numClients() == 0 && data.numShipments() > 0)
-        if constexpr (N & 1 || M & 1)  // cannot move uneven number of nodes
-            return false;              // if the instance has only shipments
-
-    return true;
+    return data.numShipments() == 0;
 }
 }  // namespace pyvrp::search
 

--- a/tests/search/test_Exchange.py
+++ b/tests/search/test_Exchange.py
@@ -620,25 +620,15 @@ def test_supports_clients(operator, instance, request):
     assert_(operator.supports(data))
 
 
-def test_supports_shipments(small_shipments):
+@pytest.mark.parametrize("operator", [Exchange10, Exchange11])
+def test_does_not_support_shipments(operator, small_shipments):
     """
-    Tests that only the even Exchange operators support instances with pure
-    shipments.
+    Tests that the Exchange operators do not support instances with shipments.
     """
-    # This is an instance with pure shipments - there are no clients.
-    assert_equal(small_shipments.num_clients, 0)
-    assert_equal(small_shipments.num_shipments, 4)
+    mixed = small_shipments.replace(clients=[Client(location=0, delivery=[0])])
 
-    # These move an even number of nodes between routes, and thus support
-    # instances with pure shipments.
-    assert_(Exchange20.supports(small_shipments))
-    assert_(Exchange22.supports(small_shipments))
-
-    # But these operators move an odd number of nodes between routes, and that
-    # is not supported.
-    assert_(not Exchange10.supports(small_shipments))
-    assert_(not Exchange11.supports(small_shipments))
-    assert_(not Exchange21.supports(small_shipments))
+    assert_(not operator.supports(small_shipments))
+    assert_(not operator.supports(mixed))
 
 
 def test_bug_release_time_shift_time_windows():
@@ -760,86 +750,3 @@ def test_name(ok_small):
     """
     assert_equal(Exchange10(ok_small).name, "Exchange10")
     assert_equal(Exchange11(ok_small).name, "Exchange11")
-
-
-def test_relocate_shipment(small_shipments):
-    """
-    Tests that the relocate operators can also move shipments.
-    """
-    activities = ["L1", "U1", "L0", "U0", "L2", "U2", "L3", "U3"]
-    route = make_search_route(small_shipments, activities)
-    assert_equal(route.distance(), 64_267)
-
-    op = Exchange20(small_shipments)
-    cost_eval = CostEvaluator([0], 0, 0)
-
-    # These moves cannot be done because they would move part of a shipment,
-    # possibly resulting in a pickup after a delivery.
-    assert_equal(op.evaluate(route[2], route[0], cost_eval), (0, False))
-    assert_equal(op.evaluate(route[4], route[0], cost_eval), (0, False))
-    assert_equal(op.evaluate(route[6], route[0], cost_eval), (0, False))
-
-    # But those one can: moving L3 U3 to the front of the route is perfectly
-    # fine, and an improving move.
-    assert_equal(op.evaluate(route[7], route[0], cost_eval), (-13_838, True))
-    op.apply(route[7], route[0])
-    route.update()
-
-    assert_equal(route.distance(), 50_429)
-    assert_equal(str(route), "L3 U3 L1 U1 L0 U0 L2 U2")
-
-
-def test_swap_shipment(small_shipments):
-    """
-    Tests swapping two shipments.
-    """
-    activities = ["L1", "U1", "L0", "U0", "L2", "U2", "L3", "U3"]
-    route = make_search_route(small_shipments, activities)
-    assert_equal(route.distance(), 64_267)
-
-    op = Exchange22(small_shipments)
-    cost_eval = CostEvaluator([0], 0, 0)
-
-    # These cannot be swapped since they would move part of a shipment,
-    # possibly resulting in a pickup after a delivery.
-    assert_equal(op.evaluate(route[2], route[0], cost_eval), (0, False))
-    assert_equal(op.evaluate(route[4], route[0], cost_eval), (0, False))
-    assert_equal(op.evaluate(route[6], route[0], cost_eval), (0, False))
-
-    # But swapping L0 U0 with L3 U3 is fine, and an improving move.
-    assert_equal(op.evaluate(route[3], route[7], cost_eval), (-5_622, True))
-    op.apply(route[3], route[7])
-    route.update()
-
-    assert_equal(route.distance(), 58_645)
-    assert_equal(str(route), "L1 U1 L3 U3 L2 U2 L0 U0")
-
-
-def test_relocate_shipment_fixed_cost(small_shipments):
-    """
-    Tests that relocating a shipment accounts for fixed cost if it leaves the
-    route empty.
-    """
-    veh_type = small_shipments.vehicle_type(0).replace(fixed_cost=10_000)
-    data = small_shipments.replace(vehicle_types=[veh_type])
-
-    route1 = make_search_route(data, ["L0", "U0"])
-    route2 = make_search_route(data, ["L3", "U3"])
-    assert_equal(route1.distance() + route2.distance(), 29_265)
-
-    # Move results in 1_902 less distance, but also empties route1, which saves
-    # a fixed cost of 10_000. So delta is 11_902.
-    op = Exchange20(data)
-    cost_eval = CostEvaluator([0], 0, 0)
-    assert_equal(op.evaluate(route1[1], route2[2], cost_eval), (-11_902, True))
-
-    op.apply(route1[1], route2[2])
-    route1.update()
-    route2.update()
-
-    # route1 is now empty, and route2 has 1_902 less distance than the two
-    # routes had previously.
-    assert_equal(route1.distance(), 0)
-    assert_equal(route2.distance(), 29_265 - 1_902)
-    assert_equal(str(route1), "")
-    assert_equal(str(route2), "L3 U3 L0 U0")


### PR DESCRIPTION
This PR is part of #1098.

Average over 6 seeds.

### 1-minute gaps

| Li size | be31b1359 | 63cb4ba4b |
|---:|---:|---:|
| 200 | 0.13% +/- 0.04% | 0.13% +/- 0.03% |
| 400 | 1.00% +/- 0.15% | 0.92% +/- 0.08% |
| 600 | 2.40% +/- 0.15% | 2.36% +/- 0.13% |
| 800 | 4.10% +/- 0.14% | 4.06% +/- 0.11% |
| 1000 | 6.57% +/- 0.21% | 6.78% +/- 0.35% |

### 1-minute average iterations

| Li size | be31b1359 | 63cb4ba4b |
|---:|---:|---:|
| 200 | 23,212 +/- 299 | 23,968 +/- 499 |
| 400 | 19,378 +/- 1,306 | 20,093 +/- 802 |
| 600 | 16,894 +/- 782 | 17,171 +/- 377 |
| 800 | 15,666 +/- 170 | 15,252 +/- 424 |
| 1000 | 14,958 +/- 259 | 14,337 +/- 711 |

### 10-minute gaps

| Li size | be31b1359 | 63cb4ba4b |
|---:|---:|---:|
| 200 | 0.05% +/- 0.02% | 0.04% +/- 0.02% |
| 400 | 0.29% +/- 0.06% | 0.27% +/- 0.05% |
| 600 | 0.46% +/- 0.04% | 0.48% +/- 0.04% |
| 800 | 0.67% +/- 0.06% | 0.62% +/- 0.08% |
| 1000 | 1.03% +/- 0.06% | 1.06% +/- 0.07% |

### 10-minute average iterations

| Li size | be31b1359 | 63cb4ba4b |
|---:|---:|---:|
| 200 | 212,362 +/- 5,597 | 214,798 +/- 10,184 |
| 400 | 176,851 +/- 15,604 | 186,450 +/- 8,976 |
| 600 | 156,461 +/- 3,906 | 156,206 +/- 1,839 |
| 800 | 149,283 +/- 3,821 | 143,196 +/- 9,514 |
| 1000 | 142,412 +/- 1,807 | 137,815 +/- 2,355 |


<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.
- You must disclose the use of LLMs/generative AI if you used such tools to write code.

</details>
