### PR TITLE
Respect group mutually exclusivity in perturbation

### DIFF
--- a/pyvrp/cpp/search/LocalSearch.cpp
+++ b/pyvrp/cpp/search/LocalSearch.cpp
@@ -36,7 +36,8 @@ pyvrp::Solution LocalSearch::operator()(pyvrp::Solution const &solution,
     if (exhaustive)
         searchSpace_.markAllPromising();
     else
-        perturbationManager_.perturb(solution_, searchSpace_, costEvaluator);
+        perturbationManager_.perturb(
+            data, solution_, searchSpace_, costEvaluator);
 
     ensureStructuralFeasibility(costEvaluator);
     search(costEvaluator);

--- a/pyvrp/cpp/search/LocalSearch.cpp
+++ b/pyvrp/cpp/search/LocalSearch.cpp
@@ -270,16 +270,6 @@ void LocalSearch::ensureStructuralFeasibility(
                     update(node.route(), node.route());
                     searchSpace_.markPromising(&node);
                     groupCount[idx]++;
-                    continue;
-                }
-
-                if (node.route() && groupCount[idx] > 1)  // must remove
-                {
-                    searchSpace_.markPromising(&node);
-                    auto *route = node.route();
-                    route->remove(node.pos());
-                    update(route, route);
-                    groupCount[idx]--;
                 }
             }
 

--- a/pyvrp/cpp/search/LocalSearch.cpp
+++ b/pyvrp/cpp/search/LocalSearch.cpp
@@ -36,8 +36,7 @@ pyvrp::Solution LocalSearch::operator()(pyvrp::Solution const &solution,
     if (exhaustive)
         searchSpace_.markAllPromising();
     else
-        perturbationManager_.perturb(
-            data, solution_, searchSpace_, costEvaluator);
+        perturbationManager_.perturb(solution_, searchSpace_, costEvaluator);
 
     ensureStructuralFeasibility(costEvaluator);
     search(costEvaluator);

--- a/pyvrp/cpp/search/LocalSearch.h
+++ b/pyvrp/cpp/search/LocalSearch.h
@@ -53,8 +53,7 @@ class LocalSearch
                               CostEvaluator const &costEvaluator);
 
     // Ensures structural feasibility of the loaded solution. The local search
-    // will insert required clients, shipments and groups if they are missing,
-    // and remove group duplicates if needed.
+    // will insert required clients, shipments and groups if they are missing.
     void ensureStructuralFeasibility(CostEvaluator const &costEvaluator);
 
     // Updates solution state after an improving local search move.

