### PR TITLE
Guard the delta cost check

### DIFF
--- a/pyvrp/cpp/search/LocalSearch.cpp
+++ b/pyvrp/cpp/search/LocalSearch.cpp
@@ -138,8 +138,9 @@ bool LocalSearch::applyUnaryOps(Route::Node *U,
             if (rU)
                 searchSpace_.markPromising(U);
 
-            [[maybe_unused]] auto const costBefore
-                = costEvaluator.penalisedCost(solution_);
+#ifndef NDEBUG
+            auto const costBefore = costEvaluator.penalisedCost(solution_);
+#endif
 
             op->apply(U);
             if (!rU)  // then U wasn't in the solution before, and the operator
@@ -150,13 +151,13 @@ bool LocalSearch::applyUnaryOps(Route::Node *U,
 
             update(rU, rU);
 
-            [[maybe_unused]] auto const costAfter
-                = costEvaluator.penalisedCost(solution_);
-
+#ifndef NDEBUG
+            auto const costAfter = costEvaluator.penalisedCost(solution_);
             // When there is an improving move, the delta cost evaluation must
             // be exact. The resulting cost is then the sum of the cost before
             // the move, plus the delta cost.
             assert(costAfter == costBefore + deltaCost);
+#endif
 
             return true;
         }
@@ -189,19 +190,20 @@ bool LocalSearch::applyBinaryOps(Route::Node *U,
                 searchSpace_.markPromising(U);
             searchSpace_.markPromising(V);
 
-            [[maybe_unused]] auto const costBefore
-                = costEvaluator.penalisedCost(solution_);
+#ifndef NDEBUG
+            auto const costBefore = costEvaluator.penalisedCost(solution_);
+#endif
 
             op->apply(U, V);
             update(rU, rV);
 
-            [[maybe_unused]] auto const costAfter
-                = costEvaluator.penalisedCost(solution_);
-
+#ifndef NDEBUG
+            auto const costAfter = costEvaluator.penalisedCost(solution_);
             // When there is an improving move, the delta cost evaluation must
             // be exact. The resulting cost is then the sum of the cost before
             // the move, plus the delta cost.
             assert(costAfter == costBefore + deltaCost);
+#endif
 
             return true;
         }


### PR DESCRIPTION
This PR adds debug guards around the delta cost assertions in local search. I always assumed that these assertions would be compiled away in release mode, but it doesn't seem to be the case. Since #1031, we've started evaluating the solution instead of the route, which results in a significant performance hit (about 10% on 1K instances, and >25% on 6K nodes). See benchmark below (1 seed, 60s).

| Benchmark | 5424078 iterations | 6529b8d96 iterations |
|---|---:|---:|
| CVRP | 82,549 | 88,963 |
| VRPTW | 51,499 | 57,577 |


<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.
- You must disclose the use of LLMs/generative AI if you used such tools to write code.

</details>
