### PR TITLE
Always apply empty route moves

### DIFF
--- a/pyvrp/cpp/search/LocalSearch.cpp
+++ b/pyvrp/cpp/search/LocalSearch.cpp
@@ -105,7 +105,7 @@ void LocalSearch::search(CostEvaluator const &costEvaluator)
             // Moves involving empty routes are not tested initially to avoid
             // using too many routes, but we will try it if we have not been
             // able to insert U yet (perhaps the solution is empty?).
-            if (step > 0 || !U->route())
+            if (step >= 0 || !U->route())
                 applyEmptyRouteMoves(U, costEvaluator);
         }
     }

--- a/pyvrp/cpp/search/LocalSearch.cpp
+++ b/pyvrp/cpp/search/LocalSearch.cpp
@@ -57,7 +57,7 @@ void LocalSearch::search(CostEvaluator const &costEvaluator)
         return;
 
     searchCompleted_ = false;
-    for (int step = 0; !searchCompleted_; ++step)
+    for ([[maybe_unused]] int step = 0; !searchCompleted_; ++step)
     {
         PYVRP_DEBUG("pyvrp.search", "Entering search loop (step={}).", step);
         searchCompleted_ = true;
@@ -102,11 +102,7 @@ void LocalSearch::search(CostEvaluator const &costEvaluator)
                 }
             }
 
-            // Moves involving empty routes are not tested initially to avoid
-            // using too many routes, but we will try it if we have not been
-            // able to insert U yet (perhaps the solution is empty?).
-            if (step >= 0 || !U->route())
-                applyEmptyRouteMoves(U, costEvaluator);
+            applyEmptyRouteMoves(U, costEvaluator);
         }
     }
 }


### PR DESCRIPTION
This PR removes the first-step guard on empty route moves. We inherited this from HGS, where it actually had a lot of benefits. I remember benchmarking this a long time ago. But with ILS this is no longer needed, so we can just always apply these empty route moves.

Five-seed comparison 7c83f4377 (main) against 0ca4c5875 (always):

| Benchmark | 1m main | 1m always | 10m main | 10m always |
|---|---:|---:|---:|---:|
| CVRP | 0.57% | 0.57% | 0.32% | 0.31% |
| VRPTW | 2.01% | 2.04% | 1.02% | 1.05% |
| PCVRPTW | 0.72% | 0.74% | 0.41% | 0.41% |
| MDVRPTW | 2.34% | 2.37% | 1.20% | 1.18% |
| VRPB | 1.21% | 1.22% | 0.75% | 0.76% |
| HFVRP | 1.05% | 1.03% | 0.53% | 0.49% |
| MTVRPTWR | 1.27% | 1.27% | 0.44% | 0.45% |
| Li1000 PDPTW | 4.37% | 4.24% | 0.81% | 0.79% |
| GVRP + ARP | 1.01% | 1.05% | 0.41% | 0.44% |



- [ ] Closes #xxxx.
- [ ] Adds and passes relevant tests.
- [ ] Has well-formatted code and documentation.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.
- You must disclose the use of LLMs/generative AI if you used such tools to write code.

</details>