--- a/pyvrp/cpp/search/PerturbationManager.cpp
+++ b/pyvrp/cpp/search/PerturbationManager.cpp
@@ -136,7 +136,7 @@ void PerturbationManager::perturb(ProblemData const &data,
     // We perturb the local neighbourhood of randomly ordered activities,
     // grouped by their current route (unplanned by their nullptr route).
     // Planned activities are removed and unplanned ones are inserted. Only
-    // successful removals and insertions count as perturbation..
+    // successful removals and insertions count as perturbation.
     for (size_t movesLeft = numPerturbations_;
          auto const &uActivity : searchSpace.activityOrder())
     {

--- a/pyvrp/cpp/search/PerturbationManager.cpp
+++ b/pyvrp/cpp/search/PerturbationManager.cpp
@@ -159,6 +159,9 @@ void PerturbationManager::perturb(Solution &solution,
         for (auto &[route, nodes] : groups)
             for (auto *node : nodes)
             {
+                if (route && !node->route())  // already removed by an earlier
+                    continue;                 // group swap
+
                 if (route)
                     remove(node);
                 else

--- a/pyvrp/cpp/search/PerturbationManager.cpp
+++ b/pyvrp/cpp/search/PerturbationManager.cpp
@@ -48,42 +48,6 @@ void PerturbationManager::perturb(Solution &solution,
     // set of promising nodes for further (local search) improvement.
     searchSpace.unmarkAllPromising();
 
-    auto const insert = [&](Route::Node *node)  // insert and mark promising
-    {
-        assert(node->isClient() || node->isPickup());
-        assert(!node->route());
-
-        if (node->isClient())
-        {
-            // We cannot insert a client whose mutually exclusive group already
-            // has another member in the solution.
-            auto const &client = data_.client(node->idx());
-            if (client.group)
-                for (auto const member : data_.group(*client.group))
-                    if (solution.clients[member].route())
-                        return false;
-
-            solution.insert(node, searchSpace, costEvaluator, true);
-            node->route()->update();
-            searchSpace.markPromising(node);
-        }
-        else
-        {
-            auto *pickup = node;
-            auto *delivery = node + 1;
-            solution.insert(pickup, delivery, searchSpace, costEvaluator, true);
-
-            auto *route = pickup->route();
-            assert(delivery->route() == route);
-
-            route->update();
-            searchSpace.markPromising(pickup);
-            searchSpace.markPromising(delivery);
-        }
-
-        return true;
-    };
-
     auto const remove = [&](Route::Node *node)  // remove and mark promising
     {
         assert(node->isClient() || node->isPickup());
@@ -104,6 +68,43 @@ void PerturbationManager::perturb(Solution &solution,
         }
 
         route->update();
+    };
+
+    auto const insert = [&](Route::Node *node)  // insert and mark promising
+    {
+        assert(node->isClient() || node->isPickup());
+        assert(!node->route());
+
+        if (node->isClient())
+        {
+            // Groups are mutually exclusive, so we first remove any planned
+            // member of the client's group before inserting the client.
+            auto const &client = data_.client(node->idx());
+            if (client.group)
+                for (auto const member : data_.group(*client.group))
+                    if (auto *other = &solution.clients[member]; other->route())
+                    {
+                        remove(other);
+                        break;
+                    }
+
+            solution.insert(node, searchSpace, costEvaluator, true);
+            node->route()->update();
+            searchSpace.markPromising(node);
+        }
+        else
+        {
+            auto *pickup = node;
+            auto *delivery = node + 1;
+            solution.insert(pickup, delivery, searchSpace, costEvaluator, true);
+
+            auto *route = pickup->route();
+            assert(delivery->route() == route);
+
+            route->update();
+            searchSpace.markPromising(pickup);
+            searchSpace.markPromising(delivery);
+        }
     };
 
     DynamicBitset perturbed
@@ -157,8 +158,8 @@ void PerturbationManager::perturb(Solution &solution,
             {
                 if (route)
                     remove(node);
-                else if (!insert(node))
-                    continue;
+                else
+                    insert(node);
 
                 movesLeft--;
                 if (!movesLeft)

--- a/pyvrp/cpp/search/PerturbationManager.cpp
+++ b/pyvrp/cpp/search/PerturbationManager.cpp
@@ -77,10 +77,10 @@ void PerturbationManager::perturb(Solution &solution,
 
         if (node->isClient())
         {
-            // Groups are mutually exclusive, so we first remove any planned
-            // member of the client's group before inserting the client.
             auto const &client = data_.client(node->idx());
             if (client.group)
+                // If another group member is already planned, we first remove
+                // it before inserting the client.
                 for (auto const member : data_.group(*client.group))
                 {
                     auto *other = &solution.clients[member];

--- a/pyvrp/cpp/search/PerturbationManager.cpp
+++ b/pyvrp/cpp/search/PerturbationManager.cpp
@@ -20,8 +20,9 @@ PerturbationParams::PerturbationParams(size_t minPerturbations,
             "min_perturbations must be <= max_perturbations.");
 }
 
-PerturbationManager::PerturbationManager(PerturbationParams params)
-    : params_(params), numPerturbations_(params_.minPerturbations)
+PerturbationManager::PerturbationManager(ProblemData const &data,
+                                         PerturbationParams params)
+    : data_(data), params_(params), numPerturbations_(params_.minPerturbations)
 {
 }
 
@@ -36,8 +37,7 @@ void PerturbationManager::shuffle(RandomNumberGenerator &rng)
     numPerturbations_ = params_.minPerturbations + rng.randint(range + 1);
 }
 
-void PerturbationManager::perturb(ProblemData const &data,
-                                  Solution &solution,
+void PerturbationManager::perturb(Solution &solution,
                                   SearchSpace &searchSpace,
                                   CostEvaluator const &costEvaluator) const
 {
@@ -57,8 +57,8 @@ void PerturbationManager::perturb(ProblemData const &data,
         {
             // We cannot insert a client whose mutually exclusive group already
             // has another member in the solution.
-            if (auto const &client = data.client(node->idx()); client.group)
-                for (auto const member : data.group(*client.group))
+            if (auto const &client = data_.client(node->idx()); client.group)
+                for (auto const member : data_.group(*client.group))
                     if (solution.clients[member].route())
                         return false;
 

--- a/pyvrp/cpp/search/PerturbationManager.cpp
+++ b/pyvrp/cpp/search/PerturbationManager.cpp
@@ -47,6 +47,7 @@ void PerturbationManager::perturb(Solution &solution,
     // set of promising nodes for further (local search) improvement.
     searchSpace.unmarkAllPromising();
 
+    auto const &data = solution.data();
     auto const insert = [&](Route::Node *node)  // insert and mark promising
     {
         assert(node->isClient() || node->isPickup());
@@ -54,6 +55,13 @@ void PerturbationManager::perturb(Solution &solution,
 
         if (node->isClient())
         {
+            // We cannot insert a client whose mutually exclusive group already
+            // has another member in the solution.
+            if (auto const &client = data.client(node->idx()); client.group)
+                for (auto const member : data.group(*client.group))
+                    if (solution.clients[member].route())
+                        return false;
+
             solution.insert(node, searchSpace, costEvaluator, true);
             node->route()->update();
             searchSpace.markPromising(node);
@@ -71,6 +79,8 @@ void PerturbationManager::perturb(Solution &solution,
             searchSpace.markPromising(pickup);
             searchSpace.markPromising(delivery);
         }
+
+        return true;
     };
 
     auto const remove = [&](Route::Node *node)  // remove and mark promising
@@ -125,7 +135,8 @@ void PerturbationManager::perturb(Solution &solution,
 
     // We perturb the local neighbourhood of randomly ordered activities,
     // grouped by their current route (unplanned by their nullptr route).
-    // Planned activities are removed and unplanned ones are inserted.
+    // Planned activities are removed and unplanned ones are inserted. Only
+    // successful removals and insertions count as perturbation..
     for (size_t movesLeft = numPerturbations_;
          auto const &uActivity : searchSpace.activityOrder())
     {
@@ -145,8 +156,8 @@ void PerturbationManager::perturb(Solution &solution,
             {
                 if (route)
                     remove(node);
-                else
-                    insert(node);
+                else if (!insert(node))
+                    continue;
 
                 movesLeft--;
                 if (!movesLeft)

--- a/pyvrp/cpp/search/PerturbationManager.cpp
+++ b/pyvrp/cpp/search/PerturbationManager.cpp
@@ -82,11 +82,14 @@ void PerturbationManager::perturb(Solution &solution,
             auto const &client = data_.client(node->idx());
             if (client.group)
                 for (auto const member : data_.group(*client.group))
-                    if (auto *other = &solution.clients[member]; other->route())
+                {
+                    auto *other = &solution.clients[member];
+                    if (other->route())
                     {
                         remove(other);
                         break;
                     }
+                }
 
             solution.insert(node, searchSpace, costEvaluator, true);
             node->route()->update();

--- a/pyvrp/cpp/search/PerturbationManager.cpp
+++ b/pyvrp/cpp/search/PerturbationManager.cpp
@@ -57,7 +57,8 @@ void PerturbationManager::perturb(Solution &solution,
         {
             // We cannot insert a client whose mutually exclusive group already
             // has another member in the solution.
-            if (auto const &client = data_.client(node->idx()); client.group)
+            auto const &client = data_.client(node->idx());
+            if (client.group)
                 for (auto const member : data_.group(*client.group))
                     if (solution.clients[member].route())
                         return false;

--- a/pyvrp/cpp/search/PerturbationManager.cpp
+++ b/pyvrp/cpp/search/PerturbationManager.cpp
@@ -36,7 +36,8 @@ void PerturbationManager::shuffle(RandomNumberGenerator &rng)
     numPerturbations_ = params_.minPerturbations + rng.randint(range + 1);
 }
 
-void PerturbationManager::perturb(Solution &solution,
+void PerturbationManager::perturb(ProblemData const &data,
+                                  Solution &solution,
                                   SearchSpace &searchSpace,
                                   CostEvaluator const &costEvaluator) const
 {
@@ -47,7 +48,6 @@ void PerturbationManager::perturb(Solution &solution,
     // set of promising nodes for further (local search) improvement.
     searchSpace.unmarkAllPromising();
 
-    auto const &data = solution.data();
     auto const insert = [&](Route::Node *node)  // insert and mark promising
     {
         assert(node->isClient() || node->isPickup());

--- a/pyvrp/cpp/search/PerturbationManager.cpp
+++ b/pyvrp/cpp/search/PerturbationManager.cpp
@@ -140,8 +140,7 @@ void PerturbationManager::perturb(Solution &solution,
 
     // We perturb the local neighbourhood of randomly ordered activities,
     // grouped by their current route (unplanned by their nullptr route).
-    // Planned activities are removed and unplanned ones are inserted. Only
-    // successful removals and insertions count as perturbation.
+    // Planned activities are removed and unplanned ones are inserted.
     for (size_t movesLeft = numPerturbations_;
          auto const &uActivity : searchSpace.activityOrder())
     {
@@ -160,7 +159,7 @@ void PerturbationManager::perturb(Solution &solution,
             for (auto *node : nodes)
             {
                 if (route && !node->route())  // already removed by an earlier
-                    continue;                 // group swap
+                    continue;                 // mutually exclusive group swap
 
                 if (route)
                     remove(node);

--- a/pyvrp/cpp/search/PerturbationManager.h
+++ b/pyvrp/cpp/search/PerturbationManager.h
@@ -2,6 +2,7 @@
 #define PYVRP_SEARCH_PERTURBATIONMANAGER_H
 
 #include "CostEvaluator.h"
+#include "ProblemData.h"
 #include "RandomNumberGenerator.h"
 #include "SearchSpace.h"
 #include "Solution.h"
@@ -71,6 +72,8 @@ public:
      *
      * Parameters
      * ----------
+     * data
+     *     Problem data instance.
      * solution
      *     Solution to perturb. Perturbation happens in place.
      * search_space
@@ -78,7 +81,8 @@ public:
      * cost_evaluator
      *     Evaluator to use for insertions.
      */
-    void perturb(Solution &solution,
+    void perturb(ProblemData const &data,
+                 Solution &solution,
                  SearchSpace &searchSpace,
                  CostEvaluator const &costEvaluator) const;
 };

--- a/pyvrp/cpp/search/PerturbationManager.h
+++ b/pyvrp/cpp/search/PerturbationManager.h
@@ -35,7 +35,7 @@ struct PerturbationParams
 };
 
 /**
- * PerturbationManager(params: PerturbationParams)
+ * PerturbationManager(data: ProblemData, params: PerturbationParams)
  *
  * Handles perturbation during the search. In each iteration, it applies
  * :meth:`~num_perturbations` perturbations that strengthen (resp., weaken)
@@ -44,16 +44,20 @@ struct PerturbationParams
  *
  * Parameters
  * ----------
+ * data
+ *     Problem data instance.
  * params
  *     Perturbation parameters for this manager.
  */
 class PerturbationManager
 {
+    ProblemData const &data_;
     PerturbationParams const params_;  // owned by us
     size_t numPerturbations_;
 
 public:
-    PerturbationManager(PerturbationParams params = PerturbationParams());
+    PerturbationManager(ProblemData const &data,
+                        PerturbationParams params = PerturbationParams());
 
     /**
      * Number of perturbations to apply.
@@ -72,8 +76,6 @@ public:
      *
      * Parameters
      * ----------
-     * data
-     *     Problem data instance.
      * solution
      *     Solution to perturb. Perturbation happens in place.
      * search_space
@@ -81,8 +83,7 @@ public:
      * cost_evaluator
      *     Evaluator to use for insertions.
      */
-    void perturb(ProblemData const &data,
-                 Solution &solution,
+    void perturb(Solution &solution,
                  SearchSpace &searchSpace,
                  CostEvaluator const &costEvaluator) const;
 };

--- a/pyvrp/cpp/search/Solution.cpp
+++ b/pyvrp/cpp/search/Solution.cpp
@@ -239,7 +239,7 @@ bool Solution::insert(Route::Node *U,
                       CostEvaluator const &costEvaluator,
                       bool required)
 {
-    assert(U->isClient());
+    assert(U->isClient() && !U->route());
 
     Route::Node *UAfter = routes[0][0];  // fallback option
     auto bestCost = insertCost(U, UAfter, data_, costEvaluator);
@@ -427,3 +427,5 @@ pyvrp::Cost pyvrp::CostEvaluator::penalisedCost(
 
     return cost;
 }
+
+pyvrp::ProblemData const &Solution::data() const { return data_; }

--- a/pyvrp/cpp/search/Solution.cpp
+++ b/pyvrp/cpp/search/Solution.cpp
@@ -427,5 +427,3 @@ pyvrp::Cost pyvrp::CostEvaluator::penalisedCost(
 
     return cost;
 }
-
-pyvrp::ProblemData const &Solution::data() const { return data_; }

--- a/pyvrp/cpp/search/Solution.h
+++ b/pyvrp/cpp/search/Solution.h
@@ -45,6 +45,9 @@ public:
 
     Solution(ProblemData const &data);
 
+    // The problem data instance this solution is defined on.
+    ProblemData const &data() const;
+
     // Converts the given solution into our node-based representation.
     void load(pyvrp::Solution const &solution);
 

--- a/pyvrp/cpp/search/Solution.h
+++ b/pyvrp/cpp/search/Solution.h
@@ -45,9 +45,6 @@ public:
 
     Solution(ProblemData const &data);
 
-    // The problem data instance this solution is defined on.
-    ProblemData const &data() const;
-
     // Converts the given solution into our node-based representation.
     void load(pyvrp::Solution const &solution);
 

--- a/pyvrp/cpp/search/bindings.cpp
+++ b/pyvrp/cpp/search/bindings.cpp
@@ -548,8 +548,10 @@ PYBIND11_MODULE(_search, m)
 
     py::class_<PerturbationManager>(
         m, "PerturbationManager", DOC(pyvrp, search, PerturbationManager))
-        .def(py::init<PerturbationParams>(),
-             py::arg("params") = PerturbationParams())
+        .def(py::init<pyvrp::ProblemData const &, PerturbationParams>(),
+             py::arg("data"),
+             py::arg("params") = PerturbationParams(),
+             py::keep_alive<1, 2>())  // keep data alive
         .def("num_perturbations",
              &PerturbationManager::numPerturbations,
              DOC(pyvrp, search, PerturbationManager, numPerturbations))
@@ -559,7 +561,6 @@ PYBIND11_MODULE(_search, m)
              DOC(pyvrp, search, PerturbationManager, shuffle))
         .def("perturb",
              &PerturbationManager::perturb,
-             py::arg("data"),
              py::arg("solution"),
              py::arg("search_space"),
              py::arg("cost_evaluator"),
@@ -578,7 +579,7 @@ PYBIND11_MODULE(_search, m)
                       PerturbationManager &>(),
              py::arg("data"),
              py::arg("neighbours"),
-             py::arg("perturbation_manager") = PerturbationManager(),
+             py::arg("perturbation_manager"),
              py::keep_alive<1, 2>(),  // keep data alive until LS is freed
              py::keep_alive<1, 4>())  // also keep perturbation_manager alive
         .def_property("neighbours",

--- a/pyvrp/cpp/search/bindings.cpp
+++ b/pyvrp/cpp/search/bindings.cpp
@@ -559,6 +559,7 @@ PYBIND11_MODULE(_search, m)
              DOC(pyvrp, search, PerturbationManager, shuffle))
         .def("perturb",
              &PerturbationManager::perturb,
+             py::arg("data"),
              py::arg("solution"),
              py::arg("search_space"),
              py::arg("cost_evaluator"),

--- a/pyvrp/search/LocalSearch.py
+++ b/pyvrp/search/LocalSearch.py
@@ -31,6 +31,7 @@ class LocalSearch:
         granular neighbourhood.
     perturbation_manager
         Perturbation manager that handles perturbation during each invocation.
+        Uses a default perturbation manager if not provided.
     """
 
     def __init__(
@@ -38,8 +39,11 @@ class LocalSearch:
         data: ProblemData,
         rng: RandomNumberGenerator,
         neighbours: dict[Activity, list[Activity]],
-        perturbation_manager: PerturbationManager = PerturbationManager(),
+        perturbation_manager: PerturbationManager | None = None,
     ):
+        if perturbation_manager is None:
+            perturbation_manager = PerturbationManager(data)
+
         self._ls = _LocalSearch(data, neighbours, perturbation_manager)
         self._rng = rng
 

--- a/pyvrp/search/_search.pyi
+++ b/pyvrp/search/_search.pyi
@@ -107,13 +107,13 @@ class PerturbationParams:
 class PerturbationManager:
     def __init__(
         self,
+        data: ProblemData,
         params: PerturbationParams = ...,
     ) -> None: ...
     def num_perturbations(self) -> int: ...
     def shuffle(self, rng: RandomNumberGenerator) -> None: ...
     def perturb(
         self,
-        data: ProblemData,
         solution: Solution,
         search_space: SearchSpace,
         cost_evaluator: CostEvaluator,
@@ -129,7 +129,7 @@ class LocalSearch:
         self,
         data: ProblemData,
         neighbours: dict[Activity, list[Activity]],
-        perturbation_manager: PerturbationManager = ...,
+        perturbation_manager: PerturbationManager,
     ) -> None: ...
     def add_operator(self, op: UnaryOperator | BinaryOperator) -> None: ...
     @property

--- a/pyvrp/search/_search.pyi
+++ b/pyvrp/search/_search.pyi
@@ -113,6 +113,7 @@ class PerturbationManager:
     def shuffle(self, rng: RandomNumberGenerator) -> None: ...
     def perturb(
         self,
+        data: ProblemData,
         solution: Solution,
         search_space: SearchSpace,
         cost_evaluator: CostEvaluator,

--- a/pyvrp/solve.py
+++ b/pyvrp/solve.py
@@ -162,7 +162,7 @@ def solve(
     """
     rng = RandomNumberGenerator(seed=seed)
     neighbours = compute_neighbours(data, params.neighbourhood)
-    perturbation = PerturbationManager(params.perturbation)
+    perturbation = PerturbationManager(data, params.perturbation)
     ls = LocalSearch(data, rng, neighbours, perturbation)
 
     for op in params.operators:

--- a/tests/search/test_LocalSearch.py
+++ b/tests/search/test_LocalSearch.py
@@ -157,7 +157,8 @@ def test_cpp_shuffle_results_in_different_solution(rc208):
     """
     rng = RandomNumberGenerator(seed=42)
 
-    ls = cpp_LocalSearch(rc208, compute_neighbours(rc208))
+    perturbation = PerturbationManager(rc208)
+    ls = cpp_LocalSearch(rc208, compute_neighbours(rc208), perturbation)
     ls.add_operator(Relocate1(rc208))
     ls.add_operator(Swap11(rc208))
 
@@ -187,7 +188,7 @@ def test_vehicle_types_are_preserved_for_locally_optimal_solutions(rc208):
     rng = RandomNumberGenerator(seed=42)
     neighbours = compute_neighbours(rc208)
 
-    ls = cpp_LocalSearch(rc208, neighbours)
+    ls = cpp_LocalSearch(rc208, neighbours, PerturbationManager(rc208))
     ls.add_operator(Relocate1(rc208))
     ls.add_operator(Swap11(rc208))
 
@@ -204,7 +205,7 @@ def test_vehicle_types_are_preserved_for_locally_optimal_solutions(rc208):
         ]
     )
 
-    ls = cpp_LocalSearch(data, neighbours)
+    ls = cpp_LocalSearch(data, neighbours, PerturbationManager(data))
     ls.add_operator(Relocate1(data))
     ls.add_operator(Swap11(data))
 
@@ -235,7 +236,8 @@ def test_bugfix_vehicle_type_offsets(ok_small):
         ]
     )
 
-    ls = cpp_LocalSearch(data, compute_neighbours(data))
+    perturbation = PerturbationManager(data)
+    ls = cpp_LocalSearch(data, compute_neighbours(data), perturbation)
     ls.add_operator(Relocate1(data))
 
     cost_evaluator = CostEvaluator([1], 1, 0)
@@ -262,7 +264,7 @@ def test_no_op_results_in_same_solution(ok_small):
         ok_small,
         rng,
         compute_neighbours(ok_small),
-        PerturbationManager(PerturbationParams(0, 0)),  # disable perturbation
+        PerturbationManager(ok_small, PerturbationParams(0, 0)),  # disabled
     )
 
     cost_eval = CostEvaluator([1], 1, 0)
@@ -321,7 +323,7 @@ def test_swap_if_improving_mutually_exclusive_group(
     data = ok_small_mutually_exclusive_groups
     rng = RandomNumberGenerator(seed=42)
     neighbours = compute_neighbours(data)
-    perturbation = PerturbationManager(PerturbationParams(0, 0))
+    perturbation = PerturbationManager(data, PerturbationParams(0, 0))
 
     ls = LocalSearch(data, rng, neighbours, perturbation)
     ls.add_operator(ReplaceGroup(data))
@@ -349,7 +351,7 @@ def test_no_op_multi_trip_instance(ok_small_multiple_trips):
         data,
         rng,
         neighbours,
-        PerturbationManager(PerturbationParams(0, 0)),  # disable perturbation
+        PerturbationManager(data, PerturbationParams(0, 0)),  # disabled
     )
 
     activities = map(Activity, ["C0", "C1", "D0", "C2", "C3"])
@@ -396,7 +398,7 @@ def test_local_search_removes_useless_reload_depots(ok_small_multiple_trips):
         data,
         rng,
         compute_neighbours(data),
-        PerturbationManager(PerturbationParams(0, 0)),  # disable perturbation
+        PerturbationManager(data, PerturbationParams(0, 0)),  # disabled
     )
     ls.add_operator(RemoveAdjacentDepot(data))
 
@@ -425,7 +427,7 @@ def test_search_statistics(ok_small):
         ok_small,
         rng,
         compute_neighbours(ok_small),
-        PerturbationManager(PerturbationParams(0, 0)),  # disable perturbation
+        PerturbationManager(ok_small, PerturbationParams(0, 0)),  # disabled
     )
 
     op = Relocate1(ok_small)
@@ -508,7 +510,7 @@ def test_inserts_required_missing(instance, exp_clients: set[int], request):
     """
     data = request.getfixturevalue(instance)
     rng = RandomNumberGenerator(seed=42)
-    perturbation = PerturbationManager(PerturbationParams(1, 1))
+    perturbation = PerturbationManager(data, PerturbationParams(1, 1))
     ls = LocalSearch(data, rng, compute_neighbours(data), perturbation)
     ls.add_operator(Relocate1(data))
 

--- a/tests/search/test_PerturbationManager.py
+++ b/tests/search/test_PerturbationManager.py
@@ -89,7 +89,7 @@ def test_perturb_inserts_clients(ok_small):
     # Perturb the empty solution exactly four times. That means we should
     # insert all missing clients.
     perturbation = PerturbationManager(PerturbationParams(4, 4))
-    perturbation.perturb(sol, search_space, cost_eval)
+    perturbation.perturb(ok_small, sol, search_space, cost_eval)
 
     perturbed = sol.unload()
     assert_equal(perturbed.num_clients(), 4)
@@ -108,7 +108,7 @@ def test_perturb_removes_clients(ok_small):
     # Perturb the complete solution four times. That means we should remove all
     # clients, and the perturbed solution should be empty.
     perturbation = PerturbationManager(PerturbationParams(4, 4))
-    perturbation.perturb(sol, search_space, cost_eval)
+    perturbation.perturb(ok_small, sol, search_space, cost_eval)
 
     perturbed = sol.unload()
     assert_equal(perturbed.num_clients(), 0)
@@ -142,7 +142,7 @@ def test_perturb_groups_neighbours_by_route(small_shipments):
     cost_eval = CostEvaluator([1], 1, 0)
 
     perturbation = PerturbationManager(PerturbationParams(3, 3))
-    perturbation.perturb(sol, search_space, cost_eval)
+    perturbation.perturb(data, sol, search_space, cost_eval)
 
     # The first two perturbations remove shipments 0 and 1 from the same
     # route. The third inserts shipment 2, exhausting the budget before
@@ -179,7 +179,7 @@ def test_perturb_inserts_into_new_routes(ok_small):
     # ensures that the empty routes are always better. We should thus end up
     # with three routes in the perturbed solution.
     perturbation = PerturbationManager(PerturbationParams(3, 3))
-    perturbation.perturb(sol, search_space, cost_eval)
+    perturbation.perturb(data, sol, search_space, cost_eval)
 
     perturbed = sol.unload()
     assert_equal(perturbed.num_routes(), 3)
@@ -209,7 +209,7 @@ def test_perturb_shipments_remove(small_shipments):
     perturbation = PerturbationManager()
     assert_equal(perturbation.num_perturbations(), 1)
 
-    perturbation.perturb(sol, search_space, cost_eval)
+    perturbation.perturb(data, sol, search_space, cost_eval)
     perturbed = sol.unload()
 
     assert_(not perturbed.is_complete())
@@ -234,7 +234,7 @@ def test_perturb_shipments_insert(small_shipments):
     neighbours = compute_neighbours(small_shipments)
     search_space = SearchSpace(small_shipments, neighbours)
     cost_eval = CostEvaluator([1], 1, 0)
-    perturbation.perturb(sol, search_space, cost_eval)
+    perturbation.perturb(small_shipments, sol, search_space, cost_eval)
 
     # We should have inserted the first missing shipment into the solution.
     # Since nothing was shuffled, that first missing shipment is L0/U0.
@@ -261,7 +261,7 @@ def test_perturb_shipment_empty_route(small_shipments):
     neighbours = compute_neighbours(small_shipments)
     search_space = SearchSpace(small_shipments, neighbours)
     cost_eval = CostEvaluator([1], 1, 0)
-    perturbation.perturb(sol, search_space, cost_eval)
+    perturbation.perturb(small_shipments, sol, search_space, cost_eval)
 
     # And thus, after perturbation we expect a complete solution.
     perturbed = sol.unload()
@@ -292,7 +292,7 @@ def test_perturb_does_not_insert_group_duplicates(
     # because client 2 is in the solution. The single perturbation should
     # instead remove client 2.
     perturbation = PerturbationManager(PerturbationParams(1, 1))
-    perturbation.perturb(sol, search_space, cost_eval)
+    perturbation.perturb(data, sol, search_space, cost_eval)
 
     perturbed = sol.unload()
     assert_equal(perturbed.num_clients(), 1)

--- a/tests/search/test_PerturbationManager.py
+++ b/tests/search/test_PerturbationManager.py
@@ -267,3 +267,34 @@ def test_perturb_shipment_empty_route(small_shipments):
     perturbed = sol.unload()
     assert_equal(perturbed.num_shipments(), 4)
     assert_(perturbed.is_complete())
+
+
+def test_perturb_does_not_insert_group_duplicates(
+    ok_small_mutually_exclusive_groups,
+):
+    """
+    Tests that perturbation does not insert a client whose mutually exclusive
+    group already has a member in the solution, and that such skipped inserts
+    do not consume the perturbation budget.
+    """
+    data = ok_small_mutually_exclusive_groups
+
+    # Clients 0, 1, and 2 are in a mutually exclusive group. Client 2 is in
+    # the solution, clients 0 and 1 are not.
+    sol = Solution(data)
+    sol.load(pyvrp.Solution(data, [[2, 3]]))
+
+    neighbours = {Activity(f"C{idx}"): [] for idx in range(data.num_clients)}
+    search_space = SearchSpace(data, neighbours)
+    cost_eval = CostEvaluator([20], 6, 0)
+
+    # Perturbation considers clients 0 and 1 first, but cannot insert them
+    # because client 2 is in the solution. The single perturbation should
+    # instead remove client 2.
+    perturbation = PerturbationManager(PerturbationParams(1, 1))
+    perturbation.perturb(sol, search_space, cost_eval)
+
+    perturbed = sol.unload()
+    assert_equal(perturbed.num_clients(), 1)
+    visits = [act.idx for act in perturbed.routes()[0] if act.is_client()]
+    assert_equal(visits, [3])

--- a/tests/search/test_PerturbationManager.py
+++ b/tests/search/test_PerturbationManager.py
@@ -275,7 +275,7 @@ def test_perturb_does_not_insert_group_duplicates(
     """
     Tests that perturbation does not insert a client whose mutually exclusive
     group already has a member in the solution, and that such skipped inserts
-    do not consume the perturbation budget.
+    do not count towards the perturbation budget.
     """
     data = ok_small_mutually_exclusive_groups
 
@@ -296,5 +296,5 @@ def test_perturb_does_not_insert_group_duplicates(
 
     perturbed = sol.unload()
     assert_equal(perturbed.num_clients(), 1)
-    visits = [act.idx for act in perturbed.routes()[0] if act.is_client()]
-    assert_equal(visits, [3])
+    assert_(Activity("C2") in perturbed.unplanned())
+    assert_(Activity("C3") not in perturbed.unplanned())

--- a/tests/search/test_PerturbationManager.py
+++ b/tests/search/test_PerturbationManager.py
@@ -33,12 +33,12 @@ def test_eq():
     assert_(params != 123)
 
 
-def test_shuffle():
+def test_shuffle(ok_small):
     """
     Tests shuffling and drawing random number of perturbations.
     """
     params = PerturbationParams(1, 10)
-    manager = PerturbationManager(params)
+    manager = PerturbationManager(ok_small, params)
 
     rng = RandomNumberGenerator(seed=42)
     for _ in range(10):  # all samples should be within bounds
@@ -46,18 +46,18 @@ def test_shuffle():
         assert_(1 <= manager.num_perturbations() <= 10)
 
     params = PerturbationParams(0, 0)
-    manager = PerturbationManager(params)
+    manager = PerturbationManager(ok_small, params)
     for _ in range(10):  # same, but now we can only draw one outcome: 0
         manager.shuffle(rng)
         assert_equal(manager.num_perturbations(), 0)
 
 
-def test_num_perturbations_randomness():
+def test_num_perturbations_randomness(ok_small):
     """
     Tests the bounds and randomness of repeated shuffles.
     """
     params = PerturbationParams(1, 10)
-    manager = PerturbationManager(params)
+    manager = PerturbationManager(ok_small, params)
 
     # Collect a large sample.
     rng = RandomNumberGenerator(seed=42)
@@ -88,8 +88,8 @@ def test_perturb_inserts_clients(ok_small):
 
     # Perturb the empty solution exactly four times. That means we should
     # insert all missing clients.
-    perturbation = PerturbationManager(PerturbationParams(4, 4))
-    perturbation.perturb(ok_small, sol, search_space, cost_eval)
+    perturbation = PerturbationManager(ok_small, PerturbationParams(4, 4))
+    perturbation.perturb(sol, search_space, cost_eval)
 
     perturbed = sol.unload()
     assert_equal(perturbed.num_clients(), 4)
@@ -107,8 +107,8 @@ def test_perturb_removes_clients(ok_small):
 
     # Perturb the complete solution four times. That means we should remove all
     # clients, and the perturbed solution should be empty.
-    perturbation = PerturbationManager(PerturbationParams(4, 4))
-    perturbation.perturb(ok_small, sol, search_space, cost_eval)
+    perturbation = PerturbationManager(ok_small, PerturbationParams(4, 4))
+    perturbation.perturb(sol, search_space, cost_eval)
 
     perturbed = sol.unload()
     assert_equal(perturbed.num_clients(), 0)
@@ -141,8 +141,8 @@ def test_perturb_groups_neighbours_by_route(small_shipments):
     search_space = SearchSpace(data, neighbours)
     cost_eval = CostEvaluator([1], 1, 0)
 
-    perturbation = PerturbationManager(PerturbationParams(3, 3))
-    perturbation.perturb(data, sol, search_space, cost_eval)
+    perturbation = PerturbationManager(data, PerturbationParams(3, 3))
+    perturbation.perturb(sol, search_space, cost_eval)
 
     # The first two perturbations remove shipments 0 and 1 from the same
     # route. The third inserts shipment 2, exhausting the budget before
@@ -178,8 +178,8 @@ def test_perturb_inserts_into_new_routes(ok_small):
     # the first route, which is a default). The large load violation penalty
     # ensures that the empty routes are always better. We should thus end up
     # with three routes in the perturbed solution.
-    perturbation = PerturbationManager(PerturbationParams(3, 3))
-    perturbation.perturb(data, sol, search_space, cost_eval)
+    perturbation = PerturbationManager(data, PerturbationParams(3, 3))
+    perturbation.perturb(sol, search_space, cost_eval)
 
     perturbed = sol.unload()
     assert_equal(perturbed.num_routes(), 3)
@@ -206,10 +206,10 @@ def test_perturb_shipments_remove(small_shipments):
     # The random solution is complete, so all we can do is remove shipments.
     # We should remove only one, because we haven't shuffled yet and we default
     # to min_perturbations in that case.
-    perturbation = PerturbationManager()
+    perturbation = PerturbationManager(data)
     assert_equal(perturbation.num_perturbations(), 1)
 
-    perturbation.perturb(data, sol, search_space, cost_eval)
+    perturbation.perturb(sol, search_space, cost_eval)
     perturbed = sol.unload()
 
     assert_(not perturbed.is_complete())
@@ -229,12 +229,12 @@ def test_perturb_shipments_insert(small_shipments):
     sol.load(pyvrp_sol)
 
     params = PerturbationParams(1, 1)  # perturb exactly once
-    perturbation = PerturbationManager(params)
+    perturbation = PerturbationManager(small_shipments, params)
 
     neighbours = compute_neighbours(small_shipments)
     search_space = SearchSpace(small_shipments, neighbours)
     cost_eval = CostEvaluator([1], 1, 0)
-    perturbation.perturb(small_shipments, sol, search_space, cost_eval)
+    perturbation.perturb(sol, search_space, cost_eval)
 
     # We should have inserted the first missing shipment into the solution.
     # Since nothing was shuffled, that first missing shipment is L0/U0.
@@ -256,12 +256,12 @@ def test_perturb_shipment_empty_route(small_shipments):
 
     # Perturbation should insert all missing shipments into the empty solution.
     params = PerturbationParams(min_perturbations=4)
-    perturbation = PerturbationManager(params)
+    perturbation = PerturbationManager(small_shipments, params)
 
     neighbours = compute_neighbours(small_shipments)
     search_space = SearchSpace(small_shipments, neighbours)
     cost_eval = CostEvaluator([1], 1, 0)
-    perturbation.perturb(small_shipments, sol, search_space, cost_eval)
+    perturbation.perturb(sol, search_space, cost_eval)
 
     # And thus, after perturbation we expect a complete solution.
     perturbed = sol.unload()
@@ -291,8 +291,8 @@ def test_perturb_does_not_insert_group_duplicates(
     # Perturbation considers clients 0 and 1 first, but cannot insert them
     # because client 2 is in the solution. The single perturbation should
     # instead remove client 2.
-    perturbation = PerturbationManager(PerturbationParams(1, 1))
-    perturbation.perturb(data, sol, search_space, cost_eval)
+    perturbation = PerturbationManager(data, PerturbationParams(1, 1))
+    perturbation.perturb(sol, search_space, cost_eval)
 
     perturbed = sol.unload()
     assert_equal(perturbed.num_clients(), 1)

--- a/tests/search/test_PerturbationManager.py
+++ b/tests/search/test_PerturbationManager.py
@@ -269,32 +269,29 @@ def test_perturb_shipment_empty_route(small_shipments):
     assert_(perturbed.is_complete())
 
 
-def test_perturb_does_not_insert_group_duplicates(
-    ok_small_mutually_exclusive_groups,
-):
+def test_perturb_replaces_group_member(ok_small_mutually_exclusive_groups):
     """
-    Tests that perturbation does not insert a client whose mutually exclusive
-    group already has a member in the solution, and that such skipped inserts
-    do not count towards the perturbation budget.
+    Tests that inserting a client whose mutually exclusive group already has a
+    member in the solution first removes that member, so the perturbation
+    replaces the group's planned member.
     """
     data = ok_small_mutually_exclusive_groups
 
     # Clients 0, 1, and 2 are in a mutually exclusive group. Client 2 is in
     # the solution, clients 0 and 1 are not.
     sol = Solution(data)
-    sol.load(pyvrp.Solution(data, [[2, 3]]))
+    sol.load(pyvrp.Solution(data, [[2]]))
 
     neighbours = {Activity(f"C{idx}"): [] for idx in range(data.num_clients)}
     search_space = SearchSpace(data, neighbours)
     cost_eval = CostEvaluator([20], 6, 0)
 
-    # Perturbation considers clients 0 and 1 first, but cannot insert them
-    # because client 2 is in the solution. The single perturbation should
-    # instead remove client 2.
+    # Perturbation considers client 0 first. Since client 2 is in the
+    # solution, the single perturbation removes client 2 and inserts client 0.
     perturbation = PerturbationManager(data, PerturbationParams(1, 1))
     perturbation.perturb(sol, search_space, cost_eval)
 
     perturbed = sol.unload()
     assert_equal(perturbed.num_clients(), 1)
+    assert_(Activity("C0") not in perturbed.unplanned())
     assert_(Activity("C2") in perturbed.unplanned())
-    assert_(Activity("C3") not in perturbed.unplanned())

--- a/tests/search/test_PerturbationManager.py
+++ b/tests/search/test_PerturbationManager.py
@@ -295,3 +295,36 @@ def test_perturb_replaces_group_member(ok_small_mutually_exclusive_groups):
     assert_equal(perturbed.num_clients(), 1)
     assert_(Activity("C0") not in perturbed.unplanned())
     assert_(Activity("C2") in perturbed.unplanned())
+
+
+def test_perturb_skips_group_member_removed_by_group_swap(
+    ok_small_mutually_exclusive_groups,
+):
+    """
+    Tests that a planned group member is skipped if an earlier group swap has
+    already removed it.
+    """
+    data = ok_small_mutually_exclusive_groups
+
+    # Clients 0, 1, and 2 are in a mutually exclusive group. Client 2 is in
+    # the solution, clients 0 and 1 are not.
+    sol = Solution(data)
+    sol.load(pyvrp.Solution(data, [[2]]))
+
+    neighbours = {Activity(f"C{idx}"): [] for idx in range(data.num_clients)}
+    neighbours[Activity("C0")] = [Activity("C2")]
+    search_space = SearchSpace(data, neighbours)
+    cost_eval = CostEvaluator([20], 6, 0)
+
+    # Perturbation inserts client 0 first, which also removes client 2 since
+    # they belong to the same mutually exclusive group. The next perturbation
+    # would remove client 2, but it has already been removed, so we skip it
+    # and insert client 1 instead.
+    perturbation = PerturbationManager(data, PerturbationParams(2, 2))
+    perturbation.perturb(sol, search_space, cost_eval)
+
+    perturbed = sol.unload()
+    assert_equal(perturbed.num_clients(), 1)
+    assert_(Activity("C0") in perturbed.unplanned())
+    assert_(Activity("C1") not in perturbed.unplanned())
+    assert_(Activity("C2") in perturbed.unplanned())

--- a/tests/test_IteratedLocalSearch.py
+++ b/tests/test_IteratedLocalSearch.py
@@ -109,7 +109,7 @@ def test_ils_result_has_correct_stats(ok_small):
     Tests that ILS correctly collects search statistics.
     """
     params = PerturbationParams(0, 0)  # disable perturbation
-    perturbation = PerturbationManager(params)
+    perturbation = PerturbationManager(ok_small, params)
 
     pm = PenaltyManager(initial_penalties=([20], 6, 6))
     rng = RandomNumberGenerator(42)


### PR DESCRIPTION
This PR:

- [x] Follow-up on #1035. Gap-wise performance neutral on GVRP and ARP, but a small regression on some internal multiple time window instances (which is fixed by #1187).
- [x] Part of #1187 and #1178.
- [ ] Adds and passes relevant tests.
- [ ] Has well-formatted code and documentation.

<details>

**Notes**:

Please read our [contributing guidelines](https://pyvrp.org/dev/contributing.html) first.
In particular:

- You must add tests when making code changes.
  This keeps the code coverage level up, and helps ensure the changes work as intended.
- When fixing a bug, you must add a test that would produce the bug in the master branch, and then show that it is fixed with the new code. 
- New code additions must be well formatted. Changes should pass the pre-commit workflow, which you can set up locally using [pre-commit](https://pre-commit.com/#intro). 
- Docstring additions must render correctly, including escapes and LaTeX.
- Finally, it is essential that all contributions in this PR are license-compatible with PyVRP's MIT license.
  Please check that this PR can be included into PyVRP under the MIT license.
- You must disclose the use of LLMs/generative AI if you used such tools to write code.

</details>
